### PR TITLE
Fix auto-scroll overriding user scroll position

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -24,7 +24,8 @@ export function App() {
   const messagesRef = useRef<HTMLDivElement | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const isNearBottomRef = useRef(true);
+  const [isNearBottom, setIsNearBottom] = useState(true);
+  const [showNewMessageHint, setShowNewMessageHint] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -104,17 +105,22 @@ export function App() {
     const el = messagesRef.current;
     if (!el) return;
     const threshold = 150;
-    isNearBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < threshold;
+    const near = el.scrollHeight - el.scrollTop - el.clientHeight < threshold;
+    setIsNearBottom(near);
+    if (near) setShowNewMessageHint(false);
   }
 
   useLayoutEffect(() => {
-    if (!isNearBottomRef.current) return;
+    if (!isNearBottom) {
+      setShowNewMessageHint(true);
+      return;
+    }
     scrollMessagesToBottom(messagesRef.current);
     const frame = window.requestAnimationFrame(() => {
-      if (isNearBottomRef.current) scrollMessagesToBottom(messagesRef.current);
+      if (isNearBottom) scrollMessagesToBottom(messagesRef.current);
     });
     return () => window.cancelAnimationFrame(frame);
-  }, [scrollKey]);
+  }, [scrollKey, isNearBottom]);
 
   async function sendMessage(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -136,7 +142,8 @@ export function App() {
       }
 
       setContent("");
-      isNearBottomRef.current = true;
+      setIsNearBottom(true);
+      setShowNewMessageHint(false);
       window.setTimeout(() => inputRef.current?.focus(), 0);
     } catch {
       setState((current) => ({
@@ -249,6 +256,18 @@ export function App() {
             state.messages.map((message) => <MessageRow key={message.id} message={message} />)
           )}
           <div ref={messagesEndRef} />
+          {showNewMessageHint && (
+            <button
+              className="scrollToBottomHint"
+              onClick={() => {
+                scrollMessagesToBottom(messagesRef.current);
+                setShowNewMessageHint(false);
+                setIsNearBottom(true);
+              }}
+            >
+              New messages ↓
+            </button>
+          )}
         </div>
 
         <form className="composer" onSubmit={sendMessage}>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -26,6 +26,7 @@ export function App() {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [isNearBottom, setIsNearBottom] = useState(true);
   const [showNewMessageHint, setShowNewMessageHint] = useState(false);
+  const isNearBottomRef = useRef(true);
 
   useEffect(() => {
     let cancelled = false;
@@ -104,23 +105,23 @@ export function App() {
   function handleMessagesScroll() {
     const el = messagesRef.current;
     if (!el) return;
-    const threshold = 150;
-    const near = el.scrollHeight - el.scrollTop - el.clientHeight < threshold;
+    const near = el.scrollHeight - el.scrollTop - el.clientHeight < 150;
+    isNearBottomRef.current = near;
     setIsNearBottom(near);
     if (near) setShowNewMessageHint(false);
   }
 
   useLayoutEffect(() => {
-    if (!isNearBottom) {
+    if (!isNearBottomRef.current) {
       setShowNewMessageHint(true);
       return;
     }
     scrollMessagesToBottom(messagesRef.current);
     const frame = window.requestAnimationFrame(() => {
-      if (isNearBottom) scrollMessagesToBottom(messagesRef.current);
+      if (isNearBottomRef.current) scrollMessagesToBottom(messagesRef.current);
     });
     return () => window.cancelAnimationFrame(frame);
-  }, [scrollKey, isNearBottom]);
+  }, [scrollKey]);
 
   async function sendMessage(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -142,6 +143,7 @@ export function App() {
       }
 
       setContent("");
+      isNearBottomRef.current = true;
       setIsNearBottom(true);
       setShowNewMessageHint(false);
       window.setTimeout(() => inputRef.current?.focus(), 0);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -267,7 +267,7 @@ export function App() {
                 setIsNearBottom(true);
               }}
             >
-              New messages ↓
+              ↓ 滚动到底部
             </button>
           )}
         </div>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -24,6 +24,7 @@ export function App() {
   const messagesRef = useRef<HTMLDivElement | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const isNearBottomRef = useRef(true);
 
   useEffect(() => {
     let cancelled = false;
@@ -99,10 +100,18 @@ export function App() {
     setSelectedMentionIndex(0);
   }, [mentionDraft?.query]);
 
+  function handleMessagesScroll() {
+    const el = messagesRef.current;
+    if (!el) return;
+    const threshold = 150;
+    isNearBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < threshold;
+  }
+
   useLayoutEffect(() => {
+    if (!isNearBottomRef.current) return;
     scrollMessagesToBottom(messagesRef.current);
     const frame = window.requestAnimationFrame(() => {
-      scrollMessagesToBottom(messagesRef.current);
+      if (isNearBottomRef.current) scrollMessagesToBottom(messagesRef.current);
     });
     return () => window.cancelAnimationFrame(frame);
   }, [scrollKey]);
@@ -127,6 +136,7 @@ export function App() {
       }
 
       setContent("");
+      isNearBottomRef.current = true;
       window.setTimeout(() => inputRef.current?.focus(), 0);
     } catch {
       setState((current) => ({
@@ -232,7 +242,7 @@ export function App() {
           </div>
         </header>
 
-        <div ref={messagesRef} className="messages" role="log" aria-live="polite" aria-label="Message list">
+        <div ref={messagesRef} className="messages" role="log" aria-live="polite" aria-label="Message list" onScroll={handleMessagesScroll}>
           {state.messages.length === 0 ? (
             <div className="emptyState">Choose an agent, then type a task.</div>
           ) : (

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -256,6 +256,27 @@ button:disabled {
   background: #fbfcfd;
 }
 
+.scrollToBottomHint {
+  position: sticky;
+  bottom: 8px;
+  display: block;
+  margin: 0 auto 8px;
+  padding: 6px 16px;
+  background: #6366f1;
+  color: #fff;
+  border: none;
+  border-radius: 16px;
+  font-size: 13px;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  z-index: 10;
+  transition: opacity 0.2s;
+}
+
+.scrollToBottomHint:hover {
+  opacity: 0.9;
+}
+
 .emptyState {
   width: fit-content;
   max-width: 100%;


### PR DESCRIPTION
## Summary
- Fixes #6 — auto-scroll no longer overrides user's scroll position
- Adds `isNearBottomRef` + `onScroll` handler to track whether user is near the bottom of the message list (within 150px threshold)
- `useLayoutEffect` now conditionally scrolls only when the ref is true
- Resets ref on `sendMessage` so user's own messages always scroll to bottom

## Test plan
- [ ] Open Orbit, send a message that triggers a long agent response
- [ ] While agent is streaming, scroll up >150px — auto-scroll should stop
- [ ] Scroll back to bottom — auto-scroll should resume
- [ ] Send a new message — should always scroll to bottom regardless of current position

🤖 Generated with [Claude Code](https://claude.com/claude-code)