### PR TITLE
Add runtime adapters and CodeBuddy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The current version is intentionally small. It validates the core workflow befor
 - Explicit assignment syntax with a colon, for example `@developer: inspect the current project`
 - Multiple agent assignments in one channel message
 - Per-agent run queue, so long-running work does not block the whole channel
-- Claude Code CLI runtime using non-interactive stream JSON output
+- Claude Code and CodeBuddy CLI runtimes using non-interactive stream JSON output
 - Markdown rendering for agent replies
 - Collapsible activity panel showing tool and command progress
 - Session persistence so agents retain conversation context across runs
@@ -47,6 +47,15 @@ npm run dev
 ```
 
 Open `http://localhost:4317`.
+
+By default, every built-in agent uses Claude Code. To run selected agents through
+CodeBuddy CLI, set `ORBIT_AGENT_RUNTIMES` before starting Orbit:
+
+```powershell
+$env:ORBIT_AGENT_RUNTIMES="developer=codebuddy,tester=codebuddy"; npm run dev
+```
+
+Supported runtime values are `claude-code` and `codebuddy`.
 
 To restart the local service on Windows PowerShell and clear the default port first:
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The current version is intentionally small. It validates the core workflow befor
 - Markdown rendering for agent replies
 - Collapsible activity panel showing tool and command progress
 - Session persistence so agents retain conversation context across runs
+- Per-agent runtime homes under `.orbit/` so CLI backends do not share incompatible local sessions
 - Channel history injection so agents see what others said since their last run
 - Local HTTP server with Server-Sent Events
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Chinese](./README.zh-CN.md)
 
-Orbit is a local-first chat control surface for coordinating multiple Claude Code agents in one shared channel.
+Orbit is a local-first chat control surface for coordinating multiple CLI-backed agents in one shared channel.
 
 The current version is intentionally small. It validates the core workflow before adding online sync, custom agents, or multi-device collaboration.
 
@@ -13,7 +13,7 @@ The current version is intentionally small. It validates the core workflow befor
 - Explicit assignment syntax with a colon, for example `@developer: inspect the current project`
 - Multiple agent assignments in one channel message
 - Per-agent run queue, so long-running work does not block the whole channel
-- Claude Code and CodeBuddy CLI runtimes using non-interactive stream JSON output
+- Codex, Claude Code, and CodeBuddy CLI runtimes using non-interactive output
 - Markdown rendering for agent replies
 - Collapsible activity panel showing tool and command progress
 - Session persistence so agents retain conversation context across runs
@@ -32,7 +32,7 @@ The current version is intentionally small. It validates the core workflow befor
 
 - Node.js
 - npm
-- Claude Code CLI available on `PATH`
+- Codex CLI, Claude Code CLI, and CodeBuddy CLI available on `PATH`
 
 ## Install
 
@@ -48,14 +48,15 @@ npm run dev
 
 Open `http://localhost:4317`.
 
-By default, every built-in agent uses Claude Code. To run selected agents through
-CodeBuddy CLI, set `ORBIT_AGENT_RUNTIMES` before starting Orbit:
+By default, `@pm:` and `@architect:` use Codex, `@developer:` uses Claude Code,
+and `@tester:` uses CodeBuddy. To override selected agents, set
+`ORBIT_AGENT_RUNTIMES` before starting Orbit:
 
 ```powershell
-$env:ORBIT_AGENT_RUNTIMES="developer=codebuddy,tester=codebuddy"; npm run dev
+$env:ORBIT_AGENT_RUNTIMES="developer=codex,tester=claude-code"; npm run dev
 ```
 
-Supported runtime values are `claude-code` and `codebuddy`.
+Supported runtime values are `codex`, `claude-code`, and `codebuddy`.
 
 To restart the local service on Windows PowerShell and clear the default port first:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -46,13 +46,13 @@ npm install
 npm run dev
 ```
 
-默认所有内置 Agent 都使用 Claude Code。可以在启动前设置 `ORBIT_AGENT_RUNTIMES`，把指定 Agent 切换到 CodeBuddy CLI：
+默认 `@pm:` 和 `@architect:` 使用 Codex，`@developer:` 使用 Claude Code，`@tester:` 使用 CodeBuddy。可以在启动前设置 `ORBIT_AGENT_RUNTIMES` 覆盖指定 Agent：
 
 ```powershell
-$env:ORBIT_AGENT_RUNTIMES="developer=codebuddy,tester=codebuddy"; npm run dev
+$env:ORBIT_AGENT_RUNTIMES="developer=codex,tester=claude-code"; npm run dev
 ```
 
-当前支持的 runtime 值是 `claude-code` 和 `codebuddy`。
+当前支持的 runtime 值是 `codex`、`claude-code` 和 `codebuddy`。
 
 打开 `http://localhost:4317`。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -46,6 +46,14 @@ npm install
 npm run dev
 ```
 
+默认所有内置 Agent 都使用 Claude Code。可以在启动前设置 `ORBIT_AGENT_RUNTIMES`，把指定 Agent 切换到 CodeBuddy CLI：
+
+```powershell
+$env:ORBIT_AGENT_RUNTIMES="developer=codebuddy,tester=codebuddy"; npm run dev
+```
+
+当前支持的 runtime 值是 `claude-code` 和 `codebuddy`。
+
 打开 `http://localhost:4317`。
 
 Windows PowerShell 下可以用下面的命令重启本地服务，并先释放默认端口：

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -101,6 +101,8 @@ The history is injected between `[Orbit Context]` and `[Full channel message]` i
 
 Each agent's CLI session ID is persisted via `src/core/session-store.ts`. Session records are namespaced by runtime, channel, conversation, and agent so switching an agent between Codex, Claude Code, and CodeBuddy does not reuse an incompatible session ID. On subsequent runs, the runtime adapter passes the corresponding resume option so the agent retains its own prior conversation context. If resumption fails (e.g. session expired), the store is cleared and the run retries without resuming.
 
+Codex also receives an agent-specific `CODEX_HOME` under `.orbit/runtimes/codex/<agent>`. Orbit bootstraps that directory with the user's existing Codex auth/config files, but leaves Codex's own sessions, logs, and cache isolated per agent. This prevents two Codex-backed agents such as `@pm:` and `@architect:` from sharing or resuming the same local Codex conversation.
+
 ## CLI Runtimes
 
 Orbit runs each backend through a runtime adapter. Codex uses:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -89,7 +89,7 @@ The history is injected between `[Orbit Context]` and `[Full channel message]` i
 
 ## Session Persistence
 
-Each agent's Claude CLI session ID is persisted via `src/core/session-store.ts`. On subsequent runs, the `--resume` flag is passed so the agent retains its own prior conversation context. If resumption fails (e.g. session expired), the store is cleared and the run retries without `--resume`.
+Each agent's CLI session ID is persisted via `src/core/session-store.ts`. Session records are namespaced by runtime, channel, conversation, and agent so switching an agent between Claude Code and CodeBuddy does not reuse an incompatible session ID. On subsequent runs, the `--resume` flag is passed so the agent retains its own prior conversation context. If resumption fails (e.g. session expired), the store is cleared and the run retries without `--resume`.
 
 ## CLI Runtimes
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -101,7 +101,7 @@ The history is injected between `[Orbit Context]` and `[Full channel message]` i
 
 Each agent's CLI session ID is persisted via `src/core/session-store.ts`. Session records are namespaced by runtime, channel, conversation, and agent so switching an agent between Codex, Claude Code, and CodeBuddy does not reuse an incompatible session ID. On subsequent runs, the runtime adapter passes the corresponding resume option so the agent retains its own prior conversation context. If resumption fails (e.g. session expired), the store is cleared and the run retries without resuming.
 
-Codex also receives an agent-specific `CODEX_HOME` under `.orbit/runtimes/codex/<agent>`. Orbit bootstraps that directory with the user's existing Codex auth/config files, but leaves Codex's own sessions, logs, and cache isolated per agent. This prevents two Codex-backed agents such as `@pm:` and `@architect:` from sharing or resuming the same local Codex conversation.
+Codex uses the user's normal Codex CLI home. Orbit does not create per-agent `CODEX_HOME` directories; agent-level continuity is handled by the session store above, which passes each agent's own saved session ID back to the runtime on the next run.
 
 ## CLI Runtimes
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Orbit Architecture
 
-Orbit is a local-first agent collaboration app. The current implementation runs one local HTTP server, one React UI, and multiple Claude Code CLI runs on the user's machine.
+Orbit is a local-first agent collaboration app. The current implementation runs one local HTTP server, one React UI, and multiple CLI-backed agent runs on the user's machine.
 
 ## Runtime Flow
 
@@ -11,8 +11,9 @@ React UI
   -> ChannelRouter
   -> RunManager
   -> AgentRegistry / AgentSession
-  -> Claude Code CLI --print --output-format stream-json
-  -> Claude stream events
+  -> Runtime adapter
+  -> Claude Code or CodeBuddy CLI --print --output-format stream-json
+  -> CLI stream events
   -> MessageStore + TerminalTranscriptStore
   -> SSE
   -> React UI
@@ -29,8 +30,10 @@ The runtime no longer uses PTY sessions or Claude Code hooks. A run is considere
 | `src/server/static-server.ts` | Static UI serving |
 | `src/core/agent-profiles.ts` | Built-in role definitions and permission profiles |
 | `src/core/agent-registry.ts` | Owns agent sessions and exposes agent state |
-| `src/core/agent-session.ts` | Starts one Claude CLI run and tracks status |
+| `src/core/agent-session.ts` | Starts one runtime adapter run and tracks status |
+| `src/core/agent-runtime.ts` | Shared runtime adapter contract |
 | `src/core/claude-cli-runtime.ts` | Spawns Claude Code CLI and parses stream JSON output |
+| `src/core/codebuddy-cli-runtime.ts` | Spawns CodeBuddy CLI and parses stream JSON output |
 | `src/core/run-manager.ts` | Per-agent run queue and lifecycle events |
 | `src/core/channel-router.ts` | Routes user and agent messages containing explicit assignments |
 | `src/core/mention-router.ts` | Parses `@agent:` assignment markers |
@@ -53,7 +56,11 @@ The current build has four fixed agents:
 | `@developer:` | Developer |
 | `@tester:` | Tester |
 
-Agent profiles are defined in `src/core/agent-profiles.ts`. They are intentionally hardcoded for now to keep the first local product loop simple.
+Agent profiles are defined in `src/core/agent-profiles.ts`. They are intentionally hardcoded for now to keep the first local product loop simple. Each profile has a `runtime` value. Defaults use `claude-code`, and `ORBIT_AGENT_RUNTIMES` can override selected agents at startup:
+
+```text
+ORBIT_AGENT_RUNTIMES=developer=codebuddy,tester=codebuddy
+```
 
 ## Routing Rules
 
@@ -84,14 +91,20 @@ The history is injected between `[Orbit Context]` and `[Full channel message]` i
 
 Each agent's Claude CLI session ID is persisted via `src/core/session-store.ts`. On subsequent runs, the `--resume` flag is passed so the agent retains its own prior conversation context. If resumption fails (e.g. session expired), the store is cleared and the run retries without `--resume`.
 
-## Claude CLI Runtime
+## CLI Runtimes
 
-Orbit runs Claude Code through non-interactive CLI mode:
+Orbit runs Claude Code and CodeBuddy through non-interactive CLI mode via runtime adapters. Claude Code uses:
 
 Orbit runs Claude Code through non-interactive CLI mode:
 
 ```text
 claude --print --verbose --output-format stream-json --include-partial-messages --permission-mode bypassPermissions
+```
+
+CodeBuddy uses:
+
+```text
+codebuddy --print --output-format stream-json --include-partial-messages --permission-mode bypassPermissions
 ```
 
 The user prompt is written to stdin. Stream JSON events are converted into:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,14 +12,14 @@ React UI
   -> RunManager
   -> AgentRegistry / AgentSession
   -> Runtime adapter
-  -> Claude Code or CodeBuddy CLI --print --output-format stream-json
+  -> Codex, Claude Code, or CodeBuddy CLI
   -> CLI stream events
   -> MessageStore + TerminalTranscriptStore
   -> SSE
   -> React UI
 ```
 
-The runtime no longer uses PTY sessions or Claude Code hooks. A run is considered complete when the Claude CLI child process exits and returns a clean final answer.
+The runtime no longer uses PTY sessions or CLI hooks. A run is considered complete when the selected CLI child process exits and returns a clean final answer.
 
 ## Core Modules
 
@@ -33,6 +33,7 @@ The runtime no longer uses PTY sessions or Claude Code hooks. A run is considere
 | `src/core/agent-session.ts` | Starts one runtime adapter run and tracks status |
 | `src/core/agent-runtime.ts` | Shared runtime adapter contract |
 | `src/core/claude-cli-runtime.ts` | Spawns Claude Code CLI and parses stream JSON output |
+| `src/core/codex-cli-runtime.ts` | Spawns Codex CLI and parses JSONL output |
 | `src/core/codebuddy-cli-runtime.ts` | Spawns CodeBuddy CLI and parses stream JSON output |
 | `src/core/run-manager.ts` | Per-agent run queue and lifecycle events |
 | `src/core/channel-router.ts` | Routes user and agent messages containing explicit assignments |
@@ -56,10 +57,19 @@ The current build has four fixed agents:
 | `@developer:` | Developer |
 | `@tester:` | Tester |
 
-Agent profiles are defined in `src/core/agent-profiles.ts`. They are intentionally hardcoded for now to keep the first local product loop simple. Each profile has a `runtime` value. Defaults use `claude-code`, and `ORBIT_AGENT_RUNTIMES` can override selected agents at startup:
+Agent profiles are defined in `src/core/agent-profiles.ts`. They are intentionally hardcoded for now to keep the first local product loop simple. Each profile has a `runtime` value. Defaults are:
+
+| Agent | Default runtime |
+| --- | --- |
+| `@pm:` | `codex` |
+| `@architect:` | `codex` |
+| `@developer:` | `claude-code` |
+| `@tester:` | `codebuddy` |
+
+`ORBIT_AGENT_RUNTIMES` can override selected agents at startup:
 
 ```text
-ORBIT_AGENT_RUNTIMES=developer=codebuddy,tester=codebuddy
+ORBIT_AGENT_RUNTIMES=developer=codex,tester=claude-code
 ```
 
 ## Routing Rules
@@ -89,13 +99,17 @@ The history is injected between `[Orbit Context]` and `[Full channel message]` i
 
 ## Session Persistence
 
-Each agent's CLI session ID is persisted via `src/core/session-store.ts`. Session records are namespaced by runtime, channel, conversation, and agent so switching an agent between Claude Code and CodeBuddy does not reuse an incompatible session ID. On subsequent runs, the `--resume` flag is passed so the agent retains its own prior conversation context. If resumption fails (e.g. session expired), the store is cleared and the run retries without `--resume`.
+Each agent's CLI session ID is persisted via `src/core/session-store.ts`. Session records are namespaced by runtime, channel, conversation, and agent so switching an agent between Codex, Claude Code, and CodeBuddy does not reuse an incompatible session ID. On subsequent runs, the runtime adapter passes the corresponding resume option so the agent retains its own prior conversation context. If resumption fails (e.g. session expired), the store is cleared and the run retries without resuming.
 
 ## CLI Runtimes
 
-Orbit runs Claude Code and CodeBuddy through non-interactive CLI mode via runtime adapters. Claude Code uses:
+Orbit runs each backend through a runtime adapter. Codex uses:
 
-Orbit runs Claude Code through non-interactive CLI mode:
+```text
+codex exec --json --cd <cwd> --sandbox danger-full-access --dangerously-bypass-approvals-and-sandbox -
+```
+
+Claude Code uses:
 
 ```text
 claude --print --verbose --output-format stream-json --include-partial-messages --permission-mode bypassPermissions
@@ -140,6 +154,6 @@ This keeps P0 simple. Persistent storage should be added behind existing stores 
 
 - Replace hardcoded profiles with user-defined agents.
 - Add persistent SQLite storage behind `MessageStore` and transcript storage.
-- Add runtime adapters for Codex CLI, CodeBuddy CLI, or other agent backends.
+- Add runtime adapters for other agent backends.
 - Add richer queue controls: cancel, retry, pause, and priority.
 - Add branch/PR workflow integration as a separate layer, not inside the runtime adapter.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "tsx src/server/index.ts",
     "build": "tsc --noEmit && vite build",
-    "test": "node --test --import tsx tests/mention-router.test.ts tests/message-store.test.ts tests/channel-router.test.ts tests/ansi-text-extractor.test.ts tests/terminal-transcript-store.test.ts tests/claude-output-detector.test.ts tests/claude-cli-runtime.test.ts tests/agent-profiles.test.ts tests/channel-context-builder.test.ts tests/channel-history.test.ts tests/run-manager.test.ts tests/session-store.test.ts tests/agent-session.test.ts",
+    "test": "node --test --import tsx tests/mention-router.test.ts tests/message-store.test.ts tests/channel-router.test.ts tests/ansi-text-extractor.test.ts tests/terminal-transcript-store.test.ts tests/claude-output-detector.test.ts tests/claude-cli-runtime.test.ts tests/codebuddy-cli-runtime.test.ts tests/agent-profiles.test.ts tests/agent-registry.test.ts tests/channel-context-builder.test.ts tests/channel-history.test.ts tests/run-manager.test.ts tests/session-store.test.ts tests/agent-session.test.ts",
     "test:glob": "node --test --import tsx tests/*.test.ts"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "tsx src/server/index.ts",
     "build": "tsc --noEmit && vite build",
-    "test": "node --test --import tsx tests/mention-router.test.ts tests/message-store.test.ts tests/channel-router.test.ts tests/ansi-text-extractor.test.ts tests/terminal-transcript-store.test.ts tests/claude-output-detector.test.ts tests/claude-cli-runtime.test.ts tests/codebuddy-cli-runtime.test.ts tests/agent-profiles.test.ts tests/agent-registry.test.ts tests/channel-context-builder.test.ts tests/channel-history.test.ts tests/run-manager.test.ts tests/session-store.test.ts tests/agent-session.test.ts",
+    "test": "node --test --import tsx tests/mention-router.test.ts tests/message-store.test.ts tests/channel-router.test.ts tests/ansi-text-extractor.test.ts tests/terminal-transcript-store.test.ts tests/claude-output-detector.test.ts tests/claude-cli-runtime.test.ts tests/codex-cli-runtime.test.ts tests/codebuddy-cli-runtime.test.ts tests/agent-profiles.test.ts tests/agent-registry.test.ts tests/channel-context-builder.test.ts tests/channel-history.test.ts tests/run-manager.test.ts tests/session-store.test.ts tests/agent-session.test.ts",
     "test:glob": "node --test --import tsx tests/*.test.ts"
   },
   "dependencies": {

--- a/src/core/agent-profiles.ts
+++ b/src/core/agent-profiles.ts
@@ -2,7 +2,7 @@ import type { AgentId, AgentProfile, AgentRole, AgentRuntimeKind, PermissionProf
 
 export type AgentRuntimeOverrides = Partial<Record<AgentId, AgentRuntimeKind>>;
 
-const CONFIGURABLE_RUNTIME_KINDS = new Set<AgentRuntimeKind>(["claude-code", "codebuddy"]);
+const CONFIGURABLE_RUNTIME_KINDS = new Set<AgentRuntimeKind>(["claude-code", "codex", "codebuddy"]);
 
 function permissionProfile(role: AgentRole): PermissionProfile {
   switch (role) {
@@ -80,7 +80,7 @@ export function createDefaultAgentProfiles(cwd: string, runtimeOverrides: AgentR
       id: "pm",
       name: "Product Manager",
       role: "pm",
-      runtime: runtimeOverrides.pm ?? "claude-code",
+      runtime: runtimeOverrides.pm ?? "codex",
       cwd,
       systemPrompt:
         "You are Orbit's product manager. Clarify requirements, define scope, acceptance criteria, and review whether implementation matches user needs. Do not edit code unless explicitly assigned.",
@@ -90,7 +90,7 @@ export function createDefaultAgentProfiles(cwd: string, runtimeOverrides: AgentR
       id: "architect",
       name: "Architect",
       role: "architect",
-      runtime: runtimeOverrides.architect ?? "claude-code",
+      runtime: runtimeOverrides.architect ?? "codex",
       cwd,
       systemPrompt:
         "You are Orbit's architect. Design technical boundaries, module responsibilities, migration plans, and review implementation risk. Prefer scoped, testable changes.",
@@ -110,7 +110,7 @@ export function createDefaultAgentProfiles(cwd: string, runtimeOverrides: AgentR
       id: "tester",
       name: "Tester",
       role: "tester",
-      runtime: runtimeOverrides.tester ?? "claude-code",
+      runtime: runtimeOverrides.tester ?? "codebuddy",
       cwd,
       systemPrompt:
         "You are Orbit's tester. Validate behavior, run tests, inspect regressions, and report risks. Do not modify production code unless explicitly assigned.",

--- a/src/core/agent-profiles.ts
+++ b/src/core/agent-profiles.ts
@@ -1,4 +1,8 @@
-import type { AgentProfile, AgentRole, PermissionProfile } from "../shared/types.ts";
+import type { AgentId, AgentProfile, AgentRole, AgentRuntimeKind, PermissionProfile } from "../shared/types.ts";
+
+export type AgentRuntimeOverrides = Partial<Record<AgentId, AgentRuntimeKind>>;
+
+const CONFIGURABLE_RUNTIME_KINDS = new Set<AgentRuntimeKind>(["claude-code", "codebuddy"]);
 
 function permissionProfile(role: AgentRole): PermissionProfile {
   switch (role) {
@@ -50,13 +54,33 @@ function permissionProfile(role: AgentRole): PermissionProfile {
   }
 }
 
-export function createDefaultAgentProfiles(cwd: string): AgentProfile[] {
+export function parseAgentRuntimeOverrides(value: string | undefined): AgentRuntimeOverrides {
+  const overrides: AgentRuntimeOverrides = {};
+  if (!value) {
+    return overrides;
+  }
+
+  for (const entry of value.split(",")) {
+    const [agentId, runtime] = entry.split("=").map((part) => part.trim());
+    if (!agentId || !runtime) {
+      continue;
+    }
+    if (!CONFIGURABLE_RUNTIME_KINDS.has(runtime as AgentRuntimeKind)) {
+      throw new Error(`Unsupported runtime for ${agentId}: ${runtime}`);
+    }
+    overrides[agentId] = runtime as AgentRuntimeKind;
+  }
+
+  return overrides;
+}
+
+export function createDefaultAgentProfiles(cwd: string, runtimeOverrides: AgentRuntimeOverrides = {}): AgentProfile[] {
   return [
     {
       id: "pm",
       name: "Product Manager",
       role: "pm",
-      runtime: "claude-code",
+      runtime: runtimeOverrides.pm ?? "claude-code",
       cwd,
       systemPrompt:
         "You are Orbit's product manager. Clarify requirements, define scope, acceptance criteria, and review whether implementation matches user needs. Do not edit code unless explicitly assigned.",
@@ -66,7 +90,7 @@ export function createDefaultAgentProfiles(cwd: string): AgentProfile[] {
       id: "architect",
       name: "Architect",
       role: "architect",
-      runtime: "claude-code",
+      runtime: runtimeOverrides.architect ?? "claude-code",
       cwd,
       systemPrompt:
         "You are Orbit's architect. Design technical boundaries, module responsibilities, migration plans, and review implementation risk. Prefer scoped, testable changes.",
@@ -76,7 +100,7 @@ export function createDefaultAgentProfiles(cwd: string): AgentProfile[] {
       id: "developer",
       name: "Developer",
       role: "developer",
-      runtime: "claude-code",
+      runtime: runtimeOverrides.developer ?? "claude-code",
       cwd,
       systemPrompt:
         "You are Orbit's developer. Follow strict TDD: write failing tests first, then implement the minimal code to pass them. Before writing any code, always create a feature branch from main (e.g. feat/issue-N-description). Run npm run test && npm run build after each meaningful change. Commit, push, and open a draft PR. Never commit directly to main.",
@@ -86,7 +110,7 @@ export function createDefaultAgentProfiles(cwd: string): AgentProfile[] {
       id: "tester",
       name: "Tester",
       role: "tester",
-      runtime: "claude-code",
+      runtime: runtimeOverrides.tester ?? "claude-code",
       cwd,
       systemPrompt:
         "You are Orbit's tester. Validate behavior, run tests, inspect regressions, and report risks. Do not modify production code unless explicitly assigned.",
@@ -94,4 +118,3 @@ export function createDefaultAgentProfiles(cwd: string): AgentProfile[] {
     },
   ];
 }
-

--- a/src/core/agent-registry.ts
+++ b/src/core/agent-registry.ts
@@ -1,7 +1,15 @@
 import type { AgentId, AgentProfile, AgentState } from "../shared/types.ts";
 import { AgentSession } from "./agent-session.ts";
+import type { AgentRuntime } from "./agent-runtime.ts";
+import { claudeCodeRuntime } from "./claude-cli-runtime.ts";
+import { codeBuddyRuntime } from "./codebuddy-cli-runtime.ts";
 import { EventBus } from "./event-bus.ts";
 import type { SessionStore } from "./session-store.ts";
+
+const DEFAULT_RUNTIMES = new Map<AgentRuntime["kind"], AgentRuntime>([
+  [claudeCodeRuntime.kind, claudeCodeRuntime],
+  [codeBuddyRuntime.kind, codeBuddyRuntime],
+]);
 
 export class AgentRegistry {
   private readonly sessions = new Map<AgentId, AgentSession>();
@@ -12,14 +20,22 @@ export class AgentRegistry {
     sessionStore: SessionStore,
     channelId: string,
     conversationId: string,
+    runtimes: ReadonlyMap<AgentRuntime["kind"], AgentRuntime> = DEFAULT_RUNTIMES,
   ) {
     for (const profile of profiles) {
+      const runtime = runtimes.get(profile.runtime);
+      if (!runtime) {
+        throw new Error(`No runtime configured for ${profile.runtime}`);
+      }
+
       this.sessions.set(
         profile.id,
         new AgentSession({
           id: profile.id,
           label: profile.name,
           cwd: profile.cwd,
+          permissionProfile: profile.permissionProfile,
+          runtime,
           eventBus,
           sessionStore,
           channelId,

--- a/src/core/agent-registry.ts
+++ b/src/core/agent-registry.ts
@@ -2,12 +2,14 @@ import type { AgentId, AgentProfile, AgentState } from "../shared/types.ts";
 import { AgentSession } from "./agent-session.ts";
 import type { AgentRuntime } from "./agent-runtime.ts";
 import { claudeCodeRuntime } from "./claude-cli-runtime.ts";
+import { codexRuntime } from "./codex-cli-runtime.ts";
 import { codeBuddyRuntime } from "./codebuddy-cli-runtime.ts";
 import { EventBus } from "./event-bus.ts";
 import type { SessionStore } from "./session-store.ts";
 
 const DEFAULT_RUNTIMES = new Map<AgentRuntime["kind"], AgentRuntime>([
   [claudeCodeRuntime.kind, claudeCodeRuntime],
+  [codexRuntime.kind, codexRuntime],
   [codeBuddyRuntime.kind, codeBuddyRuntime],
 ]);
 

--- a/src/core/agent-registry.ts
+++ b/src/core/agent-registry.ts
@@ -67,6 +67,7 @@ export class AgentRegistry {
     return this.profiles.map((profile, index) => ({
       id: profile.id,
       label: profile.name,
+      runtime: profile.runtime,
       status: this.get(profile.id).getStatus(),
       selected: index === 0,
     }));

--- a/src/core/agent-runtime.ts
+++ b/src/core/agent-runtime.ts
@@ -1,23 +1,24 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+
 import type { AgentId, AgentRuntimeKind, PermissionProfile } from "../shared/types.ts";
 
-export type AgentRunInput = {
-  runId: string;
+export type AgentRuntimeRunOptions = {
   agentId: AgentId;
   prompt: string;
   cwd: string;
   permissionProfile: PermissionProfile;
+  resumeSessionId?: string;
+  env?: NodeJS.ProcessEnv;
+  onOutput?: (text: string) => void;
 };
 
-export type AgentRuntimeEvent =
-  | { type: "activity"; text: string }
-  | { type: "tool.started"; name: string; input?: string }
-  | { type: "tool.completed"; name: string; summary?: string }
-  | { type: "final"; content: string }
-  | { type: "error"; message: string };
+export type AgentRuntimeRunHandle = {
+  process: Pick<ChildProcessWithoutNullStreams, "kill">;
+  result: Promise<string>;
+  sessionId: Promise<string | null>;
+};
 
 export interface AgentRuntime {
   readonly kind: AgentRuntimeKind;
-  run(input: AgentRunInput): AsyncIterable<AgentRuntimeEvent>;
-  cancel(runId: string): Promise<void>;
+  run(input: AgentRuntimeRunOptions): AgentRuntimeRunHandle;
 }
-

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -58,14 +58,14 @@ export class AgentSession {
     this.setStatus("running");
 
     const existingSession = this.options.sessionStore.load(
-      this.options.channelId, this.options.conversationId, this.id,
+      this.options.runtime.kind, this.options.channelId, this.options.conversationId, this.id,
     );
 
     return this.executeRun(runId, prompt, runIndex, existingSession?.sessionId ?? undefined)
       .catch((error: unknown) => {
         if (this.isResumeFailure(error, existingSession)) {
           this.options.sessionStore.clear(
-            this.options.channelId, this.options.conversationId, this.id,
+            this.options.runtime.kind, this.options.channelId, this.options.conversationId, this.id,
           );
           return this.executeRun(runId, prompt, runIndex, undefined);
         }
@@ -156,11 +156,12 @@ export class AgentSession {
 
   private persistSession(sessionId: string): void {
     const prev = this.options.sessionStore.load(
-      this.options.channelId, this.options.conversationId, this.id,
+      this.options.runtime.kind, this.options.channelId, this.options.conversationId, this.id,
     );
-    this.options.sessionStore.save(this.options.channelId, this.options.conversationId, this.id, {
+    this.options.sessionStore.save(this.options.runtime.kind, this.options.channelId, this.options.conversationId, this.id, {
       agentId: this.id,
       channelId: this.options.channelId,
+      runtime: this.options.runtime.kind,
       sessionId,
       lastRunAt: new Date().toISOString(),
       runCount: (prev?.runCount ?? 0) + 1,

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -1,8 +1,6 @@
-import type { ChildProcessWithoutNullStreams } from "node:child_process";
-
-import type { AgentId, AgentStatus, RunResult } from "../shared/types.ts";
+import type { AgentId, AgentStatus, PermissionProfile, RunResult } from "../shared/types.ts";
+import type { AgentRuntime } from "./agent-runtime.ts";
 import { sanitizeAgentVisibleReply } from "./agent-prompt.ts";
-import { runClaudeCli } from "./claude-cli-runtime.ts";
 import { isCleanFinalAnswer } from "./claude-output-detector.ts";
 import { EventBus } from "./event-bus.ts";
 import type { SessionRecord, SessionStore } from "./session-store.ts";
@@ -11,6 +9,8 @@ export type AgentSessionOptions = {
   id: AgentId;
   label: string;
   cwd: string;
+  permissionProfile: PermissionProfile;
+  runtime: AgentRuntime;
   eventBus: EventBus;
   quietWindowMs?: number;
   sessionStore: SessionStore;
@@ -20,7 +20,7 @@ export type AgentSessionOptions = {
 
 type ActiveRun = {
   runId: string;
-  child: ChildProcessWithoutNullStreams;
+  child: { kill: () => unknown };
 };
 
 export class AgentSession {
@@ -104,10 +104,11 @@ export class AgentSession {
   private executeRun(runId: string, prompt: string, runIndex: number, resumeSessionId?: string): Promise<RunResult> {
     this.setStatus("running");
 
-    const handle = runClaudeCli({
+    const handle = this.options.runtime.run({
       agentId: this.id,
       cwd: this.options.cwd,
       prompt,
+      permissionProfile: this.options.permissionProfile,
       resumeSessionId,
       onOutput: (text) => {
         this.options.eventBus.publish({

--- a/src/core/channel-history.ts
+++ b/src/core/channel-history.ts
@@ -23,7 +23,7 @@ export function buildHistoryForAgent(agentId: AgentId, allMessages: ChatMessage[
     const msg = allMessages[i];
     if (msg.kind === "system") continue;
     if (msg.status === "running") continue;
-    if (msg.routeState === "routed") continue;
+    if (msg.kind === "agent" && msg.routeState === "routed") continue;
 
     const sender = msg.kind === "user" ? "user" : (msg.agentId ?? "agent");
     const text = msg.content.slice(0, MAX_ENTRY_CHARS);

--- a/src/core/codebuddy-cli-runtime.ts
+++ b/src/core/codebuddy-cli-runtime.ts
@@ -92,6 +92,11 @@ export function runCodeBuddyCli(options: CodeBuddyCliRunOptions): CodeBuddyCliRu
       }
 
       const parsed = extractCodeBuddyCliFinalAnswer(stdout);
+      if (parsed.error) {
+        reject(new Error(parsed.error));
+        return;
+      }
+
       if (!parsed.text) {
         reject(new Error("CodeBuddy CLI completed without a final answer."));
         return;
@@ -114,9 +119,10 @@ export function buildCodeBuddyCliCommand(cliArgs?: string[]): { file: string; ar
   return { file: "cmd.exe", args: ["/d", "/s", "/c", "codebuddy.cmd", ...args] };
 }
 
-export function extractCodeBuddyCliFinalAnswer(output: string): { text: string; sessionId?: string } {
+export function extractCodeBuddyCliFinalAnswer(output: string): { text: string; sessionId?: string; error?: string } {
   let result = "";
   let sessionId: string | undefined;
+  let error: string | undefined;
   const textParts: string[] = [];
 
   for (const line of output.split(/\r?\n/)) {
@@ -129,9 +135,18 @@ export function extractCodeBuddyCliFinalAnswer(output: string): { text: string; 
       const event = JSON.parse(trimmed) as {
         type?: string;
         result?: unknown;
+        error?: unknown;
+        message?: unknown;
         session_id?: unknown;
-        message?: { content?: unknown };
       };
+
+      if (event.type === "error") {
+        if (typeof event.error === "string") {
+          error = event.error;
+        } else if (typeof event.message === "string") {
+          error = event.message;
+        }
+      }
 
       if (event.type === "result" && typeof event.result === "string") {
         result = event.result;
@@ -141,8 +156,9 @@ export function extractCodeBuddyCliFinalAnswer(output: string): { text: string; 
         sessionId = event.session_id;
       }
 
-      if (event.type === "assistant" && Array.isArray(event.message?.content)) {
-        for (const part of event.message.content as Array<{ type?: unknown; text?: unknown }>) {
+      const message = typeof event.message === "object" && event.message ? event.message as { content?: unknown } : null;
+      if (event.type === "assistant" && Array.isArray(message?.content)) {
+        for (const part of message.content as Array<{ type?: unknown; text?: unknown }>) {
           if (part.type === "text" && typeof part.text === "string") {
             textParts.push(part.text);
           }
@@ -153,7 +169,11 @@ export function extractCodeBuddyCliFinalAnswer(output: string): { text: string; 
     }
   }
 
-  return { text: (result || textParts.join("\n")).trim(), sessionId };
+  return {
+    text: (result || textParts.join("\n")).trim(),
+    ...(sessionId ? { sessionId } : {}),
+    ...(error ? { error } : {}),
+  };
 }
 
 export function extractCodeBuddySessionId(output: string): string | null {

--- a/src/core/codebuddy-cli-runtime.ts
+++ b/src/core/codebuddy-cli-runtime.ts
@@ -5,7 +5,7 @@ import type { AgentId } from "../shared/types.ts";
 import type { AgentRuntime } from "./agent-runtime.ts";
 import { extractReadableText } from "./ansi-text-extractor.ts";
 
-export type ClaudeCliRunOptions = {
+export type CodeBuddyCliRunOptions = {
   agentId: AgentId;
   cwd: string;
   prompt: string;
@@ -15,16 +15,15 @@ export type ClaudeCliRunOptions = {
   onOutput?: (text: string) => void;
 };
 
-export type ClaudeCliRunHandle = {
+export type CodeBuddyCliRunHandle = {
   process: ChildProcessWithoutNullStreams;
   result: Promise<string>;
   sessionId: Promise<string | null>;
 };
 
-export function buildClaudeCliArgs(options?: { resumeSessionId?: string }): string[] {
+export function buildCodeBuddyCliArgs(options?: { resumeSessionId?: string }): string[] {
   const args = [
     "--print",
-    "--verbose",
     "--output-format",
     "stream-json",
     "--include-partial-messages",
@@ -37,9 +36,9 @@ export function buildClaudeCliArgs(options?: { resumeSessionId?: string }): stri
   return args;
 }
 
-export function runClaudeCli(options: ClaudeCliRunOptions): ClaudeCliRunHandle {
-  const args = buildClaudeCliArgs({ resumeSessionId: options.resumeSessionId });
-  const command = buildClaudeCliCommand(args);
+export function runCodeBuddyCli(options: CodeBuddyCliRunOptions): CodeBuddyCliRunHandle {
+  const args = buildCodeBuddyCliArgs({ resumeSessionId: options.resumeSessionId });
+  const command = buildCodeBuddyCliCommand(args);
   const child = spawn(command.file, command.args, {
     cwd: options.cwd,
     env: createEnv(options.agentId, options.env ?? process.env),
@@ -49,7 +48,6 @@ export function runClaudeCli(options: ClaudeCliRunOptions): ClaudeCliRunHandle {
 
   let stdout = "";
   let stderr = "";
-
   let capturedSessionId: string | null = null;
   let sessionIdResolve!: (value: string | null) => void;
   const sessionIdPromise = new Promise<string | null>((resolve) => {
@@ -67,22 +65,10 @@ export function runClaudeCli(options: ClaudeCliRunOptions): ClaudeCliRunHandle {
     }
 
     if (!capturedSessionId) {
-      for (const line of chunk.split(/\r?\n/)) {
-        const trimmed = line.trim();
-        if (!trimmed) continue;
-        try {
-          const event = JSON.parse(trimmed);
-          if (
-            event.type === "system" &&
-            event.subtype === "init" &&
-            typeof event.session_id === "string"
-          ) {
-            capturedSessionId = event.session_id;
-            sessionIdResolve(capturedSessionId);
-          }
-        } catch {
-          // not JSON, ignore
-        }
+      const sessionId = extractCodeBuddySessionId(chunk);
+      if (sessionId) {
+        capturedSessionId = sessionId;
+        sessionIdResolve(sessionId);
       }
     }
   });
@@ -101,13 +87,13 @@ export function runClaudeCli(options: ClaudeCliRunOptions): ClaudeCliRunHandle {
       if (!capturedSessionId) sessionIdResolve(null);
 
       if (code !== 0) {
-        reject(new Error(stderr.trim() || stdout.trim() || `Claude CLI exited with code ${code}`));
+        reject(new Error(stderr.trim() || stdout.trim() || `CodeBuddy CLI exited with code ${code}`));
         return;
       }
 
-      const parsed = extractClaudeCliFinalAnswer(stdout);
+      const parsed = extractCodeBuddyCliFinalAnswer(stdout);
       if (!parsed.text) {
-        reject(new Error("Claude CLI completed without a final answer."));
+        reject(new Error("CodeBuddy CLI completed without a final answer."));
         return;
       }
 
@@ -119,21 +105,16 @@ export function runClaudeCli(options: ClaudeCliRunOptions): ClaudeCliRunHandle {
   return { process: child, result, sessionId: sessionIdPromise };
 }
 
-export function buildClaudeCliCommand(cliArgs?: string[]): { file: string; args: string[] } {
-  const args = cliArgs ?? buildClaudeCliArgs();
+export function buildCodeBuddyCliCommand(cliArgs?: string[]): { file: string; args: string[] } {
+  const args = cliArgs ?? buildCodeBuddyCliArgs();
   if (os.platform() !== "win32") {
-    return { file: "claude", args };
+    return { file: "codebuddy", args };
   }
 
-  return { file: "cmd.exe", args: ["/d", "/s", "/c", "claude.cmd", ...args] };
+  return { file: "cmd.exe", args: ["/d", "/s", "/c", "codebuddy.cmd", ...args] };
 }
 
-export const claudeCodeRuntime: AgentRuntime = {
-  kind: "claude-code",
-  run: runClaudeCli,
-};
-
-export function extractClaudeCliFinalAnswer(output: string): { text: string; sessionId?: string } {
+export function extractCodeBuddyCliFinalAnswer(output: string): { text: string; sessionId?: string } {
   let result = "";
   let sessionId: string | undefined;
   const textParts: string[] = [];
@@ -175,7 +156,7 @@ export function extractClaudeCliFinalAnswer(output: string): { text: string; ses
   return { text: (result || textParts.join("\n")).trim(), sessionId };
 }
 
-export function extractSessionId(output: string): string | null {
+export function extractCodeBuddySessionId(output: string): string | null {
   for (const line of output.split(/\r?\n/)) {
     const trimmed = line.trim();
     if (!trimmed) continue;
@@ -195,9 +176,15 @@ export function extractSessionId(output: string): string | null {
   return null;
 }
 
+export const codeBuddyRuntime: AgentRuntime = {
+  kind: "codebuddy",
+  run: runCodeBuddyCli,
+};
+
 function createEnv(agentId: AgentId, env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   return {
     ...env,
     ORBIT_AGENT_ID: agentId,
+    CODEBUDDY_AGENT_ID: agentId,
   };
 }

--- a/src/core/codex-cli-runtime.ts
+++ b/src/core/codex-cli-runtime.ts
@@ -1,0 +1,275 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import os from "node:os";
+
+import type { AgentId } from "../shared/types.ts";
+import type { AgentRuntime } from "./agent-runtime.ts";
+import { extractReadableText } from "./ansi-text-extractor.ts";
+
+export type CodexCliRunOptions = {
+  agentId: AgentId;
+  cwd: string;
+  prompt: string;
+  permissionProfile?: unknown;
+  resumeSessionId?: string;
+  env?: NodeJS.ProcessEnv;
+  onOutput?: (text: string) => void;
+};
+
+export type CodexCliRunHandle = {
+  process: ChildProcessWithoutNullStreams;
+  result: Promise<string>;
+  sessionId: Promise<string | null>;
+};
+
+export function buildCodexCliArgs(options: { cwd: string; resumeSessionId?: string }): string[] {
+  if (options.resumeSessionId) {
+    return [
+      "exec",
+      "resume",
+      options.resumeSessionId,
+      "--json",
+      "--sandbox",
+      "danger-full-access",
+      "--dangerously-bypass-approvals-and-sandbox",
+      "-",
+    ];
+  }
+
+  return [
+    "exec",
+    "--json",
+    "--cd",
+    options.cwd,
+    "--sandbox",
+    "danger-full-access",
+    "--dangerously-bypass-approvals-and-sandbox",
+    "-",
+  ];
+}
+
+export function runCodexCli(options: CodexCliRunOptions): CodexCliRunHandle {
+  const command = buildCodexCliCommand({ cwd: options.cwd, resumeSessionId: options.resumeSessionId });
+  const child = spawn(command.file, command.args, {
+    cwd: options.cwd,
+    env: createEnv(options.agentId, options.env ?? process.env),
+    stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: true,
+  });
+
+  let stdout = "";
+  let stderr = "";
+  let capturedSessionId: string | null = null;
+  let sessionIdResolve!: (value: string | null) => void;
+  const sessionIdPromise = new Promise<string | null>((resolve) => {
+    sessionIdResolve = resolve;
+  });
+
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+    const readable = extractReadableText(chunk);
+    if (readable) {
+      options.onOutput?.(readable);
+    }
+
+    if (!capturedSessionId) {
+      const sessionId = extractCodexSessionId(chunk);
+      if (sessionId) {
+        capturedSessionId = sessionId;
+        sessionIdResolve(sessionId);
+      }
+    }
+  });
+
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+    const readable = extractReadableText(chunk);
+    if (readable) {
+      options.onOutput?.(readable);
+    }
+  });
+
+  const result = new Promise<string>((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (!capturedSessionId) sessionIdResolve(null);
+
+      if (code !== 0) {
+        reject(new Error(stderr.trim() || stdout.trim() || `Codex CLI exited with code ${code}`));
+        return;
+      }
+
+      const parsed = extractCodexCliFinalAnswer(stdout);
+      if (!parsed.text) {
+        reject(new Error("Codex CLI completed without a final answer."));
+        return;
+      }
+
+      resolve(parsed.text);
+    });
+  });
+
+  child.stdin.end(options.prompt);
+  return { process: child, result, sessionId: sessionIdPromise };
+}
+
+export function buildCodexCliCommand(options: { cwd: string; resumeSessionId?: string }): { file: string; args: string[] } {
+  const args = buildCodexCliArgs(options);
+  if (os.platform() !== "win32") {
+    return { file: "codex", args };
+  }
+
+  return { file: "cmd.exe", args: ["/d", "/s", "/c", "codex.cmd", ...args] };
+}
+
+export function extractCodexCliFinalAnswer(output: string): { text: string; sessionId?: string } {
+  let sessionId: string | undefined;
+  const textParts: string[] = [];
+
+  for (const line of output.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    try {
+      const event = JSON.parse(trimmed);
+      sessionId ??= sessionIdFromEvent(event) ?? undefined;
+      const text = textFromEvent(event);
+      if (text) {
+        textParts.push(text);
+      }
+    } catch {
+      textParts.push(trimmed);
+    }
+  }
+
+  return { text: textParts.join("\n").trim(), sessionId };
+}
+
+export function extractCodexSessionId(output: string): string | null {
+  for (const line of output.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const sessionId = sessionIdFromEvent(JSON.parse(trimmed));
+      if (sessionId) {
+        return sessionId;
+      }
+    } catch {
+      // not JSON
+    }
+  }
+  return null;
+}
+
+export const codexRuntime: AgentRuntime = {
+  kind: "codex",
+  run: runCodexCli,
+};
+
+function createEnv(agentId: AgentId, env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return {
+    ...env,
+    ORBIT_AGENT_ID: agentId,
+    CODEX_AGENT_ID: agentId,
+  };
+}
+
+function sessionIdFromEvent(event: unknown): string | null {
+  if (!event || typeof event !== "object") {
+    return null;
+  }
+
+  const record = event as {
+    thread_id?: unknown;
+    session_id?: unknown;
+    conversation_id?: unknown;
+  };
+
+  if (typeof record.thread_id === "string") return record.thread_id;
+  if (typeof record.session_id === "string") return record.session_id;
+  if (typeof record.conversation_id === "string") return record.conversation_id;
+  return null;
+}
+
+function textFromEvent(event: unknown): string {
+  if (!event || typeof event !== "object") {
+    return "";
+  }
+
+  const record = event as {
+    type?: unknown;
+    item?: unknown;
+    message?: unknown;
+    content?: unknown;
+    text?: unknown;
+    result?: unknown;
+  };
+
+  if (record.type === "result" && typeof record.result === "string") {
+    return record.result;
+  }
+
+  if (typeof record.text === "string") {
+    return record.text;
+  }
+
+  return [
+    textFromMessage(record.item),
+    textFromMessage(record.message),
+    textFromContent(record.content),
+  ].filter(Boolean).join("\n");
+}
+
+function textFromMessage(value: unknown): string {
+  if (!value || typeof value !== "object") {
+    return "";
+  }
+
+  const message = value as {
+    role?: unknown;
+    type?: unknown;
+    content?: unknown;
+    text?: unknown;
+  };
+
+  if (message.role !== "assistant" && message.type !== "message") {
+    return "";
+  }
+
+  if (typeof message.text === "string") {
+    return message.text;
+  }
+
+  return textFromContent(message.content);
+}
+
+function textFromContent(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (!Array.isArray(value)) {
+    return "";
+  }
+
+  return value
+    .map((part) => {
+      if (!part || typeof part !== "object") {
+        return "";
+      }
+      const contentPart = part as { type?: unknown; text?: unknown };
+      if (
+        (contentPart.type === "text" || contentPart.type === "output_text") &&
+        typeof contentPart.text === "string"
+      ) {
+        return contentPart.text;
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}

--- a/src/core/codex-cli-runtime.ts
+++ b/src/core/codex-cli-runtime.ts
@@ -1,7 +1,5 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import fs from "node:fs";
 import os from "node:os";
-import path from "node:path";
 
 import type { AgentId } from "../shared/types.ts";
 import type { AgentRuntime } from "./agent-runtime.ts";
@@ -49,7 +47,7 @@ export function buildCodexCliArgs(options: { cwd: string; resumeSessionId?: stri
 
 export function runCodexCli(options: CodexCliRunOptions): CodexCliRunHandle {
   const command = buildCodexCliCommand({ cwd: options.cwd, resumeSessionId: options.resumeSessionId });
-  const env = createCodexEnv(options.agentId, options.cwd, options.env ?? process.env);
+  const env = createCodexEnv(options.agentId, options.env ?? process.env);
   const child = spawn(command.file, command.args, {
     cwd: options.cwd,
     env,
@@ -171,56 +169,12 @@ export const codexRuntime: AgentRuntime = {
   run: runCodexCli,
 };
 
-export function createCodexEnv(agentId: AgentId, cwd: string, env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  const sourceHome = resolveCodexSourceHome(env);
-  const agentHome = codexHomeForAgent(cwd, agentId);
-  prepareCodexHome(sourceHome, agentHome);
-
+export function createCodexEnv(agentId: AgentId, env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   return {
     ...env,
-    CODEX_HOME: agentHome,
     ORBIT_AGENT_ID: agentId,
     CODEX_AGENT_ID: agentId,
   };
-}
-
-export function codexHomeForAgent(cwd: string, agentId: AgentId): string {
-  return path.join(cwd, ".orbit", "runtimes", "codex", sanitizePathSegment(agentId));
-}
-
-export function prepareCodexHome(sourceHome: string, targetHome: string): void {
-  if (path.resolve(sourceHome) === path.resolve(targetHome)) {
-    return;
-  }
-
-  fs.mkdirSync(targetHome, { recursive: true });
-  for (const fileName of ["auth.json", "config.toml", "AGENTS.md", "installation_id", "version.json"]) {
-    copyIfNewer(path.join(sourceHome, fileName), path.join(targetHome, fileName));
-  }
-}
-
-function resolveCodexSourceHome(env: NodeJS.ProcessEnv): string {
-  return env.CODEX_HOME || path.join(os.homedir(), ".codex");
-}
-
-function copyIfNewer(source: string, target: string): void {
-  if (!fs.existsSync(source)) {
-    return;
-  }
-
-  if (fs.existsSync(target)) {
-    const sourceStat = fs.statSync(source);
-    const targetStat = fs.statSync(target);
-    if (targetStat.mtimeMs >= sourceStat.mtimeMs) {
-      return;
-    }
-  }
-
-  fs.copyFileSync(source, target);
-}
-
-function sanitizePathSegment(value: string): string {
-  return value.replace(/[^a-zA-Z0-9._-]/g, "-");
 }
 
 function sessionIdFromEvent(event: unknown): string | null {

--- a/src/core/codex-cli-runtime.ts
+++ b/src/core/codex-cli-runtime.ts
@@ -1,5 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import fs from "node:fs";
 import os from "node:os";
+import path from "node:path";
 
 import type { AgentId } from "../shared/types.ts";
 import type { AgentRuntime } from "./agent-runtime.ts";
@@ -47,9 +49,10 @@ export function buildCodexCliArgs(options: { cwd: string; resumeSessionId?: stri
 
 export function runCodexCli(options: CodexCliRunOptions): CodexCliRunHandle {
   const command = buildCodexCliCommand({ cwd: options.cwd, resumeSessionId: options.resumeSessionId });
+  const env = createCodexEnv(options.agentId, options.cwd, options.env ?? process.env);
   const child = spawn(command.file, command.args, {
     cwd: options.cwd,
-    env: createEnv(options.agentId, options.env ?? process.env),
+    env,
     stdio: ["pipe", "pipe", "pipe"],
     windowsHide: true,
   });
@@ -168,12 +171,56 @@ export const codexRuntime: AgentRuntime = {
   run: runCodexCli,
 };
 
-function createEnv(agentId: AgentId, env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+export function createCodexEnv(agentId: AgentId, cwd: string, env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const sourceHome = resolveCodexSourceHome(env);
+  const agentHome = codexHomeForAgent(cwd, agentId);
+  prepareCodexHome(sourceHome, agentHome);
+
   return {
     ...env,
+    CODEX_HOME: agentHome,
     ORBIT_AGENT_ID: agentId,
     CODEX_AGENT_ID: agentId,
   };
+}
+
+export function codexHomeForAgent(cwd: string, agentId: AgentId): string {
+  return path.join(cwd, ".orbit", "runtimes", "codex", sanitizePathSegment(agentId));
+}
+
+export function prepareCodexHome(sourceHome: string, targetHome: string): void {
+  if (path.resolve(sourceHome) === path.resolve(targetHome)) {
+    return;
+  }
+
+  fs.mkdirSync(targetHome, { recursive: true });
+  for (const fileName of ["auth.json", "config.toml", "AGENTS.md", "installation_id", "version.json"]) {
+    copyIfNewer(path.join(sourceHome, fileName), path.join(targetHome, fileName));
+  }
+}
+
+function resolveCodexSourceHome(env: NodeJS.ProcessEnv): string {
+  return env.CODEX_HOME || path.join(os.homedir(), ".codex");
+}
+
+function copyIfNewer(source: string, target: string): void {
+  if (!fs.existsSync(source)) {
+    return;
+  }
+
+  if (fs.existsSync(target)) {
+    const sourceStat = fs.statSync(source);
+    const targetStat = fs.statSync(target);
+    if (targetStat.mtimeMs >= sourceStat.mtimeMs) {
+      return;
+    }
+  }
+
+  fs.copyFileSync(source, target);
+}
+
+function sanitizePathSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, "-");
 }
 
 function sessionIdFromEvent(event: unknown): string | null {

--- a/src/core/codex-cli-runtime.ts
+++ b/src/core/codex-cli-runtime.ts
@@ -1,5 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import fs from "node:fs";
 import os from "node:os";
+import path from "node:path";
 
 import type { AgentId } from "../shared/types.ts";
 import type { AgentRuntime } from "./agent-runtime.ts";
@@ -46,7 +48,10 @@ export function buildCodexCliArgs(options: { cwd: string; resumeSessionId?: stri
 }
 
 export function runCodexCli(options: CodexCliRunOptions): CodexCliRunHandle {
-  const command = buildCodexCliCommand({ cwd: options.cwd, resumeSessionId: options.resumeSessionId });
+  const command = buildCodexCliCommand(
+    { cwd: options.cwd, resumeSessionId: options.resumeSessionId },
+    options.env ?? process.env,
+  );
   const env = createCodexEnv(options.agentId, options.env ?? process.env);
   const child = spawn(command.file, command.args, {
     cwd: options.cwd,
@@ -114,13 +119,12 @@ export function runCodexCli(options: CodexCliRunOptions): CodexCliRunHandle {
   return { process: child, result, sessionId: sessionIdPromise };
 }
 
-export function buildCodexCliCommand(options: { cwd: string; resumeSessionId?: string }): { file: string; args: string[] } {
+export function buildCodexCliCommand(
+  options: { cwd: string; resumeSessionId?: string },
+  env: NodeJS.ProcessEnv = process.env,
+): { file: string; args: string[] } {
   const args = buildCodexCliArgs(options);
-  if (os.platform() !== "win32") {
-    return { file: "codex", args };
-  }
-
-  return { file: "cmd.exe", args: ["/d", "/s", "/c", "codex.cmd", ...args] };
+  return { file: resolveCodexCommand(env), args };
 }
 
 export function extractCodexCliFinalAnswer(output: string): { text: string; sessionId?: string } {
@@ -175,6 +179,48 @@ export function createCodexEnv(agentId: AgentId, env: NodeJS.ProcessEnv): NodeJS
     ORBIT_AGENT_ID: agentId,
     CODEX_AGENT_ID: agentId,
   };
+}
+
+export function resolveCodexCommand(env: NodeJS.ProcessEnv = process.env): string {
+  const configured = env.ORBIT_CODEX_PATH || env.CODEX_CLI_PATH;
+  if (configured) {
+    return configured;
+  }
+
+  if (os.platform() !== "win32") {
+    return "codex";
+  }
+
+  return resolveWindowsCodexCommand(env) ?? "codex";
+}
+
+function resolveWindowsCodexCommand(env: NodeJS.ProcessEnv): string | null {
+  const candidates = [
+    ...codexExecutablesIn(path.join(env.LOCALAPPDATA ?? "", "OpenAI", "Codex", "bin")),
+    ...codexExecutablesIn(path.join(env.USERPROFILE ?? os.homedir(), ".codex", "packages", "standalone", "releases")),
+    ...codexCommandsOnPath(env.PATH ?? env.Path ?? ""),
+  ];
+  return candidates[0] ?? null;
+}
+
+function codexExecutablesIn(baseDir: string): string[] {
+  if (!baseDir || !fs.existsSync(baseDir)) {
+    return [];
+  }
+
+  return fs.readdirSync(baseDir, { recursive: true, withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.toLowerCase() === "codex.exe")
+    .map((entry) => path.join(entry.parentPath, entry.name))
+    .sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs);
+}
+
+function codexCommandsOnPath(pathValue: string): string[] {
+  return pathValue
+    .split(path.delimiter)
+    .filter(Boolean)
+    .filter((dir) => !dir.toLowerCase().includes(`${path.sep.toLowerCase()}windowsapps`))
+    .flatMap((dir) => [path.join(dir, "codex.cmd"), path.join(dir, "codex.exe")])
+    .filter((candidate) => fs.existsSync(candidate));
 }
 
 function sessionIdFromEvent(event: unknown): string | null {

--- a/src/core/codex-cli-runtime.ts
+++ b/src/core/codex-cli-runtime.ts
@@ -26,11 +26,9 @@ export function buildCodexCliArgs(options: { cwd: string; resumeSessionId?: stri
     return [
       "exec",
       "resume",
-      options.resumeSessionId,
       "--json",
-      "--sandbox",
-      "danger-full-access",
       "--dangerously-bypass-approvals-and-sandbox",
+      options.resumeSessionId,
       "-",
     ];
   }
@@ -236,7 +234,7 @@ function textFromMessage(value: unknown): string {
     text?: unknown;
   };
 
-  if (message.role !== "assistant" && message.type !== "message") {
+  if (message.role !== "assistant" && message.type !== "message" && message.type !== "agent_message") {
     return "";
   }
 

--- a/src/core/session-store.ts
+++ b/src/core/session-store.ts
@@ -2,9 +2,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import type { AgentRuntimeKind } from "../shared/types.ts";
+
 export type SessionRecord = {
   agentId: string;
   channelId: string;
+  runtime: AgentRuntimeKind;
   sessionId: string;
   lastRunAt: string;
   runCount: number;
@@ -17,8 +20,8 @@ export class SessionStore {
     this.baseDir = baseDir ?? path.join(process.cwd(), ".orbit", "sessions");
   }
 
-  load(channelId: string, conversationId: string, agentId: string): SessionRecord | null {
-    const filePath = this.filePath(channelId, conversationId, agentId);
+  load(runtime: AgentRuntimeKind, channelId: string, conversationId: string, agentId: string): SessionRecord | null {
+    const filePath = this.filePath(runtime, channelId, conversationId, agentId);
     try {
       const data = fs.readFileSync(filePath, "utf8");
       return JSON.parse(data) as SessionRecord;
@@ -27,8 +30,8 @@ export class SessionStore {
     }
   }
 
-  save(channelId: string, conversationId: string, agentId: string, record: SessionRecord): void {
-    const filePath = this.filePath(channelId, conversationId, agentId);
+  save(runtime: AgentRuntimeKind, channelId: string, conversationId: string, agentId: string, record: SessionRecord): void {
+    const filePath = this.filePath(runtime, channelId, conversationId, agentId);
     const dir = path.dirname(filePath);
     fs.mkdirSync(dir, { recursive: true });
 
@@ -37,8 +40,8 @@ export class SessionStore {
     fs.renameSync(tmpFile, filePath);
   }
 
-  clear(channelId: string, conversationId: string, agentId: string): void {
-    const filePath = this.filePath(channelId, conversationId, agentId);
+  clear(runtime: AgentRuntimeKind, channelId: string, conversationId: string, agentId: string): void {
+    const filePath = this.filePath(runtime, channelId, conversationId, agentId);
     try {
       fs.unlinkSync(filePath);
     } catch {
@@ -46,7 +49,7 @@ export class SessionStore {
     }
   }
 
-  private filePath(channelId: string, conversationId: string, agentId: string): string {
-    return path.join(this.baseDir, channelId, conversationId, `${agentId}.json`);
+  private filePath(runtime: AgentRuntimeKind, channelId: string, conversationId: string, agentId: string): string {
+    return path.join(this.baseDir, runtime, channelId, conversationId, `${agentId}.json`);
   }
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,6 +1,6 @@
 import http from "node:http";
 
-import { createDefaultAgentProfiles } from "../core/agent-profiles.ts";
+import { createDefaultAgentProfiles, parseAgentRuntimeOverrides } from "../core/agent-profiles.ts";
 import { AgentRegistry } from "../core/agent-registry.ts";
 import { ChannelRouter } from "../core/channel-router.ts";
 import { buildChannelContext } from "../core/channel-context-builder.ts";
@@ -24,7 +24,10 @@ const sseHub = new SseHub();
 const messages = new MessageStore();
 const transcripts = new TerminalTranscriptStore();
 const sessionStore = new SessionStore();
-const profiles = createDefaultAgentProfiles(process.cwd());
+const profiles = createDefaultAgentProfiles(
+  process.cwd(),
+  parseAgentRuntimeOverrides(process.env.ORBIT_AGENT_RUNTIMES),
+);
 const agents = new AgentRegistry(profiles, eventBus, sessionStore, CHANNEL_ID, CONVERSATION_ID);
 const agentIds = agents.ids();
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -28,6 +28,7 @@ export type AgentStatus = "starting" | "idle" | "running" | "error" | "stopped";
 export type AgentState = {
   id: AgentId;
   label: string;
+  runtime: AgentRuntimeKind;
   status: AgentStatus;
   selected?: boolean;
 };

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -4,10 +4,10 @@ import type { AgentActivityEvent, AgentId, AgentState, AppState, ChatMessage, Ru
 
 const initialState: AppState = {
   agents: [
-    { id: "pm", label: "Product Manager", status: "starting", selected: true },
-    { id: "architect", label: "Architect", status: "starting", selected: false },
-    { id: "developer", label: "Developer", status: "starting", selected: false },
-    { id: "tester", label: "Tester", status: "starting", selected: false },
+    { id: "pm", label: "Product Manager", runtime: "claude-code", status: "starting", selected: true },
+    { id: "architect", label: "Architect", runtime: "claude-code", status: "starting", selected: false },
+    { id: "developer", label: "Developer", runtime: "claude-code", status: "starting", selected: false },
+    { id: "tester", label: "Tester", runtime: "claude-code", status: "starting", selected: false },
   ],
   messages: [],
   terminal: {},
@@ -256,7 +256,13 @@ export function App() {
           {state.messages.length === 0 ? (
             <div className="emptyState">Choose an agent, then type a task.</div>
           ) : (
-            state.messages.map((message) => <MessageRow key={message.id} message={message} />)
+            state.messages.map((message) => (
+              <MessageRow
+                key={message.id}
+                message={message}
+                agent={message.agentId ? agentsById.get(message.agentId) : undefined}
+              />
+            ))
           )}
           <div ref={messagesEndRef} />
           {showNewMessageHint && (
@@ -346,7 +352,10 @@ function AgentButton(props: { agent: AgentState; selected: boolean; onClick: () 
     <button className={`agentButton ${props.selected ? "selected" : ""}`} onClick={props.onClick} type="button">
       <span className={`statusDot ${props.agent.status}`} aria-hidden="true" />
       <span className="agentText">
-        <strong>{props.agent.label}</strong>
+        <strong>
+          {props.agent.label}
+          <RuntimeBadge runtime={props.agent.runtime} />
+        </strong>
         <small>{props.agent.id}</small>
       </span>
       <span className="agentStatus">{props.agent.status}</span>
@@ -354,7 +363,7 @@ function AgentButton(props: { agent: AgentState; selected: boolean; onClick: () 
   );
 }
 
-function MessageRow({ message }: { message: ChatMessage }) {
+function MessageRow({ message, agent }: { message: ChatMessage; agent?: AgentState }) {
   const author = message.kind === "user" ? "You" : message.kind === "agent" ? message.agentId ?? "agent" : "system";
   const isRunning = message.status === "running";
 
@@ -362,6 +371,7 @@ function MessageRow({ message }: { message: ChatMessage }) {
     <article className={`message ${message.kind}`}>
       <div className="messageMeta">
         <strong>{author}</strong>
+        {message.kind === "agent" && agent ? <RuntimeBadge runtime={agent.runtime} /> : null}
         {message.status ? <span>{message.status}</span> : null}
         <DurationDisplay
           startedAt={message.startedAt ?? (isRunning ? message.createdAt : undefined)}
@@ -560,12 +570,28 @@ function upsertMessage(state: AppState, nextMessage: ChatMessage): AppState {
 
 function normalizeState(nextState: AppState): AppState {
   return {
-    agents: nextState.agents?.length ? nextState.agents : initialState.agents,
+    agents: nextState.agents?.length
+      ? nextState.agents.map((agent) => ({ ...agent, runtime: agent.runtime ?? "claude-code" }))
+      : initialState.agents,
     messages: nextState.messages ?? [],
     terminal: {
       ...(nextState.terminal ?? {}),
     },
   };
+}
+
+function RuntimeBadge({ runtime }: { runtime: AgentState["runtime"] }) {
+  return <span className={`runtimeBadge ${runtime}`}>{runtimeLabel(runtime)}</span>;
+}
+
+function runtimeLabel(runtime: AgentState["runtime"]): string {
+  if (runtime === "codebuddy") {
+    return "CodeBuddy";
+  }
+  if (runtime === "codex") {
+    return "Codex";
+  }
+  return "Claude Code";
 }
 
 function findMentionDraft(value: string, cursorIndex: number): { start: number; end: number; query: string } | null {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -4,10 +4,10 @@ import type { AgentActivityEvent, AgentId, AgentState, AppState, ChatMessage, Ru
 
 const initialState: AppState = {
   agents: [
-    { id: "pm", label: "Product Manager", runtime: "claude-code", status: "starting", selected: true },
-    { id: "architect", label: "Architect", runtime: "claude-code", status: "starting", selected: false },
+    { id: "pm", label: "Product Manager", runtime: "codex", status: "starting", selected: true },
+    { id: "architect", label: "Architect", runtime: "codex", status: "starting", selected: false },
     { id: "developer", label: "Developer", runtime: "claude-code", status: "starting", selected: false },
-    { id: "tester", label: "Tester", runtime: "claude-code", status: "starting", selected: false },
+    { id: "tester", label: "Tester", runtime: "codebuddy", status: "starting", selected: false },
   ],
   messages: [],
   terminal: {},

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -165,7 +165,15 @@ button:disabled {
 }
 
 .agentText strong {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
   font-size: 14px;
+}
+
+.agentText strong .runtimeBadge {
+  flex: 0 0 auto;
 }
 
 .agentText small,
@@ -334,6 +342,35 @@ button:disabled {
   border-radius: 999px;
   padding: 2px 7px;
   background: #eef2f6;
+}
+
+.runtimeBadge {
+  display: inline-flex;
+  align-items: center;
+  max-width: 92px;
+  overflow: hidden;
+  border: 1px solid #d7dee8;
+  border-radius: 999px;
+  padding: 1px 7px;
+  color: #4f5b6b;
+  background: #f5f7fa;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.runtimeBadge.codebuddy {
+  border-color: #c9ded5;
+  color: #276247;
+  background: #edf8f2;
+}
+
+.runtimeBadge.codex {
+  border-color: #d7d8ef;
+  color: #4c4d8e;
+  background: #f2f3ff;
 }
 
 .messageMeta .durationArrow {

--- a/tests/agent-profiles.test.ts
+++ b/tests/agent-profiles.test.ts
@@ -25,3 +25,28 @@ test("developer can write files while pm cannot", () => {
   assert.equal(developer?.permissionProfile.canWriteFiles, true);
 });
 
+test("applies runtime overrides to selected agents", () => {
+  const profiles = createDefaultAgentProfiles("D:/project", {
+    developer: "codebuddy",
+    tester: "claude-code",
+  });
+
+  assert.equal(profiles.find((profile) => profile.id === "developer")?.runtime, "codebuddy");
+  assert.equal(profiles.find((profile) => profile.id === "tester")?.runtime, "claude-code");
+  assert.equal(profiles.find((profile) => profile.id === "pm")?.runtime, "claude-code");
+});
+
+test("parses agent runtime overrides from comma separated config", async () => {
+  const { parseAgentRuntimeOverrides } = await import("../src/core/agent-profiles.ts");
+
+  assert.deepEqual(parseAgentRuntimeOverrides("developer=codebuddy,tester=claude-code"), {
+    developer: "codebuddy",
+    tester: "claude-code",
+  });
+});
+
+test("rejects runtime overrides without an adapter", async () => {
+  const { parseAgentRuntimeOverrides } = await import("../src/core/agent-profiles.ts");
+
+  assert.throws(() => parseAgentRuntimeOverrides("developer=codex"), /Unsupported runtime/);
+});

--- a/tests/agent-profiles.test.ts
+++ b/tests/agent-profiles.test.ts
@@ -25,28 +25,42 @@ test("developer can write files while pm cannot", () => {
   assert.equal(developer?.permissionProfile.canWriteFiles, true);
 });
 
+test("default runtimes use codex for planning, claude for development, and codebuddy for testing", () => {
+  const profiles = createDefaultAgentProfiles("D:/project");
+
+  assert.deepEqual(
+    profiles.map((profile) => [profile.id, profile.runtime]),
+    [
+      ["pm", "codex"],
+      ["architect", "codex"],
+      ["developer", "claude-code"],
+      ["tester", "codebuddy"],
+    ],
+  );
+});
+
 test("applies runtime overrides to selected agents", () => {
   const profiles = createDefaultAgentProfiles("D:/project", {
     developer: "codebuddy",
-    tester: "claude-code",
+    tester: "codex",
   });
 
   assert.equal(profiles.find((profile) => profile.id === "developer")?.runtime, "codebuddy");
-  assert.equal(profiles.find((profile) => profile.id === "tester")?.runtime, "claude-code");
-  assert.equal(profiles.find((profile) => profile.id === "pm")?.runtime, "claude-code");
+  assert.equal(profiles.find((profile) => profile.id === "tester")?.runtime, "codex");
+  assert.equal(profiles.find((profile) => profile.id === "pm")?.runtime, "codex");
 });
 
 test("parses agent runtime overrides from comma separated config", async () => {
   const { parseAgentRuntimeOverrides } = await import("../src/core/agent-profiles.ts");
 
-  assert.deepEqual(parseAgentRuntimeOverrides("developer=codebuddy,tester=claude-code"), {
+  assert.deepEqual(parseAgentRuntimeOverrides("developer=codebuddy,tester=codex"), {
     developer: "codebuddy",
-    tester: "claude-code",
+    tester: "codex",
   });
 });
 
-test("rejects runtime overrides without an adapter", async () => {
+test("rejects unknown runtime overrides", async () => {
   const { parseAgentRuntimeOverrides } = await import("../src/core/agent-profiles.ts");
 
-  assert.throws(() => parseAgentRuntimeOverrides("developer=codex"), /Unsupported runtime/);
+  assert.throws(() => parseAgentRuntimeOverrides("developer=unknown"), /Unsupported runtime/);
 });

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { AgentRegistry } from "../src/core/agent-registry.ts";
+import type { AgentRuntime } from "../src/core/agent-runtime.ts";
+import { createDefaultAgentProfiles } from "../src/core/agent-profiles.ts";
+import { EventBus } from "../src/core/event-bus.ts";
+import { SessionStore } from "../src/core/session-store.ts";
+
+test("creates sessions with the runtime selected by each profile", async () => {
+  const profiles = createDefaultAgentProfiles(process.cwd()).map((profile) =>
+    profile.id === "tester" ? { ...profile, runtime: "codebuddy" as const } : profile,
+  );
+  const calls: string[] = [];
+  const codeBuddyRuntime: AgentRuntime = {
+    kind: "codebuddy",
+    run(options) {
+      calls.push(options.agentId);
+      return {
+        process: { kill: () => true },
+        result: Promise.resolve("codebuddy final"),
+        sessionId: Promise.resolve("codebuddy-session"),
+      };
+    },
+  };
+  const claudeRuntime: AgentRuntime = {
+    kind: "claude-code",
+    run() {
+      throw new Error("Claude runtime should not run for tester");
+    },
+  };
+  const registry = new AgentRegistry(
+    profiles,
+    new EventBus(),
+    new SessionStore(),
+    "default",
+    "default",
+    new Map([
+      ["claude-code", claudeRuntime],
+      ["codebuddy", codeBuddyRuntime],
+    ]),
+  );
+
+  registry.startAll();
+  const result = await registry.get("tester").send("run-1", "hello");
+
+  assert.equal(result.content, "codebuddy final");
+  assert.deepEqual(calls, ["tester"]);
+});

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -47,3 +47,34 @@ test("creates sessions with the runtime selected by each profile", async () => {
   assert.equal(result.content, "codebuddy final");
   assert.deepEqual(calls, ["tester"]);
 });
+
+test("states include each agent runtime", () => {
+  const profiles = createDefaultAgentProfiles(process.cwd()).map((profile) =>
+    profile.id === "developer" ? { ...profile, runtime: "codebuddy" as const } : profile,
+  );
+  const runtime: AgentRuntime = {
+    kind: "claude-code",
+    run() {
+      throw new Error("runtime should not run");
+    },
+  };
+  const codeBuddyRuntime: AgentRuntime = {
+    ...runtime,
+    kind: "codebuddy",
+  };
+  const registry = new AgentRegistry(
+    profiles,
+    new EventBus(),
+    new SessionStore(),
+    "default",
+    "default",
+    new Map([
+      ["claude-code", runtime],
+      ["codebuddy", codeBuddyRuntime],
+    ]),
+  );
+
+  const developer = registry.states().find((state) => state.id === "developer");
+
+  assert.equal(developer?.runtime, "codebuddy");
+});

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -29,6 +29,12 @@ test("creates sessions with the runtime selected by each profile", async () => {
       throw new Error("Claude runtime should not run for tester");
     },
   };
+  const codexRuntime: AgentRuntime = {
+    kind: "codex",
+    run() {
+      throw new Error("Codex runtime should not run for tester");
+    },
+  };
   const registry = new AgentRegistry(
     profiles,
     new EventBus(),
@@ -37,6 +43,7 @@ test("creates sessions with the runtime selected by each profile", async () => {
     "default",
     new Map([
       ["claude-code", claudeRuntime],
+      ["codex", codexRuntime],
       ["codebuddy", codeBuddyRuntime],
     ]),
   );
@@ -62,6 +69,10 @@ test("states include each agent runtime", () => {
     ...runtime,
     kind: "codebuddy",
   };
+  const codexRuntime: AgentRuntime = {
+    ...runtime,
+    kind: "codex",
+  };
   const registry = new AgentRegistry(
     profiles,
     new EventBus(),
@@ -70,6 +81,7 @@ test("states include each agent runtime", () => {
     "default",
     new Map([
       ["claude-code", runtime],
+      ["codex", codexRuntime],
       ["codebuddy", codeBuddyRuntime],
     ]),
   );

--- a/tests/agent-session.test.ts
+++ b/tests/agent-session.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { AgentSession } from "../src/core/agent-session.ts";
+import type { AgentRuntime, AgentRuntimeRunOptions } from "../src/core/agent-runtime.ts";
 import { EventBus } from "../src/core/event-bus.ts";
 import { SessionStore } from "../src/core/session-store.ts";
 
@@ -17,11 +18,45 @@ function makeSession(store: SessionStore): AgentSession {
     id: "developer",
     label: "Developer",
     cwd: process.cwd(),
+    permissionProfile: {
+      canReadFiles: true,
+      canWriteFiles: true,
+      canRunCommands: true,
+      canInstallDependencies: true,
+      canGitCommit: false,
+      allowedDirectories: ["."],
+    },
+    runtime: {
+      kind: "claude-code",
+      run() {
+        throw new Error("test runtime should not be called");
+      },
+    },
     eventBus: new EventBus(),
     sessionStore: store,
     channelId: "default",
     conversationId: "default",
   });
+}
+
+function controllableRuntime(result: string, sessionId: string | null = null) {
+  const calls: AgentRuntimeRunOptions[] = [];
+  const runtime: AgentRuntime = {
+    kind: "codebuddy",
+    run(options) {
+      calls.push(options);
+      return {
+        process: {
+          kill() {
+            return true;
+          },
+        },
+        result: Promise.resolve(result),
+        sessionId: Promise.resolve(sessionId),
+      };
+    },
+  };
+  return { runtime, calls };
 }
 
 test("send without prior session — no resume flag, session persisted", async () => {
@@ -116,6 +151,15 @@ test("different conversations use independent sessions", () => {
     id: "developer",
     label: "Developer",
     cwd: process.cwd(),
+    permissionProfile: {
+      canReadFiles: true,
+      canWriteFiles: true,
+      canRunCommands: true,
+      canInstallDependencies: true,
+      canGitCommit: false,
+      allowedDirectories: ["."],
+    },
+    runtime: controllableRuntime("unused").runtime,
     eventBus: new EventBus(),
     sessionStore: store,
     channelId: "default",
@@ -126,6 +170,15 @@ test("different conversations use independent sessions", () => {
     id: "developer",
     label: "Developer",
     cwd: process.cwd(),
+    permissionProfile: {
+      canReadFiles: true,
+      canWriteFiles: true,
+      canRunCommands: true,
+      canInstallDependencies: true,
+      canGitCommit: false,
+      allowedDirectories: ["."],
+    },
+    runtime: controllableRuntime("unused").runtime,
     eventBus: new EventBus(),
     sessionStore: store,
     channelId: "default",
@@ -153,4 +206,47 @@ test("different conversations use independent sessions", () => {
 
   assert.equal(store.load("default", "conv-a", "developer")!.sessionId, "sess-a");
   assert.equal(store.load("default", "conv-b", "developer")!.sessionId, "sess-b");
+});
+
+test("send executes through configured runtime and passes resume session", async () => {
+  const dir = tmpDir();
+  const store = new SessionStore(dir);
+  store.save("default", "default", "developer", {
+    agentId: "developer",
+    channelId: "default",
+    sessionId: "existing-sess",
+    lastRunAt: new Date().toISOString(),
+    runCount: 1,
+  });
+  const { runtime, calls } = controllableRuntime("clean final", "next-sess");
+  const session = new AgentSession({
+    id: "developer",
+    label: "Developer",
+    cwd: "D:/workspace",
+    permissionProfile: {
+      canReadFiles: true,
+      canWriteFiles: true,
+      canRunCommands: true,
+      canInstallDependencies: true,
+      canGitCommit: false,
+      allowedDirectories: ["."],
+    },
+    runtime,
+    eventBus: new EventBus(),
+    sessionStore: store,
+    channelId: "default",
+    conversationId: "default",
+  });
+
+  session.start();
+  const result = await session.send("run-1", "hello");
+
+  assert.equal(result.content, "clean final");
+  assert.equal(result.sessionId, "next-sess");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.agentId, "developer");
+  assert.equal(calls[0]!.cwd, "D:/workspace");
+  assert.equal(calls[0]!.prompt, "hello");
+  assert.equal(calls[0]!.resumeSessionId, "existing-sess");
+  assert.equal(store.load("default", "default", "developer")!.sessionId, "next-sess");
 });

--- a/tests/agent-session.test.ts
+++ b/tests/agent-session.test.ts
@@ -65,16 +65,17 @@ test("send without prior session — no resume flag, session persisted", async (
   const session = makeSession(store);
   session.start();
 
-  assert.equal(store.load("default", "default", "developer"), null);
+  assert.equal(store.load("claude-code", "default", "default", "developer"), null);
   assert.equal(session.getStatus(), "idle");
 });
 
 test("send with prior session — resume flag passed", () => {
   const dir = tmpDir();
   const store = new SessionStore(dir);
-  store.save("default", "default", "developer", {
+  store.save("claude-code", "default", "default", "developer", {
     agentId: "developer",
     channelId: "default",
+    runtime: "claude-code",
     sessionId: "existing-sess",
     lastRunAt: new Date().toISOString(),
     runCount: 3,
@@ -83,7 +84,7 @@ test("send with prior session — resume flag passed", () => {
   const session = makeSession(store);
   session.start();
 
-  const loaded = store.load("default", "default", "developer");
+  const loaded = store.load("claude-code", "default", "default", "developer");
   assert.equal(loaded!.sessionId, "existing-sess");
   assert.equal(loaded!.runCount, 3);
 });
@@ -91,54 +92,58 @@ test("send with prior session — resume flag passed", () => {
 test("resume failure clears and retries — store cleared after session-not-found", () => {
   const dir = tmpDir();
   const store = new SessionStore(dir);
-  store.save("default", "default", "developer", {
+  store.save("claude-code", "default", "default", "developer", {
     agentId: "developer",
     channelId: "default",
+    runtime: "claude-code",
     sessionId: "bad-session",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  store.clear("default", "default", "developer");
-  assert.equal(store.load("default", "default", "developer"), null);
+  store.clear("claude-code", "default", "default", "developer");
+  assert.equal(store.load("claude-code", "default", "default", "developer"), null);
 });
 
 test("non-resume failure does not clear store", () => {
   const dir = tmpDir();
   const store = new SessionStore(dir);
-  store.save("default", "default", "developer", {
+  store.save("claude-code", "default", "default", "developer", {
     agentId: "developer",
     channelId: "default",
+    runtime: "claude-code",
     sessionId: "good-session",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  const loaded = store.load("default", "default", "developer");
+  const loaded = store.load("claude-code", "default", "default", "developer");
   assert.equal(loaded!.sessionId, "good-session");
 });
 
 test("persistSession increments runCount", () => {
   const dir = tmpDir();
   const store = new SessionStore(dir);
-  store.save("default", "default", "developer", {
+  store.save("claude-code", "default", "default", "developer", {
     agentId: "developer",
     channelId: "default",
+    runtime: "claude-code",
     sessionId: "sess-1",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  const prev = store.load("default", "default", "developer");
-  store.save("default", "default", "developer", {
+  const prev = store.load("claude-code", "default", "default", "developer");
+  store.save("claude-code", "default", "default", "developer", {
     agentId: "developer",
     channelId: "default",
+    runtime: "claude-code",
     sessionId: "sess-2",
     lastRunAt: new Date().toISOString(),
     runCount: (prev?.runCount ?? 0) + 1,
   });
 
-  const updated = store.load("default", "default", "developer");
+  const updated = store.load("claude-code", "default", "default", "developer");
   assert.equal(updated!.runCount, 2);
   assert.equal(updated!.sessionId, "sess-2");
 });
@@ -188,32 +193,35 @@ test("different conversations use independent sessions", () => {
   sessionA.start();
   sessionB.start();
 
-  store.save("default", "conv-a", "developer", {
+  store.save("codebuddy", "default", "conv-a", "developer", {
     agentId: "developer",
     channelId: "default",
+    runtime: "codebuddy",
     sessionId: "sess-a",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  store.save("default", "conv-b", "developer", {
+  store.save("codebuddy", "default", "conv-b", "developer", {
     agentId: "developer",
     channelId: "default",
+    runtime: "codebuddy",
     sessionId: "sess-b",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  assert.equal(store.load("default", "conv-a", "developer")!.sessionId, "sess-a");
-  assert.equal(store.load("default", "conv-b", "developer")!.sessionId, "sess-b");
+  assert.equal(store.load("codebuddy", "default", "conv-a", "developer")!.sessionId, "sess-a");
+  assert.equal(store.load("codebuddy", "default", "conv-b", "developer")!.sessionId, "sess-b");
 });
 
 test("send executes through configured runtime and passes resume session", async () => {
   const dir = tmpDir();
   const store = new SessionStore(dir);
-  store.save("default", "default", "developer", {
+  store.save("codebuddy", "default", "default", "developer", {
     agentId: "developer",
     channelId: "default",
+    runtime: "codebuddy",
     sessionId: "existing-sess",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
@@ -248,5 +256,5 @@ test("send executes through configured runtime and passes resume session", async
   assert.equal(calls[0]!.cwd, "D:/workspace");
   assert.equal(calls[0]!.prompt, "hello");
   assert.equal(calls[0]!.resumeSessionId, "existing-sess");
-  assert.equal(store.load("default", "default", "developer")!.sessionId, "next-sess");
+  assert.equal(store.load("codebuddy", "default", "default", "developer")!.sessionId, "next-sess");
 });

--- a/tests/agent-session.test.ts
+++ b/tests/agent-session.test.ts
@@ -258,3 +258,64 @@ test("send executes through configured runtime and passes resume session", async
   assert.equal(calls[0]!.resumeSessionId, "existing-sess");
   assert.equal(store.load("codebuddy", "default", "default", "developer")!.sessionId, "next-sess");
 });
+
+test("resume failure clears stale session and retries without resume", async () => {
+  const dir = tmpDir();
+  const store = new SessionStore(dir);
+  store.save("codebuddy", "default", "default", "developer", {
+    agentId: "developer",
+    channelId: "default",
+    runtime: "codebuddy",
+    sessionId: "bad-session",
+    lastRunAt: new Date().toISOString(),
+    runCount: 1,
+  });
+
+  const calls: AgentRuntimeRunOptions[] = [];
+  const runtime: AgentRuntime = {
+    kind: "codebuddy",
+    run(options) {
+      calls.push(options);
+      return {
+        process: {
+          kill() {
+            return true;
+          },
+        },
+        result: calls.length === 1
+          ? Promise.reject(new Error("No conversation found with session ID: bad-session"))
+          : Promise.resolve("clean final"),
+        sessionId: Promise.resolve(calls.length === 1 ? null : "fresh-session"),
+      };
+    },
+  };
+
+  const session = new AgentSession({
+    id: "developer",
+    label: "Developer",
+    cwd: "D:/workspace",
+    permissionProfile: {
+      canReadFiles: true,
+      canWriteFiles: true,
+      canRunCommands: true,
+      canInstallDependencies: true,
+      canGitCommit: false,
+      allowedDirectories: ["."],
+    },
+    runtime,
+    eventBus: new EventBus(),
+    sessionStore: store,
+    channelId: "default",
+    conversationId: "default",
+  });
+
+  session.start();
+  const result = await session.send("run-1", "hello");
+
+  assert.equal(result.content, "clean final");
+  assert.equal(result.sessionId, "fresh-session");
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0]!.resumeSessionId, "bad-session");
+  assert.equal(calls[1]!.resumeSessionId, undefined);
+  assert.equal(store.load("codebuddy", "default", "default", "developer")!.sessionId, "fresh-session");
+});

--- a/tests/channel-history.test.ts
+++ b/tests/channel-history.test.ts
@@ -65,19 +65,21 @@ test("different agents have independent cutoff points", () => {
   assert.equal(archHistory[0].content, "req 2");
 });
 
-test("filters out system, running, and routed messages", () => {
+test("filters out system, running, and routed agent messages but keeps routed user messages", () => {
   const messages: ChatMessage[] = [
     msg({ kind: "user", content: "user msg" }),
     msg({ kind: "system", content: "sys msg", status: "done" }),
     msg({ kind: "agent", agentId: "pm", content: "pm running", status: "running" }),
-    msg({ kind: "user", content: "routed msg", routeState: "routed" }),
+    msg({ kind: "user", content: "routed user msg", routeState: "routed" }),
+    msg({ kind: "agent", agentId: "pm", content: "routed agent msg", routeState: "routed", status: "done" }),
     msg({ kind: "agent", agentId: "architect", content: "arch done", status: "done" }),
   ];
 
   const history = buildHistoryForAgent("developer", messages);
-  assert.equal(history.length, 2);
+  assert.equal(history.length, 3);
   assert.equal(history[0].content, "user msg");
-  assert.equal(history[1].content, "arch done");
+  assert.equal(history[1].content, "routed user msg");
+  assert.equal(history[2].content, "arch done");
 });
 
 test("truncates total history to MAX_HISTORY_CHARS", () => {

--- a/tests/codebuddy-cli-runtime.test.ts
+++ b/tests/codebuddy-cli-runtime.test.ts
@@ -51,6 +51,15 @@ test("extracts final answer from CodeBuddy stream-json result events", () => {
   });
 });
 
+test("extracts CodeBuddy error events", () => {
+  const output = JSON.stringify({ type: "error", error: "No conversation found with session ID: bad-session" });
+
+  assert.deepEqual(extractCodeBuddyCliFinalAnswer(output), {
+    text: "",
+    error: "No conversation found with session ID: bad-session",
+  });
+});
+
 test("extracts CodeBuddy session id from init events", () => {
   const output = JSON.stringify({ type: "system", subtype: "init", session_id: "sess-init" });
   assert.equal(extractCodeBuddySessionId(output), "sess-init");

--- a/tests/codebuddy-cli-runtime.test.ts
+++ b/tests/codebuddy-cli-runtime.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildCodeBuddyCliArgs,
+  buildCodeBuddyCliCommand,
+  extractCodeBuddyCliFinalAnswer,
+  extractCodeBuddySessionId,
+} from "../src/core/codebuddy-cli-runtime.ts";
+
+test("builds non-interactive CodeBuddy CLI args without resume", () => {
+  assert.deepEqual(buildCodeBuddyCliArgs(), [
+    "--print",
+    "--output-format",
+    "stream-json",
+    "--include-partial-messages",
+    "--permission-mode",
+    "bypassPermissions",
+  ]);
+});
+
+test("builds CodeBuddy CLI args with --resume when resumeSessionId is set", () => {
+  assert.deepEqual(buildCodeBuddyCliArgs({ resumeSessionId: "sess-abc" }), [
+    "--print",
+    "--output-format",
+    "stream-json",
+    "--include-partial-messages",
+    "--permission-mode",
+    "bypassPermissions",
+    "--resume",
+    "sess-abc",
+  ]);
+});
+
+test("builds a spawnable CodeBuddy command", () => {
+  const command = buildCodeBuddyCliCommand();
+
+  assert.ok(command.file.length > 0);
+  assert.ok(command.args.includes("--print"));
+});
+
+test("extracts final answer from CodeBuddy stream-json result events", () => {
+  const output = [
+    JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text: "draft" }] } }),
+    JSON.stringify({ type: "result", result: "final answer", session_id: "sess-final" }),
+  ].join("\n");
+
+  assert.deepEqual(extractCodeBuddyCliFinalAnswer(output), {
+    text: "final answer",
+    sessionId: "sess-final",
+  });
+});
+
+test("extracts CodeBuddy session id from init events", () => {
+  const output = JSON.stringify({ type: "system", subtype: "init", session_id: "sess-init" });
+  assert.equal(extractCodeBuddySessionId(output), "sess-init");
+});

--- a/tests/codex-cli-runtime.test.ts
+++ b/tests/codex-cli-runtime.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildCodexCliArgs,
+  buildCodexCliCommand,
+  extractCodexCliFinalAnswer,
+  extractCodexSessionId,
+} from "../src/core/codex-cli-runtime.ts";
+
+test("builds non-interactive Codex exec args without resume", () => {
+  assert.deepEqual(buildCodexCliArgs({ cwd: "D:/workspace" }), [
+    "exec",
+    "--json",
+    "--cd",
+    "D:/workspace",
+    "--sandbox",
+    "danger-full-access",
+    "--dangerously-bypass-approvals-and-sandbox",
+    "-",
+  ]);
+});
+
+test("builds Codex resume args with session id", () => {
+  assert.deepEqual(buildCodexCliArgs({ cwd: "D:/workspace", resumeSessionId: "sess-abc" }), [
+    "exec",
+    "resume",
+    "sess-abc",
+    "--json",
+    "--sandbox",
+    "danger-full-access",
+    "--dangerously-bypass-approvals-and-sandbox",
+    "-",
+  ]);
+});
+
+test("builds a spawnable Codex command", () => {
+  const command = buildCodexCliCommand({ cwd: "D:/workspace" });
+
+  assert.ok(command.file.length > 0);
+  assert.ok(command.args.includes("exec"));
+});
+
+test("extracts final answer from Codex JSONL message events", () => {
+  const output = [
+    JSON.stringify({ type: "thread.started", thread_id: "thread-123" }),
+    JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "final answer" }],
+      },
+    }),
+  ].join("\n");
+
+  assert.deepEqual(extractCodexCliFinalAnswer(output), {
+    text: "final answer",
+    sessionId: "thread-123",
+  });
+});
+
+test("extracts Codex session id from thread or session fields", () => {
+  assert.equal(extractCodexSessionId(JSON.stringify({ type: "thread.started", thread_id: "thread-123" })), "thread-123");
+  assert.equal(extractCodexSessionId(JSON.stringify({ type: "session.started", session_id: "sess-123" })), "sess-123");
+});

--- a/tests/codex-cli-runtime.test.ts
+++ b/tests/codex-cli-runtime.test.ts
@@ -1,12 +1,22 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
   buildCodexCliArgs,
   buildCodexCliCommand,
+  codexHomeForAgent,
+  createCodexEnv,
   extractCodexCliFinalAnswer,
   extractCodexSessionId,
+  prepareCodexHome,
 } from "../src/core/codex-cli-runtime.ts";
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "orbit-codex-runtime-test-"));
+}
 
 test("builds non-interactive Codex exec args without resume", () => {
   assert.deepEqual(buildCodexCliArgs({ cwd: "D:/workspace" }), [
@@ -37,6 +47,53 @@ test("builds a spawnable Codex command", () => {
 
   assert.ok(command.file.length > 0);
   assert.ok(command.args.includes("exec"));
+});
+
+test("creates isolated Codex homes per agent", () => {
+  assert.equal(
+    codexHomeForAgent("D:/workspace", "pm"),
+    path.join("D:/workspace", ".orbit", "runtimes", "codex", "pm"),
+  );
+  assert.equal(
+    codexHomeForAgent("D:/workspace", "architect"),
+    path.join("D:/workspace", ".orbit", "runtimes", "codex", "architect"),
+  );
+});
+
+test("Codex env uses agent-specific CODEX_HOME and bootstraps auth files", () => {
+  const cwd = tmpDir();
+  const sourceHome = tmpDir();
+  fs.writeFileSync(path.join(sourceHome, "auth.json"), "{\"token\":\"test\"}");
+  fs.writeFileSync(path.join(sourceHome, "config.toml"), "model = \"test\"");
+  fs.mkdirSync(path.join(sourceHome, "sessions"));
+  fs.writeFileSync(path.join(sourceHome, "sessions", "shared.json"), "{}");
+
+  const env = createCodexEnv("pm", cwd, { CODEX_HOME: sourceHome });
+  const targetHome = path.join(cwd, ".orbit", "runtimes", "codex", "pm");
+
+  assert.equal(env.CODEX_HOME, targetHome);
+  assert.equal(env.ORBIT_AGENT_ID, "pm");
+  assert.equal(env.CODEX_AGENT_ID, "pm");
+  assert.equal(fs.readFileSync(path.join(targetHome, "auth.json"), "utf8"), "{\"token\":\"test\"}");
+  assert.equal(fs.readFileSync(path.join(targetHome, "config.toml"), "utf8"), "model = \"test\"");
+  assert.equal(fs.existsSync(path.join(targetHome, "sessions", "shared.json")), false);
+});
+
+test("prepareCodexHome preserves newer target auth files", () => {
+  const sourceHome = tmpDir();
+  const targetHome = tmpDir();
+  const sourceAuth = path.join(sourceHome, "auth.json");
+  const targetAuth = path.join(targetHome, "auth.json");
+  fs.writeFileSync(sourceAuth, "source");
+  fs.writeFileSync(targetAuth, "target");
+
+  const now = Date.now();
+  fs.utimesSync(sourceAuth, new Date(now - 10_000), new Date(now - 10_000));
+  fs.utimesSync(targetAuth, new Date(now), new Date(now));
+
+  prepareCodexHome(sourceHome, targetHome);
+
+  assert.equal(fs.readFileSync(targetAuth, "utf8"), "target");
 });
 
 test("extracts final answer from Codex JSONL message events", () => {

--- a/tests/codex-cli-runtime.test.ts
+++ b/tests/codex-cli-runtime.test.ts
@@ -25,11 +25,9 @@ test("builds Codex resume args with session id", () => {
   assert.deepEqual(buildCodexCliArgs({ cwd: "D:/workspace", resumeSessionId: "sess-abc" }), [
     "exec",
     "resume",
-    "sess-abc",
     "--json",
-    "--sandbox",
-    "danger-full-access",
     "--dangerously-bypass-approvals-and-sandbox",
+    "sess-abc",
     "-",
   ]);
 });
@@ -50,6 +48,24 @@ test("extracts final answer from Codex JSONL message events", () => {
         type: "message",
         role: "assistant",
         content: [{ type: "output_text", text: "final answer" }],
+      },
+    }),
+  ].join("\n");
+
+  assert.deepEqual(extractCodexCliFinalAnswer(output), {
+    text: "final answer",
+    sessionId: "thread-123",
+  });
+});
+
+test("extracts final answer from Codex agent_message events", () => {
+  const output = [
+    JSON.stringify({ type: "thread.started", thread_id: "thread-123" }),
+    JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        text: "final answer",
       },
     }),
   ].join("\n");

--- a/tests/codex-cli-runtime.test.ts
+++ b/tests/codex-cli-runtime.test.ts
@@ -7,6 +7,7 @@ import {
   createCodexEnv,
   extractCodexCliFinalAnswer,
   extractCodexSessionId,
+  resolveCodexCommand,
 } from "../src/core/codex-cli-runtime.ts";
 
 test("builds non-interactive Codex exec args without resume", () => {
@@ -34,10 +35,15 @@ test("builds Codex resume args with session id", () => {
 });
 
 test("builds a spawnable Codex command", () => {
-  const command = buildCodexCliCommand({ cwd: "D:/workspace" });
+  const command = buildCodexCliCommand({ cwd: "D:/workspace" }, { ORBIT_CODEX_PATH: "C:/codex/bin/codex.exe" });
 
-  assert.ok(command.file.length > 0);
+  assert.equal(command.file, "C:/codex/bin/codex.exe");
   assert.ok(command.args.includes("exec"));
+});
+
+test("uses configured Codex CLI path when provided", () => {
+  assert.equal(resolveCodexCommand({ ORBIT_CODEX_PATH: "C:/tools/codex.exe" }), "C:/tools/codex.exe");
+  assert.equal(resolveCodexCommand({ CODEX_CLI_PATH: "D:/tools/codex.exe" }), "D:/tools/codex.exe");
 });
 
 test("Codex env preserves the user's Codex home", () => {

--- a/tests/codex-cli-runtime.test.ts
+++ b/tests/codex-cli-runtime.test.ts
@@ -1,22 +1,13 @@
 import assert from "node:assert/strict";
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import test from "node:test";
 
 import {
   buildCodexCliArgs,
   buildCodexCliCommand,
-  codexHomeForAgent,
   createCodexEnv,
   extractCodexCliFinalAnswer,
   extractCodexSessionId,
-  prepareCodexHome,
 } from "../src/core/codex-cli-runtime.ts";
-
-function tmpDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "orbit-codex-runtime-test-"));
-}
 
 test("builds non-interactive Codex exec args without resume", () => {
   assert.deepEqual(buildCodexCliArgs({ cwd: "D:/workspace" }), [
@@ -49,51 +40,12 @@ test("builds a spawnable Codex command", () => {
   assert.ok(command.args.includes("exec"));
 });
 
-test("creates isolated Codex homes per agent", () => {
-  assert.equal(
-    codexHomeForAgent("D:/workspace", "pm"),
-    path.join("D:/workspace", ".orbit", "runtimes", "codex", "pm"),
-  );
-  assert.equal(
-    codexHomeForAgent("D:/workspace", "architect"),
-    path.join("D:/workspace", ".orbit", "runtimes", "codex", "architect"),
-  );
-});
+test("Codex env preserves the user's Codex home", () => {
+  const env = createCodexEnv("pm", { CODEX_HOME: "C:/Users/Sean/.codex" });
 
-test("Codex env uses agent-specific CODEX_HOME and bootstraps auth files", () => {
-  const cwd = tmpDir();
-  const sourceHome = tmpDir();
-  fs.writeFileSync(path.join(sourceHome, "auth.json"), "{\"token\":\"test\"}");
-  fs.writeFileSync(path.join(sourceHome, "config.toml"), "model = \"test\"");
-  fs.mkdirSync(path.join(sourceHome, "sessions"));
-  fs.writeFileSync(path.join(sourceHome, "sessions", "shared.json"), "{}");
-
-  const env = createCodexEnv("pm", cwd, { CODEX_HOME: sourceHome });
-  const targetHome = path.join(cwd, ".orbit", "runtimes", "codex", "pm");
-
-  assert.equal(env.CODEX_HOME, targetHome);
+  assert.equal(env.CODEX_HOME, "C:/Users/Sean/.codex");
   assert.equal(env.ORBIT_AGENT_ID, "pm");
   assert.equal(env.CODEX_AGENT_ID, "pm");
-  assert.equal(fs.readFileSync(path.join(targetHome, "auth.json"), "utf8"), "{\"token\":\"test\"}");
-  assert.equal(fs.readFileSync(path.join(targetHome, "config.toml"), "utf8"), "model = \"test\"");
-  assert.equal(fs.existsSync(path.join(targetHome, "sessions", "shared.json")), false);
-});
-
-test("prepareCodexHome preserves newer target auth files", () => {
-  const sourceHome = tmpDir();
-  const targetHome = tmpDir();
-  const sourceAuth = path.join(sourceHome, "auth.json");
-  const targetAuth = path.join(targetHome, "auth.json");
-  fs.writeFileSync(sourceAuth, "source");
-  fs.writeFileSync(targetAuth, "target");
-
-  const now = Date.now();
-  fs.utimesSync(sourceAuth, new Date(now - 10_000), new Date(now - 10_000));
-  fs.utimesSync(targetAuth, new Date(now), new Date(now));
-
-  prepareCodexHome(sourceHome, targetHome);
-
-  assert.equal(fs.readFileSync(targetAuth, "utf8"), "target");
 });
 
 test("extracts final answer from Codex JSONL message events", () => {

--- a/tests/session-store.test.ts
+++ b/tests/session-store.test.ts
@@ -12,7 +12,7 @@ function tmpDir(): string {
 
 test("load returns null for missing file", () => {
   const store = new SessionStore(tmpDir());
-  assert.equal(store.load("default", "default", "pm"), null);
+  assert.equal(store.load("claude-code", "default", "default", "pm"), null);
 });
 
 test("save then load round-trips", () => {
@@ -21,13 +21,14 @@ test("save then load round-trips", () => {
   const record = {
     agentId: "pm",
     channelId: "default",
+    runtime: "claude-code" as const,
     sessionId: "sess-123",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   };
 
-  store.save("default", "default", "pm", record);
-  const loaded = store.load("default", "default", "pm");
+  store.save("claude-code", "default", "default", "pm", record);
+  const loaded = store.load("claude-code", "default", "default", "pm");
 
   assert.deepEqual(loaded, record);
 });
@@ -36,54 +37,58 @@ test("save creates directories", () => {
   const dir = path.join(tmpDir(), "nested", "deep");
   const store = new SessionStore(dir);
 
-  store.save("default", "default", "developer", {
+  store.save("claude-code", "default", "default", "developer", {
     agentId: "developer",
     channelId: "default",
+    runtime: "claude-code",
     sessionId: "s1",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  assert.ok(fs.existsSync(path.join(dir, "default", "default", "developer.json")));
+  assert.ok(fs.existsSync(path.join(dir, "claude-code", "default", "default", "developer.json")));
 });
 
 test("clear removes the file", () => {
   const dir = tmpDir();
   const store = new SessionStore(dir);
 
-  store.save("default", "default", "architect", {
+  store.save("claude-code", "default", "default", "architect", {
     agentId: "architect",
     channelId: "default",
+    runtime: "claude-code",
     sessionId: "s2",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  store.clear("default", "default", "architect");
-  assert.equal(store.load("default", "default", "architect"), null);
+  store.clear("claude-code", "default", "default", "architect");
+  assert.equal(store.load("claude-code", "default", "default", "architect"), null);
 });
 
 test("save overwrites previous", () => {
   const dir = tmpDir();
   const store = new SessionStore(dir);
 
-  store.save("default", "default", "tester", {
+  store.save("claude-code", "default", "default", "tester", {
     agentId: "tester",
     channelId: "default",
+    runtime: "claude-code",
     sessionId: "old",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  store.save("default", "default", "tester", {
+  store.save("claude-code", "default", "default", "tester", {
     agentId: "tester",
     channelId: "default",
+    runtime: "claude-code",
     sessionId: "new",
     lastRunAt: new Date().toISOString(),
     runCount: 2,
   });
 
-  const loaded = store.load("default", "default", "tester");
+  const loaded = store.load("claude-code", "default", "default", "tester");
   assert.equal(loaded!.sessionId, "new");
   assert.equal(loaded!.runCount, 2);
 });
@@ -92,15 +97,16 @@ test("custom baseDir is used", () => {
   const dir = tmpDir();
   const store = new SessionStore(dir);
 
-  store.save("ch1", "conv1", "pm", {
+  store.save("claude-code", "ch1", "conv1", "pm", {
     agentId: "pm",
     channelId: "ch1",
+    runtime: "claude-code",
     sessionId: "s3",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  const expectedPath = path.join(dir, "ch1", "conv1", "pm.json");
+  const expectedPath = path.join(dir, "claude-code", "ch1", "conv1", "pm.json");
   assert.ok(fs.existsSync(expectedPath));
 });
 
@@ -108,22 +114,50 @@ test("different conversations for the same agent are independent", () => {
   const dir = tmpDir();
   const store = new SessionStore(dir);
 
-  store.save("default", "conv-a", "developer", {
+  store.save("claude-code", "default", "conv-a", "developer", {
     agentId: "developer",
     channelId: "default",
+    runtime: "claude-code",
     sessionId: "sess-conv-a",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  store.save("default", "conv-b", "developer", {
+  store.save("claude-code", "default", "conv-b", "developer", {
     agentId: "developer",
     channelId: "default",
+    runtime: "claude-code",
     sessionId: "sess-conv-b",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  assert.equal(store.load("default", "conv-a", "developer")!.sessionId, "sess-conv-a");
-  assert.equal(store.load("default", "conv-b", "developer")!.sessionId, "sess-conv-b");
+  assert.equal(store.load("claude-code", "default", "conv-a", "developer")!.sessionId, "sess-conv-a");
+  assert.equal(store.load("claude-code", "default", "conv-b", "developer")!.sessionId, "sess-conv-b");
+});
+
+test("different runtimes for the same agent are independent", () => {
+  const dir = tmpDir();
+  const store = new SessionStore(dir);
+
+  store.save("claude-code", "default", "default", "developer", {
+    agentId: "developer",
+    channelId: "default",
+    runtime: "claude-code",
+    sessionId: "claude-session",
+    lastRunAt: new Date().toISOString(),
+    runCount: 1,
+  });
+
+  store.save("codebuddy", "default", "default", "developer", {
+    agentId: "developer",
+    channelId: "default",
+    runtime: "codebuddy",
+    sessionId: "codebuddy-session",
+    lastRunAt: new Date().toISOString(),
+    runCount: 1,
+  });
+
+  assert.equal(store.load("claude-code", "default", "default", "developer")!.sessionId, "claude-session");
+  assert.equal(store.load("codebuddy", "default", "default", "developer")!.sessionId, "codebuddy-session");
 });


### PR DESCRIPTION
## What changed

- Closes #12.
- Routed `AgentSession` execution through a runtime adapter interface instead of calling Claude directly.
- Added default Claude Code and CodeBuddy CLI runtime adapters.
- Added `ORBIT_AGENT_RUNTIMES` so selected built-in agents can run through CodeBuddy, for example `developer=codebuddy,tester=codebuddy`.
- Documented runtime selection in README files and architecture docs.
- Added focused tests for CodeBuddy CLI args/parsing, runtime selection, and AgentSession runtime integration.

## Verification

- `npm run test` passed: 85 tests.
- `npm run build` passed.
- `git diff --check` passed.

## Known limitations / follow-up

- CodeBuddy support uses its documented `--print --output-format stream-json` path, but this PR does not run a real model call in CI.
- `codex` remains a reserved runtime type only; env overrides reject it until a Codex adapter exists.
- Persistence still uses the current project-local `.orbit` behavior. Moving state to `~/.orbit/workspaces/<workspace-id>` is still P2.