### PR TITLE
Improve Activity tool visibility

### DIFF
--- a/src/core/run-manager.ts
+++ b/src/core/run-manager.ts
@@ -43,6 +43,8 @@ export class RunManager {
   private readonly active = new Map<AgentId, ManagedRun>();
   private readonly runs = new Map<string, ManagedRun>();
   private readonly lastTerminalActivityAt = new Map<string, number>();
+  private readonly chunkBuffers = new Map<string, string>();
+  private readonly lastToolNames = new Map<string, string>();
 
   constructor(private readonly options: RunManagerOptions) {
     this.options.eventBus.subscribe((event) => this.handleRuntimeEvent(event));
@@ -116,6 +118,8 @@ export class RunManager {
     run.status = "completed";
     run.completedAt = new Date().toISOString();
     this.active.delete(run.agentId);
+    this.chunkBuffers.delete(run.id);
+    this.lastToolNames.delete(run.id);
     this.appendActivity(run, "Run completed.");
 
     const updated = this.options.messages.update(run.resultMessageId, {
@@ -143,6 +147,8 @@ export class RunManager {
     run.status = "failed";
     run.completedAt = new Date().toISOString();
     this.active.delete(run.agentId);
+    this.chunkBuffers.delete(run.id);
+    this.lastToolNames.delete(run.id);
     this.appendActivity(run, `Run failed: ${errorSummary}`);
 
     const updated = this.options.messages.update(run.resultMessageId, {
@@ -208,7 +214,29 @@ export class RunManager {
       return;
     }
 
-    const activities = classifyTerminalActivities(event.text);
+    const { complete, nonJson } = this.flushChunkBuffer(run.id, event.text);
+    const allActivities: AgentActivityEvent[] = [];
+
+    if (nonJson) {
+      allActivities.push(...classifyTerminalActivities(nonJson));
+    }
+    if (complete) {
+      allActivities.push(...classifyTerminalActivities(complete));
+    }
+
+    for (const activity of allActivities) {
+      if (activity.type === "tool.started") {
+        this.lastToolNames.set(run.id, activity.name);
+      }
+      if ((activity.type === "tool.completed" || activity.type === "tool.failed") && activity.name === "tool") {
+        const lastName = this.lastToolNames.get(run.id);
+        if (lastName) {
+          (activity as { name: string }).name = lastName;
+        }
+      }
+    }
+
+    const activities = allActivities;
     if (activities.length === 0) {
       return;
     }
@@ -237,6 +265,46 @@ export class RunManager {
     this.queues.set(agentId, nextQueue);
     return nextQueue;
   }
+
+  private flushChunkBuffer(runId: string, incoming: string): { complete: string; nonJson: string } {
+    const prev = this.chunkBuffers.get(runId) ?? "";
+
+    if (!prev) {
+      const lastBrace = findLastTopLevelClose(incoming);
+      if (lastBrace === -1) {
+        const startsLikeJson = /^\s*\{/.test(incoming);
+        if (startsLikeJson) {
+          this.chunkBuffers.set(runId, incoming);
+          return { complete: "", nonJson: "" };
+        }
+        return { complete: "", nonJson: incoming };
+      }
+      const complete = incoming.slice(0, lastBrace + 1);
+      const tail = incoming.slice(lastBrace + 1).replace(/^\s+/, "");
+      if (tail) {
+        this.chunkBuffers.set(runId, tail);
+      } else {
+        this.chunkBuffers.delete(runId);
+      }
+      return { complete, nonJson: "" };
+    }
+
+    const combined = prev + incoming;
+    const lastBrace = findLastTopLevelClose(combined);
+    if (lastBrace === -1) {
+      this.chunkBuffers.set(runId, combined);
+      return { complete: "", nonJson: "" };
+    }
+
+    const complete = combined.slice(0, lastBrace + 1);
+    const tail = combined.slice(lastBrace + 1).replace(/^\s+/, "");
+    if (tail) {
+      this.chunkBuffers.set(runId, tail);
+    } else {
+      this.chunkBuffers.delete(runId);
+    }
+    return { complete, nonJson: "" };
+  }
 }
 
 function createRunId(agentId: AgentId): string {
@@ -249,6 +317,41 @@ function createActivity(text: string): AgentActivityEvent {
 
 function getAgentLabel(agentId: AgentId): string {
   return agentId;
+}
+
+function findLastTopLevelClose(text: string): number {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  let lastClose = -1;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === "\"") {
+      inString = true;
+      continue;
+    }
+    if (ch === "{") {
+      depth += 1;
+    } else if (ch === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        lastClose = i;
+      }
+    }
+  }
+
+  return lastClose;
 }
 
 export function classifyTerminalActivity(text: string): AgentActivityEvent | null {

--- a/src/core/run-manager.ts
+++ b/src/core/run-manager.ts
@@ -139,20 +139,21 @@ export class RunManager {
   }
 
   private fail(run: ManagedRun, error: string): void {
+    const errorSummary = summarizeRunError(error);
     run.status = "failed";
     run.completedAt = new Date().toISOString();
     this.active.delete(run.agentId);
-    this.appendActivity(run, `Run failed: ${error}`);
+    this.appendActivity(run, `Run failed: ${errorSummary}`);
 
     const updated = this.options.messages.update(run.resultMessageId, {
-      content: `${getAgentLabel(run.agentId)} failed: ${error}`,
+      content: `${getAgentLabel(run.agentId)} failed: ${errorSummary}`,
       status: "error",
       activity: run.activity,
       completedAt: run.completedAt,
       startedAt: run.startedAt,
     });
     this.options.eventBus.publish({ type: "message.updated", message: updated });
-    this.options.eventBus.publish({ type: "run.failed", agentId: run.agentId, runId: run.id, error });
+    this.options.eventBus.publish({ type: "run.failed", agentId: run.agentId, runId: run.id, error: errorSummary });
     this.startNext(run.agentId);
   }
 
@@ -179,11 +180,11 @@ export class RunManager {
   }
 
   private appendActivityEvent(run: ManagedRun, activity: AgentActivityEvent): void {
-    run.activity.push(activity);
+    run.activity.push(truncateActivity(activity));
     this.options.messages.update(run.resultMessageId, {
       activity: run.activity,
     });
-    this.options.eventBus.publish({ type: "run.activity", agentId: run.agentId, runId: run.id, activity });
+    this.options.eventBus.publish({ type: "run.activity", agentId: run.agentId, runId: run.id, activity: run.activity[run.activity.length - 1]! });
   }
 
   private handleRuntimeEvent(event: RuntimeEvent): void {
@@ -283,21 +284,38 @@ export function classifyTerminalActivities(text: string): AgentActivityEvent[] {
 
 function extractStreamJsonActivities(text: string): AgentActivityEvent[] {
   const activities: AgentActivityEvent[] = [];
-  for (const line of text.split(/\r?\n/)) {
-    const trimmed = line.trim();
-    if (!trimmed.startsWith("{")) {
-      continue;
-    }
-
+  for (const event of parseJsonObjects(text)) {
     try {
-      const event = JSON.parse(trimmed) as {
+      const record = event as {
         type?: string;
-        message?: { content?: unknown };
+        message?: string | { content?: unknown };
+        item?: unknown;
+        result?: unknown;
+        text?: unknown;
+        error?: unknown;
+        data?: unknown;
         tool_use_result?: { stdout?: unknown; stderr?: unknown; is_error?: unknown };
       };
 
-      if (event.type === "assistant" && Array.isArray(event.message?.content)) {
-        for (const part of event.message.content as Array<{ type?: unknown; name?: unknown; input?: unknown }>) {
+      const codexActivity = activityFromCodexItem(record.item, record.type);
+      if (codexActivity) {
+        activities.push(codexActivity);
+      }
+
+      if (record.type === "error") {
+        const message = typeof record.message === "string" ? record.message : typeof record.error === "string" ? record.error : "";
+        if (message) {
+          activities.push({
+            type: "error",
+            message: truncateText(message, MAX_ACTIVITY_TEXT_CHARS),
+            timestamp: new Date().toISOString(),
+          });
+        }
+      }
+
+      const message = typeof record.message === "object" && record.message ? record.message as { content?: unknown } : null;
+      if (record.type === "assistant" && Array.isArray(message?.content)) {
+        for (const part of message.content as Array<{ type?: unknown; name?: unknown; input?: unknown }>) {
           if (part.type === "tool_use" && typeof part.name === "string") {
             activities.push({
               type: "tool.started",
@@ -309,14 +327,26 @@ function extractStreamJsonActivities(text: string): AgentActivityEvent[] {
         }
       }
 
-      if (event.type === "user" && event.tool_use_result) {
-        const summary = summarizeToolResult(event.tool_use_result);
-        activities.push({
-          type: "tool.completed",
-          name: "tool",
-          summary,
-          timestamp: new Date().toISOString(),
-        });
+      if (record.type === "user" && record.tool_use_result) {
+        const isError = !!record.tool_use_result.is_error;
+        const lastToolName = findLastToolName(activities);
+        if (isError) {
+          const summary = summarizeFailedToolResult(record.tool_use_result);
+          activities.push({
+            type: "tool.failed",
+            name: lastToolName,
+            summary,
+            timestamp: new Date().toISOString(),
+          });
+        } else {
+          const summary = summarizeToolResult(record.tool_use_result);
+          activities.push({
+            type: "tool.completed",
+            name: lastToolName,
+            summary,
+            timestamp: new Date().toISOString(),
+          });
+        }
       }
     } catch {
       continue;
@@ -324,6 +354,220 @@ function extractStreamJsonActivities(text: string): AgentActivityEvent[] {
   }
 
   return activities;
+}
+
+const MAX_RUN_ERROR_CHARS = 2_000;
+const MAX_ACTIVITY_TEXT_CHARS = 2_000;
+const MAX_TOOL_SUMMARY_CHARS = 120;
+
+function parseJsonObjects(text: string): unknown[] {
+  const objects: unknown[] = [];
+  let start = -1;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+
+    if (start === -1) {
+      if (char === "{") {
+        start = index;
+        depth = 1;
+        inString = false;
+        escaped = false;
+      }
+      continue;
+    }
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === "\"") {
+      inString = true;
+      continue;
+    }
+
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+
+    if (char !== "}") {
+      continue;
+    }
+
+    depth -= 1;
+    if (depth === 0) {
+      const candidate = text.slice(start, index + 1);
+      try {
+        objects.push(JSON.parse(candidate));
+      } catch {
+        // Ignore malformed chunks and keep scanning after this candidate.
+      }
+      start = -1;
+    }
+  }
+
+  return objects;
+}
+
+function activityFromCodexItem(item: unknown, eventType: unknown): AgentActivityEvent | null {
+  if (!item || typeof item !== "object") {
+    return null;
+  }
+
+  const record = item as {
+    type?: unknown;
+    command?: unknown;
+    aggregated_output?: unknown;
+    exit_code?: unknown;
+    status?: unknown;
+  };
+
+  if (record.type !== "command_execution") {
+    return null;
+  }
+
+  const name = commandToolName(record.command);
+  if (eventType === "item.started") {
+    return {
+      type: "tool.started",
+      name,
+      input: typeof record.command === "string" ? truncateText(record.command, MAX_TOOL_SUMMARY_CHARS) : undefined,
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  if (eventType !== "item.completed") {
+    return null;
+  }
+
+  const summary = summarizeCodexCommandOutput(record.aggregated_output);
+  if (typeof record.exit_code === "number" && record.exit_code !== 0) {
+    return {
+      type: "tool.failed",
+      name,
+      summary: summary || `exit ${record.exit_code}`,
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  if (record.status === "failed") {
+    return {
+      type: "tool.failed",
+      name,
+      summary: summary || "failed",
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  return {
+    type: "tool.completed",
+    name,
+    summary: summary || "completed",
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function commandToolName(command: unknown): string {
+  if (typeof command !== "string") {
+    return "Command";
+  }
+
+  if (/powershell|pwsh/i.test(command)) return "PowerShell";
+  if (/\b(cmd\.exe|cmd)\b/i.test(command)) return "Command";
+  if (/\b(bash|sh|zsh)\b/i.test(command)) return "Bash";
+  return "Command";
+}
+
+function summarizeCodexCommandOutput(output: unknown): string | undefined {
+  if (typeof output !== "string") {
+    return undefined;
+  }
+
+  const summary = output.replace(/\s+/g, " ").trim();
+  if (!summary) {
+    return undefined;
+  }
+
+  return truncateText(summary, MAX_TOOL_SUMMARY_CHARS);
+}
+
+function truncateActivity(activity: AgentActivityEvent): AgentActivityEvent {
+  if (activity.type === "status") {
+    return { ...activity, text: truncateText(activity.text, MAX_ACTIVITY_TEXT_CHARS) };
+  }
+  if (activity.type === "error") {
+    return { ...activity, message: truncateText(activity.message, MAX_ACTIVITY_TEXT_CHARS) };
+  }
+  if (activity.type === "tool.started") {
+    return { ...activity, input: activity.input ? truncateText(activity.input, MAX_TOOL_SUMMARY_CHARS) : undefined };
+  }
+  if (activity.type === "tool.completed" || activity.type === "tool.failed") {
+    return { ...activity, summary: activity.summary ? truncateText(activity.summary, MAX_TOOL_SUMMARY_CHARS) : undefined };
+  }
+  return activity;
+}
+
+function summarizeRunError(error: string): string {
+  const normalized = error.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return "Runtime failed without an error message. Check the transcript for details.";
+  }
+
+  return truncateText(stripRawJsonNoise(normalized), MAX_RUN_ERROR_CHARS);
+}
+
+function stripRawJsonNoise(value: string): string {
+  if (!value.includes("{\"type\":")) {
+    return value;
+  }
+
+  const parsedMessages = parseJsonObjects(value)
+    .map((event) => {
+      const record = event as {
+        type?: unknown;
+        message?: { content?: unknown };
+        error?: unknown;
+        result?: unknown;
+        item?: { type?: unknown; exit_code?: unknown; status?: unknown; aggregated_output?: unknown };
+      };
+
+      if (typeof record.error === "string") return record.error;
+      if (typeof record.message === "string") return record.message;
+      if (typeof record.result === "string") return record.result;
+      if (record.item?.type === "command_execution" && record.item.status === "failed") {
+        const output = typeof record.item.aggregated_output === "string" ? record.item.aggregated_output : "";
+        return output || `Command failed${typeof record.item.exit_code === "number" ? ` with exit ${record.item.exit_code}` : ""}`;
+      }
+      return "";
+    })
+    .filter(Boolean);
+
+  if (parsedMessages.length > 0) {
+    return parsedMessages.join(" ");
+  }
+
+  return "Runtime failed. Check the transcript for details.";
+}
+
+function findLastToolName(activities: AgentActivityEvent[]): string {
+  for (let i = activities.length - 1; i >= 0; i--) {
+    const activity = activities[i];
+    if (activity?.type === "tool.started") {
+      return activity.name;
+    }
+  }
+  return "tool";
 }
 
 function summarizeToolInput(input: unknown): string | undefined {
@@ -339,10 +583,6 @@ function summarizeToolInput(input: unknown): string | undefined {
 }
 
 function summarizeToolResult(result: { stdout?: unknown; stderr?: unknown; is_error?: unknown }): string {
-  if (result.is_error) {
-    return "failed";
-  }
-
   const stdout = typeof result.stdout === "string" ? result.stdout.trim() : "";
   const stderr = typeof result.stderr === "string" ? result.stderr.trim() : "";
   const summary = stdout || stderr;
@@ -350,5 +590,24 @@ function summarizeToolResult(result: { stdout?: unknown; stderr?: unknown; is_er
     return "completed";
   }
 
-  return summary.length > 120 ? `${summary.slice(0, 117)}...` : summary;
+  return truncateText(summary, MAX_TOOL_SUMMARY_CHARS);
+}
+
+function summarizeFailedToolResult(result: { stdout?: unknown; stderr?: unknown }): string {
+  const stderr = typeof result.stderr === "string" ? result.stderr.trim() : "";
+  const stdout = typeof result.stdout === "string" ? result.stdout.trim() : "";
+  const summary = stderr || stdout;
+  if (!summary) {
+    return "failed";
+  }
+
+  return truncateText(summary, MAX_TOOL_SUMMARY_CHARS);
+}
+
+function truncateText(value: string, maxChars: number): string {
+  if (value.length <= maxChars) {
+    return value;
+  }
+
+  return `${value.slice(0, Math.max(0, maxChars - 1))}…`;
 }

--- a/src/core/run-manager.ts
+++ b/src/core/run-manager.ts
@@ -442,11 +442,9 @@ function extractStreamJsonActivities(text: string): AgentActivityEvent[] {
             timestamp: new Date().toISOString(),
           });
         } else {
-          const summary = summarizeToolResult(record.tool_use_result);
           activities.push({
             type: "tool.completed",
             name: lastToolName,
-            summary,
             timestamp: new Date().toISOString(),
           });
         }
@@ -554,8 +552,8 @@ function activityFromCodexItem(item: unknown, eventType: unknown): AgentActivity
     return null;
   }
 
-  const summary = summarizeCodexCommandOutput(record.aggregated_output);
   if (typeof record.exit_code === "number" && record.exit_code !== 0) {
+    const summary = summarizeCodexCommandOutput(record.aggregated_output);
     return {
       type: "tool.failed",
       name,
@@ -565,6 +563,7 @@ function activityFromCodexItem(item: unknown, eventType: unknown): AgentActivity
   }
 
   if (record.status === "failed") {
+    const summary = summarizeCodexCommandOutput(record.aggregated_output);
     return {
       type: "tool.failed",
       name,
@@ -576,7 +575,6 @@ function activityFromCodexItem(item: unknown, eventType: unknown): AgentActivity
   return {
     type: "tool.completed",
     name,
-    summary: summary || "completed",
     timestamp: new Date().toISOString(),
   };
 }
@@ -683,17 +681,6 @@ function summarizeToolInput(input: unknown): string | undefined {
   const filePath = typeof value.file_path === "string" ? value.file_path : undefined;
   const pattern = typeof value.pattern === "string" ? value.pattern : undefined;
   return command ?? filePath ?? pattern;
-}
-
-function summarizeToolResult(result: { stdout?: unknown; stderr?: unknown; is_error?: unknown }): string {
-  const stdout = typeof result.stdout === "string" ? result.stdout.trim() : "";
-  const stderr = typeof result.stderr === "string" ? result.stderr.trim() : "";
-  const summary = stdout || stderr;
-  if (!summary) {
-    return "completed";
-  }
-
-  return truncateText(summary, MAX_TOOL_SUMMARY_CHARS);
 }
 
 function summarizeFailedToolResult(result: { stdout?: unknown; stderr?: unknown }): string {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -43,6 +43,7 @@ export type AgentActivityEvent =
   | { type: "status"; text: string; timestamp: string }
   | { type: "tool.started"; name: string; input?: string; timestamp: string }
   | { type: "tool.completed"; name: string; summary?: string; timestamp: string }
+  | { type: "tool.failed"; name: string; summary?: string; timestamp: string }
   | { type: "error"; message: string; timestamp: string };
 
 export type ChatMessage = {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -448,6 +448,7 @@ function ActivityList({ activity, status }: { activity: AgentActivityEvent[]; st
   const [expanded, setExpanded] = useState(!shouldAutoCollapse);
   const timelineRef = useRef<HTMLDivElement | null>(null);
   const toolCount = activity.filter((item) => item.type === "tool.started").length;
+  const failedCount = activity.filter((item) => item.type === "tool.failed").length;
   const errorCount = activity.filter((item) => item.type === "error").length;
   const latest = activity[activity.length - 1];
   const visibleActivity = expanded ? activity : activity.slice(-3);
@@ -476,6 +477,7 @@ function ActivityList({ activity, status }: { activity: AgentActivityEvent[]; st
           <strong>Activity</strong>
           <span>{activity.length} events</span>
           {toolCount > 0 ? <span>{toolCount} tools</span> : null}
+          {failedCount > 0 ? <span className="activityErrorCount">{failedCount} failed</span> : null}
           {errorCount > 0 ? <span className="activityErrorCount">{errorCount} errors</span> : null}
         </div>
         {activity.length > 3 ? (
@@ -507,6 +509,9 @@ function activityText(item: AgentActivityEvent): string {
       return item.summary ? `Completed: ${item.summary}` : "Completed";
     }
     return item.summary ? `Completed ${item.name}: ${item.summary}` : `Completed ${item.name}`;
+  }
+  if (item.type === "tool.failed") {
+    return item.summary ? `Failed ${item.name}: ${item.summary}` : `Failed ${item.name}`;
   }
   if (item.type === "error") {
     return item.message;

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -543,6 +543,10 @@ button:disabled {
   background: #50a46f;
 }
 
+.activityItem.tool-failed .activityDot {
+  background: #d45b5b;
+}
+
 .activityItem.error .activityDot {
   background: #c94b4b;
 }
@@ -558,7 +562,8 @@ button:disabled {
   white-space: nowrap;
 }
 
-.activityItem.error .activityText {
+.activityItem.error .activityText,
+.activityItem.tool-failed .activityText {
   color: #a33838;
 }
 

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import { AgentRegistry } from "../src/core/agent-registry.ts";
@@ -6,6 +9,11 @@ import type { AgentRuntime } from "../src/core/agent-runtime.ts";
 import { createDefaultAgentProfiles } from "../src/core/agent-profiles.ts";
 import { EventBus } from "../src/core/event-bus.ts";
 import { SessionStore } from "../src/core/session-store.ts";
+
+function createTempSessionStore(): SessionStore {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orbit-agent-registry-"));
+  return new SessionStore(dir);
+}
 
 test("creates sessions with the runtime selected by each profile", async () => {
   const profiles = createDefaultAgentProfiles(process.cwd()).map((profile) =>
@@ -38,7 +46,7 @@ test("creates sessions with the runtime selected by each profile", async () => {
   const registry = new AgentRegistry(
     profiles,
     new EventBus(),
-    new SessionStore(),
+    createTempSessionStore(),
     "default",
     "default",
     new Map([
@@ -76,7 +84,7 @@ test("states include each agent runtime", () => {
   const registry = new AgentRegistry(
     profiles,
     new EventBus(),
-    new SessionStore(),
+    createTempSessionStore(),
     "default",
     "default",
     new Map([

--- a/tests/run-manager.test.ts
+++ b/tests/run-manager.test.ts
@@ -281,6 +281,211 @@ test("classifies failed Codex command execution", () => {
   }
 });
 
+test("split Claude tool_use across two terminal chunks still produces tool.started", async () => {
+  const messages = new MessageStore();
+  const eventBus = new EventBus();
+  const first = deferred();
+  let activeRunId = "";
+
+  const manager = new RunManager({
+    messages,
+    eventBus,
+    agents: {
+      get() {
+        return {
+          send(runId: string) {
+            activeRunId = runId;
+            return first.promise;
+          },
+        };
+      },
+    },
+    buildPrompt(_agentId, prompt) {
+      return prompt;
+    },
+    onRunCompleted() {},
+  });
+
+  const run = manager.enqueue("developer", "split tool_use test", createSourceMessage());
+
+  const fullJson = JSON.stringify({
+    type: "assistant",
+    message: { content: [{ type: "tool_use", name: "Read", input: { file_path: "src/main.ts" } }] },
+  });
+  const mid = Math.floor(fullJson.length / 2);
+  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: fullJson.slice(0, mid) });
+  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: fullJson.slice(mid) });
+
+  const msg = messages.get(run.resultMessageId);
+  const toolStarted = msg?.activity?.find((a) => a.type === "tool.started");
+  assert.ok(toolStarted, "Expected tool.started from split tool_use JSON");
+  if (toolStarted?.type === "tool.started") {
+    assert.equal(toolStarted.name, "Read");
+    assert.equal(toolStarted.input, "src/main.ts");
+  }
+
+  first.resolve({ content: "done" });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+test("split Claude tool_use_result across chunks still produces tool.completed with summary", async () => {
+  const messages = new MessageStore();
+  const eventBus = new EventBus();
+  const first = deferred();
+  let activeRunId = "";
+
+  const manager = new RunManager({
+    messages,
+    eventBus,
+    agents: {
+      get() {
+        return {
+          send(runId: string) {
+            activeRunId = runId;
+            return first.promise;
+          },
+        };
+      },
+    },
+    buildPrompt(_agentId, prompt) {
+      return prompt;
+    },
+    onRunCompleted() {},
+  });
+
+  const run = manager.enqueue("developer", "split result test", createSourceMessage());
+
+  const started = JSON.stringify({
+    type: "assistant",
+    message: { content: [{ type: "tool_use", name: "Bash", input: { command: "ls" } }] },
+  });
+  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: `${started}\n` });
+
+  const resultJson = JSON.stringify({
+    type: "user",
+    tool_use_result: { stdout: "file1.ts\nfile2.ts", stderr: "", is_error: false },
+  });
+  const mid = Math.floor(resultJson.length / 2);
+  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: resultJson.slice(0, mid) });
+  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: resultJson.slice(mid) });
+
+  const msg = messages.get(run.resultMessageId);
+  const toolCompleted = msg?.activity?.find((a) => a.type === "tool.completed");
+  assert.ok(toolCompleted, "Expected tool.completed from split tool_use_result JSON");
+  if (toolCompleted?.type === "tool.completed") {
+    assert.equal(toolCompleted.name, "Bash");
+    assert.ok(toolCompleted.summary?.includes("file1.ts"), `Expected summary with output, got: ${toolCompleted.summary}`);
+  }
+
+  first.resolve({ content: "done" });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+test("split Claude tool_use_result error across chunks still produces tool.failed", async () => {
+  const messages = new MessageStore();
+  const eventBus = new EventBus();
+  const first = deferred();
+  let activeRunId = "";
+
+  const manager = new RunManager({
+    messages,
+    eventBus,
+    agents: {
+      get() {
+        return {
+          send(runId: string) {
+            activeRunId = runId;
+            return first.promise;
+          },
+        };
+      },
+    },
+    buildPrompt(_agentId, prompt) {
+      return prompt;
+    },
+    onRunCompleted() {},
+  });
+
+  const run = manager.enqueue("developer", "split failed result test", createSourceMessage());
+
+  const started = JSON.stringify({
+    type: "assistant",
+    message: { content: [{ type: "tool_use", name: "Bash", input: { command: "bad" } }] },
+  });
+  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: `${started}\n` });
+
+  const failedJson = JSON.stringify({
+    type: "user",
+    tool_use_result: { stdout: "", stderr: "command not found", is_error: true },
+  });
+  const mid = Math.floor(failedJson.length / 2);
+  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: failedJson.slice(0, mid) });
+  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: failedJson.slice(mid) });
+
+  const msg = messages.get(run.resultMessageId);
+  const toolFailed = msg?.activity?.find((a) => a.type === "tool.failed");
+  assert.ok(toolFailed, "Expected tool.failed from split error tool_use_result JSON");
+  if (toolFailed?.type === "tool.failed") {
+    assert.equal(toolFailed.name, "Bash");
+    assert.ok(toolFailed.summary?.includes("command not found"), `Expected stderr in summary, got: ${toolFailed.summary}`);
+  }
+
+  first.resolve({ content: "done" });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+test("split Codex command_execution completion across chunks still produces tool.completed", async () => {
+  const messages = new MessageStore();
+  const eventBus = new EventBus();
+  const first = deferred();
+  let activeRunId = "";
+
+  const manager = new RunManager({
+    messages,
+    eventBus,
+    agents: {
+      get() {
+        return {
+          send(runId: string) {
+            activeRunId = runId;
+            return first.promise;
+          },
+        };
+      },
+    },
+    buildPrompt(_agentId, prompt) {
+      return prompt;
+    },
+    onRunCompleted() {},
+  });
+
+  const run = manager.enqueue("developer", "split codex test", createSourceMessage());
+
+  const started = JSON.stringify({
+    type: "item.started",
+    item: { id: "item_1", type: "command_execution", command: "git status", status: "in_progress" },
+  });
+  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: `${started}\n` });
+
+  const completedJson = JSON.stringify({
+    type: "item.completed",
+    item: { id: "item_1", type: "command_execution", command: "git status", aggregated_output: "On branch main", exit_code: 0, status: "completed" },
+  });
+  const mid = Math.floor(completedJson.length / 2);
+  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: completedJson.slice(0, mid) });
+  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: completedJson.slice(mid) });
+
+  const msg = messages.get(run.resultMessageId);
+  const toolCompleted = msg?.activity?.find((a) => a.type === "tool.completed");
+  assert.ok(toolCompleted, "Expected tool.completed from split Codex command_execution JSON");
+  if (toolCompleted?.type === "tool.completed") {
+    assert.ok(toolCompleted.summary?.includes("On branch main"), `Expected output in summary, got: ${toolCompleted.summary}`);
+  }
+
+  first.resolve({ content: "done" });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
 test("run failures store a concise error instead of raw stream output", async () => {
   const messages = new MessageStore();
   const eventBus = new EventBus();

--- a/tests/run-manager.test.ts
+++ b/tests/run-manager.test.ts
@@ -150,7 +150,10 @@ test("classifies Claude stream-json tool events", () => {
   );
   assert.equal(activities[0]?.type === "tool.started" ? activities[0].name : "", "Bash");
   assert.equal(activities[0]?.type === "tool.started" ? activities[0].input : "", "pwd");
-  assert.equal(activities[1]?.type === "tool.completed" ? activities[1].summary : "", "/d/projects/orbit");
+  if (activities[1]?.type === "tool.completed") {
+    assert.equal(activities[1].name, "Bash");
+    assert.equal(activities[1].summary, undefined);
+  }
 });
 
 test("classifies tool_use_result with is_error=true as tool.failed", () => {
@@ -199,6 +202,43 @@ test("tool.failed falls back to stdout when stderr is empty", () => {
   assert.equal(activities[0]?.type, "tool.failed");
   if (activities[0]?.type === "tool.failed") {
     assert.ok(activities[0].summary?.includes("fallback output"), `Expected stdout in summary, got: ${activities[0].summary}`);
+  }
+});
+
+test("tool.completed does not include stdout/stderr summary", () => {
+  const started = JSON.stringify({
+    type: "assistant",
+    message: { content: [{ type: "tool_use", name: "Bash", input: { command: "cat large.log" } }] },
+  });
+  const completed = JSON.stringify({
+    type: "user",
+    tool_use_result: { stdout: "x".repeat(10_000), stderr: "some error output", is_error: false },
+  });
+
+  const activities = classifyTerminalActivities(`${started}\n${completed}`);
+  assert.equal(activities[1]?.type, "tool.completed");
+  if (activities[1]?.type === "tool.completed") {
+    assert.equal(activities[1].name, "Bash");
+    assert.equal(activities[1].summary, undefined);
+  }
+});
+
+test("Codex tool.completed does not include aggregated_output summary", () => {
+  const completed = JSON.stringify({
+    type: "item.completed",
+    item: {
+      type: "command_execution",
+      command: "npm test",
+      aggregated_output: "x".repeat(10_000),
+      exit_code: 0,
+      status: "completed",
+    },
+  });
+
+  const activities = classifyTerminalActivities(completed);
+  assert.equal(activities[0]?.type, "tool.completed");
+  if (activities[0]?.type === "tool.completed") {
+    assert.equal(activities[0].summary, undefined);
   }
 });
 
@@ -253,10 +293,10 @@ test("classifies Codex command execution items in order", () => {
 
   assert.deepEqual(activities.map((a) => a.type), ["tool.started", "tool.completed"]);
   assert.equal(activities[0]?.type === "tool.started" ? activities[0].name : "", "PowerShell");
-  assert.equal(
-    activities[1]?.type === "tool.completed" ? activities[1].summary : "",
-    "## fix/issue-14-activity-tool-visibility",
-  );
+  if (activities[1]?.type === "tool.completed") {
+    assert.equal(activities[1].name, "PowerShell");
+    assert.equal(activities[1].summary, undefined);
+  }
 });
 
 test("classifies failed Codex command execution", () => {
@@ -374,7 +414,7 @@ test("split Claude tool_use_result across chunks still produces tool.completed w
   assert.ok(toolCompleted, "Expected tool.completed from split tool_use_result JSON");
   if (toolCompleted?.type === "tool.completed") {
     assert.equal(toolCompleted.name, "Bash");
-    assert.ok(toolCompleted.summary?.includes("file1.ts"), `Expected summary with output, got: ${toolCompleted.summary}`);
+    assert.equal(toolCompleted.summary, undefined);
   }
 
   first.resolve({ content: "done" });
@@ -479,7 +519,8 @@ test("split Codex command_execution completion across chunks still produces tool
   const toolCompleted = msg?.activity?.find((a) => a.type === "tool.completed");
   assert.ok(toolCompleted, "Expected tool.completed from split Codex command_execution JSON");
   if (toolCompleted?.type === "tool.completed") {
-    assert.ok(toolCompleted.summary?.includes("On branch main"), `Expected output in summary, got: ${toolCompleted.summary}`);
+    assert.equal(toolCompleted.name, "Command");
+    assert.equal(toolCompleted.summary, undefined);
   }
 
   first.resolve({ content: "done" });

--- a/tests/run-manager.test.ts
+++ b/tests/run-manager.test.ts
@@ -152,3 +152,169 @@ test("classifies Claude stream-json tool events", () => {
   assert.equal(activities[0]?.type === "tool.started" ? activities[0].input : "", "pwd");
   assert.equal(activities[1]?.type === "tool.completed" ? activities[1].summary : "", "/d/projects/orbit");
 });
+
+test("classifies tool_use_result with is_error=true as tool.failed", () => {
+  const started = JSON.stringify({
+    type: "assistant",
+    message: {
+      content: [{ type: "tool_use", name: "Bash", input: { command: "bad-cmd" } }],
+    },
+  });
+  const failed = JSON.stringify({
+    type: "user",
+    tool_use_result: { stdout: "some output", stderr: "command not found", is_error: true },
+  });
+
+  const activities = classifyTerminalActivities(`${started}\n${failed}`);
+  assert.equal(activities.length, 2);
+  assert.equal(activities[0]?.type, "tool.started");
+  assert.equal(activities[1]?.type, "tool.failed");
+  if (activities[1]?.type === "tool.failed") {
+    assert.equal(activities[1].name, "Bash");
+    assert.ok(activities[1].summary?.includes("command not found"), `Expected stderr in summary, got: ${activities[1].summary}`);
+  }
+});
+
+test("tool.failed summary prefers stderr over stdout", () => {
+  const failed = JSON.stringify({
+    type: "user",
+    tool_use_result: { stdout: "stdout content", stderr: "stderr content", is_error: true },
+  });
+
+  const activities = classifyTerminalActivities(failed);
+  assert.equal(activities.length, 1);
+  assert.equal(activities[0]?.type, "tool.failed");
+  if (activities[0]?.type === "tool.failed") {
+    assert.ok(activities[0].summary?.includes("stderr content"), `Expected stderr in summary, got: ${activities[0].summary}`);
+  }
+});
+
+test("tool.failed falls back to stdout when stderr is empty", () => {
+  const failed = JSON.stringify({
+    type: "user",
+    tool_use_result: { stdout: "fallback output", stderr: "", is_error: true },
+  });
+
+  const activities = classifyTerminalActivities(failed);
+  assert.equal(activities[0]?.type, "tool.failed");
+  if (activities[0]?.type === "tool.failed") {
+    assert.ok(activities[0].summary?.includes("fallback output"), `Expected stdout in summary, got: ${activities[0].summary}`);
+  }
+});
+
+test("classifies sequential tool started/completed/failed events in order", () => {
+  const started1 = JSON.stringify({
+    type: "assistant",
+    message: { content: [{ type: "tool_use", name: "Read", input: { file_path: "a.ts" } }] },
+  });
+  const completed1 = JSON.stringify({
+    type: "user",
+    tool_use_result: { stdout: "file contents", stderr: "", is_error: false },
+  });
+  const started2 = JSON.stringify({
+    type: "assistant",
+    message: { content: [{ type: "tool_use", name: "Bash", input: { command: "test" } }] },
+  });
+  const failed2 = JSON.stringify({
+    type: "user",
+    tool_use_result: { stdout: "", stderr: "exit 1", is_error: true },
+  });
+
+  const activities = classifyTerminalActivities([started1, completed1, started2, failed2].join("\n"));
+  assert.deepEqual(activities.map((a) => a.type), ["tool.started", "tool.completed", "tool.started", "tool.failed"]);
+  if (activities[3]?.type === "tool.failed") {
+    assert.equal(activities[3].name, "Bash");
+  }
+});
+
+test("classifies Codex command execution items in order", () => {
+  const started = JSON.stringify({
+    type: "item.started",
+    item: {
+      id: "item_1",
+      type: "command_execution",
+      command: "\"C:\\\\windows\\\\System32\\\\WindowsPowerShell\\\\v1.0\\\\powershell.exe\" -Command \"git status\"",
+      status: "in_progress",
+    },
+  });
+  const completed = JSON.stringify({
+    type: "item.completed",
+    item: {
+      id: "item_1",
+      type: "command_execution",
+      command: "\"C:\\\\windows\\\\System32\\\\WindowsPowerShell\\\\v1.0\\\\powershell.exe\" -Command \"git status\"",
+      aggregated_output: "## fix/issue-14-activity-tool-visibility",
+      exit_code: 0,
+      status: "completed",
+    },
+  });
+
+  const activities = classifyTerminalActivities(`${started}${completed}`);
+
+  assert.deepEqual(activities.map((a) => a.type), ["tool.started", "tool.completed"]);
+  assert.equal(activities[0]?.type === "tool.started" ? activities[0].name : "", "PowerShell");
+  assert.equal(
+    activities[1]?.type === "tool.completed" ? activities[1].summary : "",
+    "## fix/issue-14-activity-tool-visibility",
+  );
+});
+
+test("classifies failed Codex command execution", () => {
+  const completed = JSON.stringify({
+    type: "item.completed",
+    item: {
+      id: "item_1",
+      type: "command_execution",
+      command: "bash -lc \"npm test\"",
+      aggregated_output: "Error: failed test",
+      exit_code: 1,
+      status: "completed",
+    },
+  });
+
+  const activities = classifyTerminalActivities(completed);
+
+  assert.equal(activities[0]?.type, "tool.failed");
+  if (activities[0]?.type === "tool.failed") {
+    assert.equal(activities[0].name, "Bash");
+    assert.equal(activities[0].summary, "Error: failed test");
+  }
+});
+
+test("run failures store a concise error instead of raw stream output", async () => {
+  const messages = new MessageStore();
+  const eventBus = new EventBus();
+  const failure = deferred();
+
+  const manager = new RunManager({
+    messages,
+    eventBus,
+    agents: {
+      get() {
+        return {
+          send() {
+            return failure.promise;
+          },
+        };
+      },
+    },
+    buildPrompt(_agentId, prompt) {
+      return prompt;
+    },
+    onRunCompleted() {},
+  });
+
+  const run = manager.enqueue("developer", "first", createSourceMessage());
+  const rawEvent = JSON.stringify({ type: "system", subtype: "hook_started", hook_id: "x".repeat(5_000) });
+  failure.reject(new Error(rawEvent.repeat(100)));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const failed = messages.get(run.resultMessageId);
+  assert.equal(failed?.status, "error");
+  assert.ok((failed?.content.length ?? 0) < 2_100, `content was too long: ${failed?.content.length}`);
+  assert.ok(!failed?.content.includes("hook_id\":\"" + "x".repeat(100)), "raw JSON should not be persisted in content");
+
+  const lastActivity = failed?.activity?.at(-1);
+  assert.equal(lastActivity?.type, "status");
+  assert.ok(lastActivity?.type === "status" && lastActivity.text.length < 2_100);
+});


### PR DESCRIPTION
Closes #14

## What changed
- Added `tool.failed` activity type to distinguish tool failures from successes in the Activity timeline.
- `tool.completed` no longer saves stdout/stderr/aggregated_output summary — keeps messages.json compact.
- `tool.failed` retains a short error summary (up to 120 chars, preferring stderr) for debugging.
- Added per-runId chunk buffer in RunManager to handle JSON events split across stdout chunks.
- Tool name propagation works across chunk boundaries for both Claude and Codex runtimes.
- Activity timeline renders failed counts and failed tool status with distinct red styling.

## Verification
- `npm run test` — 145 tests pass
- `npm run build` — clean
- `git diff --check` — no whitespace issues

## Known limitations / follow-up
- Activity summaries are intentionally concise; richer tool-specific output details can be added later if the UI needs expandable per-tool logs.