### PR TITLE
Add configurable agent system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ dist/
 output/
 .local/
 .claude/
-
+.playwright-mcp/
 .env
 .env.*
 *.log
@@ -14,3 +14,6 @@ coverage/
 .orbit/
 .DS_Store
 Thumbs.db
+
+# Local screenshots (not for repo)
+orbit-ui-*.png

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,12 +72,29 @@ Agent replies can contain `@other_agent:` assignments, enabling delegation chain
 - **`src/core/channel-router.ts`** + **`mention-router.ts`** — Message routing and @mention parsing
 - **`src/core/run-manager.ts`** — Per-agent FIFO run queue, lifecycle events, activity classification
 - **`src/core/claude-cli-runtime.ts`** — Spawns `claude --print --output-format stream-json`, parses stdout
+- **`src/core/codex-cli-runtime.ts`** — Spawns Codex CLI in JSONL mode, parses output
+- **`src/core/codebuddy-cli-runtime.ts`** — Spawns CodeBuddy CLI in stream-json mode, parses output
+- **`src/core/agent-runtime.ts`** — Shared runtime interface for all CLI adapters
+- **`src/core/agent-config-store.ts`** — Persistent agent configuration (load/save/reset via JSON file)
 - **`src/core/channel-context-builder.ts`** — Builds private system prompt injected into each Claude run
 - **`src/core/channel-history.ts`** — Builds scoped channel history (messages since agent's last completed run)
 - **`src/core/session-store.ts`** — Per-agent session persistence for `--resume`
-- **`src/core/agent-profiles.ts`** — Four hardcoded agent profiles (pm, architect, developer, tester)
+- **`src/core/agent-profiles.ts`** — Four built-in agent profiles (pm, architect, developer, tester)
 - **`src/core/agent-session.ts`** — Manages one agent's lifecycle (idle/running/error/stopped)
 - **`src/core/agent-registry.ts`** — Owns AgentSession instances, exposes agent state
+- **`src/core/message-store.ts`** — Message persistence (in-memory + optional file-based storage)
+- **`src/core/event-bus.ts`** — Typed pub/sub event bus for runtime events
+- **`src/core/terminal-transcript-store.ts`** — Per-agent terminal output logging with ANSI stripping
+- **`src/core/workspace-store.ts`** — Workspace resolution and metadata (path-based isolation)
+- **`src/core/claude-output-detector.ts`** — Detects tool.started/completed/failed from Claude stream events
+- **`src/core/ansi-text-extractor.ts`** — Strips ANSI codes and extracts readable text
+- **`src/core/agent-prompt.ts`** — Prompt templates for agent role instructions
+
+### UI Module
+
+- **`src/ui/App.tsx`** — Single-page React app (all UI in one file, no router)
+- **`src/ui/styles.css`** — "Warm Observatory" design system (CSS custom properties, no Tailwind)
+- **`src/ui/markdown-renderer.ts`** — Markdown→HTML with code block headers (language label + copy button)
 
 ### Built-in Agents
 
@@ -96,6 +113,9 @@ The developer agent creates feature branches, commits, pushes, and opens draft P
 |---|---|---|
 | GET | `/api/state` | Full state snapshot |
 | POST | `/api/messages` | Send user message (`{ content: string }`) |
+| GET | `/api/agents` | List agent configurations |
+| PUT | `/api/agents` | Update agent configurations |
+| POST | `/api/agents/reset` | Reset agents to default configuration |
 | GET | `/events` | SSE stream of all runtime events |
 | GET | `/*` | Static files from `dist/ui/` |
 
@@ -105,6 +125,19 @@ The developer agent creates feature branches, commits, pushes, and opens draft P
 - **Per-agent serial queue**: Each agent runs one CLI process at a time; additional tasks queue automatically
 - **Private context injection**: Each agent prompt is wrapped with a private routing context block; leaked markers are stripped from replies
 - **In-memory state**: All state (messages, agent statuses, queued runs) lives in memory with no persistence layer
+
+### UI Design System ("Warm Observatory")
+
+The UI uses a warm cream + deep teal design system, implemented entirely in CSS custom properties. No dark mode support.
+
+**Design tokens** (all in `:root` CSS variables):
+- **Surfaces**: `--bg-base: #f5f3ef` (warm cream), `--bg-sidebar: #eeebe5`, `--bg-surface: #ffffff`
+- **Accent**: `--accent: #0f766e` (deep teal), `--secondary: #c2410c` (burnt sienna for inline code)
+- **Shadows**: 5-tier warm-tinted system (`--shadow-xs` through `--shadow-xl`)
+- **Typography**: Plus Jakarta Sans (Google Fonts import), no Inter/Roboto
+- **Animations**: Custom cubic-bezier easing (`--ease-out`, `--ease-spring`)
+
+When modifying UI: use CSS variables, never hardcode colors. Keep all changes in `styles.css`. JSX changes in `App.tsx` only.
 
 ### Routing Rules
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ The current version is intentionally small. It validates the core workflow befor
 ## Features
 
 - One local channel: `Orbit P0`
-- Four built-in agents: `@pm:`, `@architect:`, `@developer:`, `@tester:`
+- Configurable agents with settings UI (gear icon in sidebar)
+- Four built-in agents by default: `@pm:`, `@architect:`, `@developer:`, `@tester:`
+- Custom agent creation, editing, enable/disable, and delete
+- Per-agent configurable permissions (read/write/run/install/git commit, allowed directories)
 - Explicit assignment syntax with a colon, for example `@developer: inspect the current project`
 - Multiple agent assignments in one channel message
 - Per-agent run queue, so long-running work does not block the whole channel
@@ -23,7 +26,6 @@ The current version is intentionally small. It validates the core workflow befor
 
 ## Not Included Yet
 
-- Custom agent creation
 - Persistent database storage
 - Online sync or multi-device support
 - GitHub PR workflow automation inside Orbit
@@ -49,15 +51,38 @@ npm run dev
 
 Open `http://localhost:4317`.
 
-By default, `@pm:` and `@architect:` use Codex, `@developer:` uses Claude Code,
-and `@tester:` uses CodeBuddy. To override selected agents, set
-`ORBIT_AGENT_RUNTIMES` before starting Orbit:
+### Agent Configuration
 
-```powershell
-$env:ORBIT_AGENT_RUNTIMES="developer=codex,tester=claude-code"; npm run dev
+Agents are configured via the settings modal (gear icon in the sidebar) or by
+editing the config file directly:
+
+```
+~/.orbit/workspaces/<workspace-id>/agents.json
 ```
 
-Supported runtime values are `codex`, `claude-code`, and `codebuddy`.
+By default, four agents are seeded: `pm`, `architect`, `developer`, `tester`.
+You can add, edit, disable, or remove agents through the UI. Disabled agents
+are excluded from routing — mentions like `@disabled_agent:` will not trigger
+runs.
+
+Each agent config includes:
+- **id**: Unique identifier (alphanumeric, hyphens, underscores)
+- **name**: Display name
+- **description**: Short description of the agent's purpose
+- **role**: One of `pm`, `architect`, `developer`, `tester`, `general`
+- **runtime**: `claude-code`, `codex`, or `codebuddy`
+- **systemPrompt**: System prompt injected into each run
+- **permissionProfile**: Read/write/run/install/git commit permissions and allowed directories
+- **enabled**: Whether the agent is active
+- **ui.label**: Optional display label override
+
+Changes take effect immediately after save. If any agent is currently running,
+save is blocked with a 409 response until the run completes.
+
+**API endpoints:**
+- `GET /api/agents` — list all agent configs
+- `PUT /api/agents` — save agent configs (validates first)
+- `POST /api/agents/reset` — restore default configs
 
 To restart the local service on Windows PowerShell and clear the default port first:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,7 +28,8 @@ The runtime no longer uses PTY sessions or CLI hooks. A run is considered comple
 | `src/server/index.ts` | Local HTTP routes, SSE wiring, message intake |
 | `src/server/sse-hub.ts` | Server-Sent Events client management |
 | `src/server/static-server.ts` | Static UI serving |
-| `src/core/agent-profiles.ts` | Built-in role definitions and permission profiles |
+| `src/core/agent-profiles.ts` | Built-in role definitions, permission profiles, and config-to-profile conversion |
+| `src/core/agent-config-store.ts` | Persistent agent configuration (load/save/reset/validate) |
 | `src/core/agent-registry.ts` | Owns agent sessions and exposes agent state |
 | `src/core/agent-session.ts` | Starts one runtime adapter run and tracks status |
 | `src/core/agent-runtime.ts` | Shared runtime adapter contract |
@@ -49,29 +50,42 @@ The runtime no longer uses PTY sessions or CLI hooks. A run is considered comple
 
 ## Agents
 
-The current build has four fixed agents:
+Agents are configured via `AgentConfigStore` and persisted per-workspace in `~/.orbit/workspaces/<workspace-id>/agents.json`. Four agents are seeded by default:
 
-| Agent | Role |
-| --- | --- |
-| `@pm:` | Product manager |
-| `@architect:` | Architect |
-| `@developer:` | Developer |
-| `@tester:` | Tester |
+| Agent | Role | Default runtime |
+| --- | --- | --- |
+| `@pm:` | Product manager | `codex` |
+| `@architect:` | Architect | `codex` |
+| `@developer:` | Developer | `claude-code` |
+| `@tester:` | Tester | `codebuddy` |
 
-Agent profiles are defined in `src/core/agent-profiles.ts`. They are intentionally hardcoded for now to keep the first local product loop simple. Each profile has a `runtime` value. Defaults are:
+These defaults can be modified, disabled, or removed through the settings UI. Custom agents can be added with any of the supported runtimes and configurable permissions. Only enabled agents participate in routing.
 
-| Agent | Default runtime |
-| --- | --- |
-| `@pm:` | `codex` |
-| `@architect:` | `codex` |
-| `@developer:` | `claude-code` |
-| `@tester:` | `codebuddy` |
+### Two-Layer Model
 
-`ORBIT_AGENT_RUNTIMES` can override selected agents at startup:
+- **`AgentConfig`** (`src/shared/types.ts`): Persistence and UI model — includes id, name, description, role, runtime, systemPrompt, permissionProfile, enabled, and ui metadata.
+- **`AgentProfile`** (`src/shared/types.ts`): Runtime model used by `AgentRegistry` and `AgentSession` — includes cwd and resolved permissionProfile.
 
-```text
-ORBIT_AGENT_RUNTIMES=developer=codex,tester=claude-code
-```
+`configsToProfiles()` in `agent-profiles.ts` converts enabled `AgentConfig` entries to `AgentProfile` instances, using the config's `permissionProfile` if provided or deriving one from the role.
+
+### Config Store
+
+`AgentConfigStore` (`src/core/agent-config-store.ts`) handles:
+- **load**: Reads `agents.json`, returns seed defaults if missing or corrupted
+- **save**: Validates then writes with atomic file swap
+- **reset**: Restores the four built-in default configs
+- **validateAgentConfigs**: Checks id format, uniqueness, reserved names, runtime validity, systemPrompt, name, permissionProfile.allowedDirectories, and at least one enabled agent
+
+### Runtime Refresh
+
+When config is saved or reset, the server calls `refreshEnabledAgents()` which:
+1. Filters to enabled configs, converts to profiles
+2. Stops all current agent sessions
+3. Creates a new `AgentRegistry` and starts fresh sessions
+4. Disposes the old `RunManager` (unsubscribes from EventBus)
+5. Creates a new `RunManager` and `ChannelRouter` with the updated agent set
+
+This ensures routing and run dispatch use the current agent configuration. A 409 response is returned if any agent is currently running.
 
 ## Routing Rules
 
@@ -166,7 +180,6 @@ This keeps P0 simple. Persistent storage should be added behind existing stores 
 
 ## Future Extension Points
 
-- Replace hardcoded profiles with user-defined agents.
 - Add persistent SQLite storage behind `MessageStore` and transcript storage (currently JSON/log files).
 - Add runtime adapters for other agent backends.
 - Add richer queue controls: cancel, retry, pause, and priority.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "tsx src/server/index.ts",
     "build": "tsc --noEmit && vite build",
-    "test": "node --test --import tsx tests/mention-router.test.ts tests/message-store.test.ts tests/channel-router.test.ts tests/ansi-text-extractor.test.ts tests/terminal-transcript-store.test.ts tests/claude-output-detector.test.ts tests/claude-cli-runtime.test.ts tests/codex-cli-runtime.test.ts tests/codebuddy-cli-runtime.test.ts tests/agent-profiles.test.ts tests/agent-registry.test.ts tests/channel-context-builder.test.ts tests/channel-history.test.ts tests/run-manager.test.ts tests/session-store.test.ts tests/agent-session.test.ts tests/workspace-store.test.ts tests/markdown-renderer.test.ts",
+    "test": "node --test --import tsx tests/mention-router.test.ts tests/message-store.test.ts tests/channel-router.test.ts tests/ansi-text-extractor.test.ts tests/terminal-transcript-store.test.ts tests/claude-output-detector.test.ts tests/claude-cli-runtime.test.ts tests/codex-cli-runtime.test.ts tests/codebuddy-cli-runtime.test.ts tests/agent-profiles.test.ts tests/agent-registry.test.ts tests/channel-context-builder.test.ts tests/channel-history.test.ts tests/run-manager.test.ts tests/session-store.test.ts tests/agent-session.test.ts tests/workspace-store.test.ts tests/markdown-renderer.test.ts tests/agent-config-store.test.ts",
     "test:glob": "node --test --import tsx tests/*.test.ts"
   },
   "dependencies": {

--- a/src/core/agent-config-store.ts
+++ b/src/core/agent-config-store.ts
@@ -1,10 +1,11 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { AgentConfig, AgentId, AgentRuntimeKind } from "../shared/types.ts";
+import type { AgentConfig, AgentId, AgentRole, AgentRuntimeKind } from "../shared/types.ts";
 
 export type { AgentConfig };
 
+const VALID_ROLES = new Set<AgentRole>(["pm", "architect", "developer", "tester", "general"]);
 const VALID_RUNTIMES = new Set<AgentRuntimeKind>(["claude-code", "codex", "codebuddy"]);
 const RESERVED_IDS = new Set(["all"]);
 const ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
@@ -75,6 +76,14 @@ export function validateAgentConfigs(configs: AgentConfig[]): string[] {
 
     if (!config.name || !config.name.trim()) {
       errors.push(`Agent "${config.id}" name is required.`);
+    }
+
+    if (!VALID_ROLES.has(config.role)) {
+      errors.push(`Agent "${config.id}" has invalid role "${config.role}".`);
+    }
+
+    if (typeof config.enabled !== "boolean") {
+      errors.push(`Agent "${config.id}" enabled must be a boolean.`);
     }
 
     if (!VALID_RUNTIMES.has(config.runtime)) {

--- a/src/core/agent-config-store.ts
+++ b/src/core/agent-config-store.ts
@@ -1,0 +1,131 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { AgentConfig, AgentId, AgentRuntimeKind } from "../shared/types.ts";
+
+export type { AgentConfig };
+
+const VALID_RUNTIMES = new Set<AgentRuntimeKind>(["claude-code", "codex", "codebuddy"]);
+const RESERVED_IDS = new Set(["all"]);
+const ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+export const DEFAULT_AGENT_CONFIGS: AgentConfig[] = [
+  {
+    id: "pm",
+    name: "Product Manager",
+    role: "pm",
+    runtime: "codex",
+    systemPrompt:
+      "You are Orbit's product manager. Clarify requirements, define scope, acceptance criteria, and review whether implementation matches user needs. Do not edit code unless explicitly assigned.",
+    enabled: true,
+  },
+  {
+    id: "architect",
+    name: "Architect",
+    role: "architect",
+    runtime: "codex",
+    systemPrompt:
+      "You are Orbit's architect. Design technical boundaries, module responsibilities, migration plans, and review implementation risk. Prefer scoped, testable changes.",
+    enabled: true,
+  },
+  {
+    id: "developer",
+    name: "Developer",
+    role: "developer",
+    runtime: "claude-code",
+    systemPrompt:
+      "You are Orbit's developer. Follow strict TDD: write failing tests first, then implement the minimal code to pass them. Before writing any code, always create a feature branch from main (e.g. feat/issue-N-description). Run npm run test && npm run build after each meaningful change. Commit, push, and open a draft PR. Never commit directly to main.",
+    enabled: true,
+  },
+  {
+    id: "tester",
+    name: "Tester",
+    role: "tester",
+    runtime: "codebuddy",
+    systemPrompt:
+      "You are Orbit's tester. Validate behavior, run tests, inspect regressions, and report risks. Do not modify production code unless explicitly assigned.",
+    enabled: true,
+  },
+];
+
+export function validateAgentConfigs(configs: AgentConfig[]): string[] {
+  const errors: string[] = [];
+
+  if (configs.length === 0) {
+    errors.push("At least one agent config is required.");
+    return errors;
+  }
+
+  const seen = new Set<AgentId>();
+  for (const config of configs) {
+    if (!config.id || !config.id.trim()) {
+      errors.push(`Agent id is required.`);
+    } else if (RESERVED_IDS.has(config.id)) {
+      errors.push(`Agent id "${config.id}" is reserved.`);
+    } else if (!ID_PATTERN.test(config.id)) {
+      errors.push(`Agent id "${config.id}" has invalid format. Use letters, digits, hyphens, and underscores.`);
+    } else if (seen.has(config.id)) {
+      errors.push(`Duplicate agent id "${config.id}".`);
+    }
+    seen.add(config.id);
+
+    if (!config.name || !config.name.trim()) {
+      errors.push(`Agent "${config.id}" name is required.`);
+    }
+
+    if (!VALID_RUNTIMES.has(config.runtime)) {
+      errors.push(`Agent "${config.id}" has invalid runtime "${config.runtime}".`);
+    }
+
+    if (!config.systemPrompt || !config.systemPrompt.trim()) {
+      errors.push(`Agent "${config.id}" systemPrompt is required.`);
+    }
+  }
+
+  if (!configs.some((c) => c.enabled)) {
+    errors.push("At least one agent must be enabled.");
+  }
+
+  return errors;
+}
+
+export class AgentConfigStore {
+  private readonly baseDir: string;
+
+  constructor(baseDir?: string) {
+    this.baseDir = baseDir ?? path.join(os.homedir(), ".orbit");
+  }
+
+  load(workspaceId: string): AgentConfig[] {
+    const filePath = this.configPath(workspaceId);
+    try {
+      const data = fs.readFileSync(filePath, "utf8");
+      const configs = JSON.parse(data) as AgentConfig[];
+      if (!Array.isArray(configs) || configs.length === 0) {
+        return structuredClone(DEFAULT_AGENT_CONFIGS);
+      }
+      return configs;
+    } catch {
+      return structuredClone(DEFAULT_AGENT_CONFIGS);
+    }
+  }
+
+  save(workspaceId: string, configs: AgentConfig[]): void {
+    const filePath = this.configPath(workspaceId);
+    const dir = path.dirname(filePath);
+    fs.mkdirSync(dir, { recursive: true });
+    const tmpFile = filePath + ".tmp";
+    fs.writeFileSync(tmpFile, JSON.stringify(configs, null, 2) + os.EOL);
+    fs.renameSync(tmpFile, filePath);
+  }
+
+  reset(workspaceId: string): AgentConfig[] {
+    const defaults = structuredClone(DEFAULT_AGENT_CONFIGS);
+    this.save(workspaceId, defaults);
+    return defaults;
+  }
+
+  private configPath(workspaceId: string): string {
+    return path.join(this.baseDir, "workspaces", workspaceId, "agents.json");
+  }
+}

--- a/src/core/agent-config-store.ts
+++ b/src/core/agent-config-store.ts
@@ -62,7 +62,12 @@ export function validateAgentConfigs(configs: AgentConfig[]): string[] {
   }
 
   const seen = new Set<AgentId>();
-  for (const config of configs) {
+  for (let i = 0; i < configs.length; i++) {
+    const config = configs[i];
+    if (!config || typeof config !== "object" || Array.isArray(config)) {
+      errors.push(`Agent config at index ${i} must be an object.`);
+      continue;
+    }
     const configId = typeof config.id === "string" ? config.id : String(config.id ?? "");
 
     if (typeof config.id !== "string" || !config.id.trim()) {
@@ -111,7 +116,7 @@ export function validateAgentConfigs(configs: AgentConfig[]): string[] {
     }
   }
 
-  if (!configs.some((c) => c.enabled)) {
+  if (!configs.some((c) => c && typeof c === "object" && c.enabled)) {
     errors.push("At least one agent must be enabled.");
   }
 

--- a/src/core/agent-config-store.ts
+++ b/src/core/agent-config-store.ts
@@ -13,6 +13,7 @@ export const DEFAULT_AGENT_CONFIGS: AgentConfig[] = [
   {
     id: "pm",
     name: "Product Manager",
+    description: "Clarifies requirements, defines scope and acceptance criteria.",
     role: "pm",
     runtime: "codex",
     systemPrompt:
@@ -22,6 +23,7 @@ export const DEFAULT_AGENT_CONFIGS: AgentConfig[] = [
   {
     id: "architect",
     name: "Architect",
+    description: "Designs technical boundaries, reviews implementation risk.",
     role: "architect",
     runtime: "codex",
     systemPrompt:
@@ -31,6 +33,7 @@ export const DEFAULT_AGENT_CONFIGS: AgentConfig[] = [
   {
     id: "developer",
     name: "Developer",
+    description: "Implements features with TDD, creates branches and draft PRs.",
     role: "developer",
     runtime: "claude-code",
     systemPrompt:
@@ -40,6 +43,7 @@ export const DEFAULT_AGENT_CONFIGS: AgentConfig[] = [
   {
     id: "tester",
     name: "Tester",
+    description: "Validates behavior, runs tests, reports risks.",
     role: "tester",
     runtime: "codebuddy",
     systemPrompt:

--- a/src/core/agent-config-store.ts
+++ b/src/core/agent-config-store.ts
@@ -87,6 +87,13 @@ export function validateAgentConfigs(configs: AgentConfig[]): string[] {
 
     if (config.permissionProfile) {
       const pp = config.permissionProfile;
+      const boolFlags: (keyof Pick<typeof pp, "canReadFiles" | "canWriteFiles" | "canRunCommands" | "canInstallDependencies" | "canGitCommit">)[] =
+        ["canReadFiles", "canWriteFiles", "canRunCommands", "canInstallDependencies", "canGitCommit"];
+      for (const flag of boolFlags) {
+        if (typeof pp[flag] !== "boolean") {
+          errors.push(`Agent "${config.id}" permissionProfile.${flag} must be a boolean.`);
+        }
+      }
       if (!Array.isArray(pp.allowedDirectories) || pp.allowedDirectories.length === 0) {
         errors.push(`Agent "${config.id}" permissionProfile.allowedDirectories must be non-empty.`);
       }

--- a/src/core/agent-config-store.ts
+++ b/src/core/agent-config-store.ts
@@ -122,6 +122,11 @@ export class AgentConfigStore {
       if (!Array.isArray(configs) || configs.length === 0) {
         return structuredClone(DEFAULT_AGENT_CONFIGS);
       }
+      const errors = validateAgentConfigs(configs);
+      if (errors.length > 0) {
+        console.error(`[orbit] Invalid agents.json, using defaults: ${errors.join("; ")}`);
+        return structuredClone(DEFAULT_AGENT_CONFIGS);
+      }
       return configs;
     } catch {
       return structuredClone(DEFAULT_AGENT_CONFIGS);

--- a/src/core/agent-config-store.ts
+++ b/src/core/agent-config-store.ts
@@ -84,6 +84,13 @@ export function validateAgentConfigs(configs: AgentConfig[]): string[] {
     if (!config.systemPrompt || !config.systemPrompt.trim()) {
       errors.push(`Agent "${config.id}" systemPrompt is required.`);
     }
+
+    if (config.permissionProfile) {
+      const pp = config.permissionProfile;
+      if (!Array.isArray(pp.allowedDirectories) || pp.allowedDirectories.length === 0) {
+        errors.push(`Agent "${config.id}" permissionProfile.allowedDirectories must be non-empty.`);
+      }
+    }
   }
 
   if (!configs.some((c) => c.enabled)) {

--- a/src/core/agent-config-store.ts
+++ b/src/core/agent-config-store.ts
@@ -63,35 +63,37 @@ export function validateAgentConfigs(configs: AgentConfig[]): string[] {
 
   const seen = new Set<AgentId>();
   for (const config of configs) {
-    if (!config.id || !config.id.trim()) {
+    const configId = typeof config.id === "string" ? config.id : String(config.id ?? "");
+
+    if (typeof config.id !== "string" || !config.id.trim()) {
       errors.push(`Agent id is required.`);
     } else if (RESERVED_IDS.has(config.id)) {
       errors.push(`Agent id "${config.id}" is reserved.`);
     } else if (!ID_PATTERN.test(config.id)) {
       errors.push(`Agent id "${config.id}" has invalid format. Use letters, digits, hyphens, and underscores.`);
-    } else if (seen.has(config.id)) {
+    } else if (seen.has(config.id as AgentId)) {
       errors.push(`Duplicate agent id "${config.id}".`);
     }
-    seen.add(config.id);
+    seen.add(configId as AgentId);
 
-    if (!config.name || !config.name.trim()) {
-      errors.push(`Agent "${config.id}" name is required.`);
+    if (typeof config.name !== "string" || !config.name.trim()) {
+      errors.push(`Agent "${configId}" name is required.`);
     }
 
     if (!VALID_ROLES.has(config.role)) {
-      errors.push(`Agent "${config.id}" has invalid role "${config.role}".`);
+      errors.push(`Agent "${configId}" has invalid role "${config.role}".`);
     }
 
     if (typeof config.enabled !== "boolean") {
-      errors.push(`Agent "${config.id}" enabled must be a boolean.`);
+      errors.push(`Agent "${configId}" enabled must be a boolean.`);
     }
 
     if (!VALID_RUNTIMES.has(config.runtime)) {
-      errors.push(`Agent "${config.id}" has invalid runtime "${config.runtime}".`);
+      errors.push(`Agent "${configId}" has invalid runtime "${config.runtime}".`);
     }
 
-    if (!config.systemPrompt || !config.systemPrompt.trim()) {
-      errors.push(`Agent "${config.id}" systemPrompt is required.`);
+    if (typeof config.systemPrompt !== "string" || !config.systemPrompt.trim()) {
+      errors.push(`Agent "${configId}" systemPrompt is required.`);
     }
 
     if (config.permissionProfile) {

--- a/src/core/agent-profiles.ts
+++ b/src/core/agent-profiles.ts
@@ -4,7 +4,7 @@ export type AgentRuntimeOverrides = Partial<Record<AgentId, AgentRuntimeKind>>;
 
 const CONFIGURABLE_RUNTIME_KINDS = new Set<AgentRuntimeKind>(["claude-code", "codex", "codebuddy"]);
 
-function permissionProfile(role: AgentRole): PermissionProfile {
+export function permissionProfile(role: AgentRole): PermissionProfile {
   switch (role) {
     case "pm":
       return {
@@ -122,7 +122,7 @@ export function createDefaultAgentProfiles(cwd: string, runtimeOverrides: AgentR
 export function configsToProfiles(configs: readonly AgentConfig[], cwd: string): AgentProfile[] {
   return configs.map((config) => ({
     id: config.id,
-    name: config.name,
+    name: config.ui?.label || config.name,
     role: config.role,
     runtime: config.runtime,
     cwd,

--- a/src/core/agent-profiles.ts
+++ b/src/core/agent-profiles.ts
@@ -127,6 +127,6 @@ export function configsToProfiles(configs: readonly AgentConfig[], cwd: string):
     runtime: config.runtime,
     cwd,
     systemPrompt: config.systemPrompt,
-    permissionProfile: permissionProfile(config.role),
+    permissionProfile: config.permissionProfile ?? permissionProfile(config.role),
   }));
 }

--- a/src/core/agent-profiles.ts
+++ b/src/core/agent-profiles.ts
@@ -79,6 +79,7 @@ export function createDefaultAgentProfiles(cwd: string, runtimeOverrides: AgentR
     {
       id: "pm",
       name: "Product Manager",
+      description: "Clarifies requirements, defines scope and acceptance criteria.",
       role: "pm",
       runtime: runtimeOverrides.pm ?? "codex",
       cwd,
@@ -89,6 +90,7 @@ export function createDefaultAgentProfiles(cwd: string, runtimeOverrides: AgentR
     {
       id: "architect",
       name: "Architect",
+      description: "Designs technical boundaries, reviews implementation risk.",
       role: "architect",
       runtime: runtimeOverrides.architect ?? "codex",
       cwd,
@@ -99,6 +101,7 @@ export function createDefaultAgentProfiles(cwd: string, runtimeOverrides: AgentR
     {
       id: "developer",
       name: "Developer",
+      description: "Implements features with TDD, creates branches and draft PRs.",
       role: "developer",
       runtime: runtimeOverrides.developer ?? "claude-code",
       cwd,
@@ -109,6 +112,7 @@ export function createDefaultAgentProfiles(cwd: string, runtimeOverrides: AgentR
     {
       id: "tester",
       name: "Tester",
+      description: "Validates behavior, runs tests, reports risks.",
       role: "tester",
       runtime: runtimeOverrides.tester ?? "codebuddy",
       cwd,
@@ -123,6 +127,7 @@ export function configsToProfiles(configs: readonly AgentConfig[], cwd: string):
   return configs.map((config) => ({
     id: config.id,
     name: config.ui?.label || config.name,
+    description: config.description,
     role: config.role,
     runtime: config.runtime,
     cwd,

--- a/src/core/agent-profiles.ts
+++ b/src/core/agent-profiles.ts
@@ -1,4 +1,4 @@
-import type { AgentId, AgentProfile, AgentRole, AgentRuntimeKind, PermissionProfile } from "../shared/types.ts";
+import type { AgentConfig, AgentId, AgentProfile, AgentRole, AgentRuntimeKind, PermissionProfile } from "../shared/types.ts";
 
 export type AgentRuntimeOverrides = Partial<Record<AgentId, AgentRuntimeKind>>;
 
@@ -117,4 +117,16 @@ export function createDefaultAgentProfiles(cwd: string, runtimeOverrides: AgentR
       permissionProfile: permissionProfile("tester"),
     },
   ];
+}
+
+export function configsToProfiles(configs: readonly AgentConfig[], cwd: string): AgentProfile[] {
+  return configs.map((config) => ({
+    id: config.id,
+    name: config.name,
+    role: config.role,
+    runtime: config.runtime,
+    cwd,
+    systemPrompt: config.systemPrompt,
+    permissionProfile: permissionProfile(config.role),
+  }));
 }

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -97,7 +97,14 @@ export class AgentSession {
       lower.includes("session expired") ||
       lower.includes("could not resume") ||
       lower.includes("invalid session") ||
-      lower.includes("no conversation found")
+      lower.includes("no conversation found") ||
+      (
+        lower.includes("failed to deserialize the json body") &&
+        lower.includes("messages[") &&
+        lower.includes(".role") &&
+        lower.includes("unknown variant") &&
+        lower.includes("system")
+      )
     );
   }
 

--- a/src/core/channel-context-builder.ts
+++ b/src/core/channel-context-builder.ts
@@ -21,7 +21,10 @@ function renderHistory(entries: ChannelHistoryEntry[]): string[] {
 
 export function buildChannelContext(input: ChannelContextInput): string {
   const profile = input.profiles.find((agent) => agent.id === input.agentId);
-  const availableAgents = input.profiles.map((agent) => `@${agent.id}: ${agent.name}`).join("\n");
+  const availableAgents = input.profiles.map((agent) => {
+    const desc = agent.description ? ` — ${agent.description}` : "";
+    return `@${agent.id}: ${agent.name}${desc}`;
+  }).join("\n");
   const permissions = profile
     ? [
         `- read files: ${profile.permissionProfile.canReadFiles ? "yes" : "no"}`,

--- a/src/core/run-manager.ts
+++ b/src/core/run-manager.ts
@@ -45,9 +45,14 @@ export class RunManager {
   private readonly lastTerminalActivityAt = new Map<string, number>();
   private readonly chunkBuffers = new Map<string, string>();
   private readonly lastToolNames = new Map<string, string>();
+  private readonly unsubscribe: () => void;
 
   constructor(private readonly options: RunManagerOptions) {
-    this.options.eventBus.subscribe((event) => this.handleRuntimeEvent(event));
+    this.unsubscribe = this.options.eventBus.subscribe((event) => this.handleRuntimeEvent(event));
+  }
+
+  dispose(): void {
+    this.unsubscribe();
   }
 
   enqueue(agentId: AgentId, prompt: string, sourceMessage: ChatMessage): ManagedRun {

--- a/src/core/terminal-transcript-store.ts
+++ b/src/core/terminal-transcript-store.ts
@@ -18,7 +18,7 @@ export class TerminalTranscriptStore {
     const cleaned = stripAnsi(chunk);
     this.transcripts[agentId] ??= "";
     this.transcripts[agentId] += cleaned;
-    this.saveAgent(agentId);
+    this.saveAgentChunk(agentId, cleaned);
     return this.transcripts[agentId];
   }
 
@@ -51,12 +51,14 @@ export class TerminalTranscriptStore {
     }
   }
 
-  private saveAgent(agentId: AgentId): void {
-    if (!this.dirPath) return;
-    fs.mkdirSync(this.dirPath, { recursive: true });
-    const filePath = path.join(this.dirPath, `${agentId}.log`);
-    const tmp = filePath + ".tmp";
-    fs.writeFileSync(tmp, this.transcripts[agentId]);
-    fs.renameSync(tmp, filePath);
+  private saveAgentChunk(agentId: AgentId, chunk: string): void {
+    if (!this.dirPath || chunk.length === 0) return;
+    try {
+      fs.mkdirSync(this.dirPath, { recursive: true });
+      fs.appendFileSync(path.join(this.dirPath, `${agentId}.log`), chunk);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[orbit] failed to persist terminal transcript for ${agentId}: ${message}`);
+    }
   }
 }

--- a/src/core/terminal-transcript-store.ts
+++ b/src/core/terminal-transcript-store.ts
@@ -7,7 +7,8 @@ const RETRY_SAVE_DELAY_MS = 50;
 
 export class TerminalTranscriptStore {
   private transcripts: TerminalState = {};
-  private pendingChunks = new Map<AgentId, string>();
+  private handles = new Map<AgentId, number>();
+  private persistedLengths = new Map<AgentId, number>();
   private retryTimers = new Map<AgentId, ReturnType<typeof setTimeout>>();
   private warnedAgents = new Set<AgentId>();
   private readonly dirPath?: string;
@@ -39,6 +40,16 @@ export class TerminalTranscriptStore {
     return this.list();
   }
 
+  dispose(): void {
+    for (const timer of this.retryTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.retryTimers.clear();
+    for (const agentId of this.handles.keys()) {
+      this.closeHandle(agentId);
+    }
+  }
+
   private load(): void {
     try {
       const entries = fs.readdirSync(this.dirPath!);
@@ -47,8 +58,10 @@ export class TerminalTranscriptStore {
         const agentId = entry.slice(0, -4);
         try {
           this.transcripts[agentId] = fs.readFileSync(path.join(this.dirPath!, entry), "utf8");
+          this.persistedLengths.set(agentId, this.transcripts[agentId].length);
         } catch {
           this.transcripts[agentId] = "";
+          this.persistedLengths.set(agentId, 0);
         }
       }
     } catch {
@@ -58,23 +71,49 @@ export class TerminalTranscriptStore {
 
   private saveAgentChunk(agentId: AgentId, chunk: string): void {
     if (!this.dirPath || chunk.length === 0) return;
-    this.pendingChunks.set(agentId, `${this.pendingChunks.get(agentId) ?? ""}${chunk}`);
     this.flushAgent(agentId);
   }
 
   private flushAgent(agentId: AgentId): void {
     if (!this.dirPath) return;
-    const pending = this.pendingChunks.get(agentId);
-    if (!pending) return;
+    const transcript = this.transcripts[agentId] ?? "";
+    const persistedLength = this.persistedLengths.get(agentId) ?? 0;
+    const pending = transcript.slice(persistedLength);
+    if (!pending) {
+      this.clearRetry(agentId);
+      return;
+    }
     try {
-      fs.mkdirSync(this.dirPath, { recursive: true });
-      fs.appendFileSync(path.join(this.dirPath, `${agentId}.log`), pending);
-      this.pendingChunks.delete(agentId);
+      const handle = this.openHandle(agentId);
+      fs.writeSync(handle, pending);
+      this.persistedLengths.set(agentId, transcript.length);
       this.warnedAgents.delete(agentId);
       this.clearRetry(agentId);
     } catch (error) {
+      this.closeHandle(agentId);
       this.warnOnce(agentId, error);
       this.scheduleRetry(agentId);
+    }
+  }
+
+  private openHandle(agentId: AgentId): number {
+    const existing = this.handles.get(agentId);
+    if (existing !== undefined) return existing;
+    if (!this.dirPath) throw new Error("Transcript directory is not configured.");
+    fs.mkdirSync(this.dirPath, { recursive: true });
+    const handle = fs.openSync(path.join(this.dirPath, `${agentId}.log`), "a");
+    this.handles.set(agentId, handle);
+    return handle;
+  }
+
+  private closeHandle(agentId: AgentId): void {
+    const handle = this.handles.get(agentId);
+    if (handle === undefined) return;
+    this.handles.delete(agentId);
+    try {
+      fs.closeSync(handle);
+    } catch {
+      // best effort cleanup after a write failure
     }
   }
 

--- a/src/core/terminal-transcript-store.ts
+++ b/src/core/terminal-transcript-store.ts
@@ -3,8 +3,13 @@ import path from "node:path";
 import { stripAnsi } from "./ansi-text-extractor.ts";
 import type { AgentId, TerminalState } from "../shared/types.ts";
 
+const RETRY_SAVE_DELAY_MS = 50;
+
 export class TerminalTranscriptStore {
   private transcripts: TerminalState = {};
+  private pendingChunks = new Map<AgentId, string>();
+  private retryTimers = new Map<AgentId, ReturnType<typeof setTimeout>>();
+  private warnedAgents = new Set<AgentId>();
   private readonly dirPath?: string;
 
   constructor(dirPath?: string) {
@@ -53,12 +58,47 @@ export class TerminalTranscriptStore {
 
   private saveAgentChunk(agentId: AgentId, chunk: string): void {
     if (!this.dirPath || chunk.length === 0) return;
+    this.pendingChunks.set(agentId, `${this.pendingChunks.get(agentId) ?? ""}${chunk}`);
+    this.flushAgent(agentId);
+  }
+
+  private flushAgent(agentId: AgentId): void {
+    if (!this.dirPath) return;
+    const pending = this.pendingChunks.get(agentId);
+    if (!pending) return;
     try {
       fs.mkdirSync(this.dirPath, { recursive: true });
-      fs.appendFileSync(path.join(this.dirPath, `${agentId}.log`), chunk);
+      fs.appendFileSync(path.join(this.dirPath, `${agentId}.log`), pending);
+      this.pendingChunks.delete(agentId);
+      this.warnedAgents.delete(agentId);
+      this.clearRetry(agentId);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.warn(`[orbit] failed to persist terminal transcript for ${agentId}: ${message}`);
+      this.warnOnce(agentId, error);
+      this.scheduleRetry(agentId);
     }
+  }
+
+  private scheduleRetry(agentId: AgentId): void {
+    if (this.retryTimers.has(agentId)) return;
+    const timer = setTimeout(() => {
+      this.retryTimers.delete(agentId);
+      this.flushAgent(agentId);
+    }, RETRY_SAVE_DELAY_MS);
+    timer.unref?.();
+    this.retryTimers.set(agentId, timer);
+  }
+
+  private clearRetry(agentId: AgentId): void {
+    const timer = this.retryTimers.get(agentId);
+    if (!timer) return;
+    clearTimeout(timer);
+    this.retryTimers.delete(agentId);
+  }
+
+  private warnOnce(agentId: AgentId, error: unknown): void {
+    if (this.warnedAgents.has(agentId)) return;
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[orbit] failed to persist terminal transcript for ${agentId}: ${message}`);
+    this.warnedAgents.add(agentId);
   }
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -53,7 +53,7 @@ agents.startAll();
 
 let channelRouter: ChannelRouter;
 
-const runManager = new RunManager({
+let runManager = new RunManager({
   agents,
   messages,
   eventBus,
@@ -117,6 +117,10 @@ const server = http.createServer(async (req, res) => {
     }
 
     if (req.method === "POST" && url.pathname === "/api/agents/reset") {
+      if (hasRunningAgent()) {
+        sendJson(res, 409, { ok: false, message: "Cannot reset while an agent is running. Wait for it to finish." });
+        return;
+      }
       allConfigs = configStore.reset(workspace.id);
       refreshEnabledAgents();
       sendJson(res, 200, allConfigs);
@@ -190,6 +194,35 @@ function refreshEnabledAgents(): void {
   agents = new AgentRegistry(profiles, eventBus, sessionStore, CHANNEL_ID, CONVERSATION_ID);
   agentIds = agents.ids();
   agents.startAll();
+
+  runManager = new RunManager({
+    agents,
+    messages,
+    eventBus,
+    buildPrompt(agentId: AgentId, prompt: string) {
+      const history = buildHistoryForAgent(agentId, messages.list());
+      return buildChannelContext({ agentId, profiles, channelMessage: prompt, history });
+    },
+    onRunCompleted(message) {
+      channelRouter.process(message);
+    },
+  });
+
+  channelRouter = new ChannelRouter({
+    availableAgents: agentIds,
+    maxRouteDepth: MAX_ROUTE_DEPTH,
+    createSystemMessage(content: string, parentMessageId?: string) {
+      const msg = messages.add({ kind: "system", content, status: "done", parentMessageId });
+      eventBus.publish({ type: "message.created", message: msg });
+      return msg;
+    },
+    startAgentRun(agentId: AgentId, prompt: string, sourceMessage) {
+      runManager.enqueue(agentId, prompt, sourceMessage);
+    },
+    markMessageRouted(messageId: string, routeState) {
+      messages.markRouteState(messageId, routeState);
+    },
+  });
 }
 
 function hasRunningAgent(): boolean {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -195,6 +195,7 @@ function refreshEnabledAgents(): void {
   agentIds = agents.ids();
   agents.startAll();
 
+  runManager.dispose();
   runManager = new RunManager({
     agents,
     messages,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,7 +1,9 @@
 import http from "node:http";
 import path from "node:path";
 
-import { createDefaultAgentProfiles, parseAgentRuntimeOverrides } from "../core/agent-profiles.ts";
+import { configsToProfiles } from "../core/agent-profiles.ts";
+import { AgentConfigStore, validateAgentConfigs } from "../core/agent-config-store.ts";
+import type { AgentConfig } from "../core/agent-config-store.ts";
 import { AgentRegistry } from "../core/agent-registry.ts";
 import { ChannelRouter } from "../core/channel-router.ts";
 import { buildChannelContext } from "../core/channel-context-builder.ts";
@@ -12,7 +14,7 @@ import { RunManager } from "../core/run-manager.ts";
 import { SessionStore } from "../core/session-store.ts";
 import { TerminalTranscriptStore } from "../core/terminal-transcript-store.ts";
 import { WorkspaceStore } from "../core/workspace-store.ts";
-import type { AgentId } from "../shared/types.ts";
+import type { AgentId, AgentProfile } from "../shared/types.ts";
 import { serveStatic } from "./static-server.ts";
 import { SseHub } from "./sse-hub.ts";
 
@@ -33,12 +35,12 @@ const transcriptsDir = workspaceStore.transcriptsDir(workspace.id, CHANNEL_ID, C
 const messages = new MessageStore(messagesPath);
 const transcripts = new TerminalTranscriptStore(transcriptsDir);
 const sessionStore = new SessionStore(workspaceStore.sessionsDir(workspace.id));
-const profiles = createDefaultAgentProfiles(
-  process.cwd(),
-  parseAgentRuntimeOverrides(process.env.ORBIT_AGENT_RUNTIMES),
-);
-const agents = new AgentRegistry(profiles, eventBus, sessionStore, CHANNEL_ID, CONVERSATION_ID);
-const agentIds = agents.ids();
+const configStore = new AgentConfigStore();
+let allConfigs = configStore.load(workspace.id);
+let enabledConfigs = allConfigs.filter((c) => c.enabled);
+let profiles = configsToProfiles(enabledConfigs, process.cwd());
+let agents = new AgentRegistry(profiles, eventBus, sessionStore, CHANNEL_ID, CONVERSATION_ID);
+let agentIds = agents.ids();
 
 eventBus.subscribe((event) => {
   if (event.type === "terminal.chunk") {
@@ -104,6 +106,23 @@ const server = http.createServer(async (req, res) => {
       return;
     }
 
+    if (req.method === "GET" && url.pathname === "/api/agents") {
+      sendJson(res, 200, allConfigs);
+      return;
+    }
+
+    if (req.method === "PUT" && url.pathname === "/api/agents") {
+      await handlePutAgents(req, res);
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/api/agents/reset") {
+      allConfigs = configStore.reset(workspace.id);
+      refreshEnabledAgents();
+      sendJson(res, 200, allConfigs);
+      return;
+    }
+
     if (req.method === "GET" && serveStatic(url.pathname, res)) {
       return;
     }
@@ -162,6 +181,43 @@ function readJson(req: http.IncomingMessage): Promise<unknown> {
 function sendJson(res: http.ServerResponse, status: number, value: unknown): void {
   res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
   res.end(JSON.stringify(value));
+}
+
+function refreshEnabledAgents(): void {
+  enabledConfigs = allConfigs.filter((c) => c.enabled);
+  profiles = configsToProfiles(enabledConfigs, process.cwd());
+  agents.stopAll();
+  agents = new AgentRegistry(profiles, eventBus, sessionStore, CHANNEL_ID, CONVERSATION_ID);
+  agentIds = agents.ids();
+  agents.startAll();
+}
+
+function hasRunningAgent(): boolean {
+  return agents.states().some((s) => s.status === "running");
+}
+
+async function handlePutAgents(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  if (hasRunningAgent()) {
+    sendJson(res, 409, { ok: false, message: "Cannot save while an agent is running. Wait for it to finish." });
+    return;
+  }
+
+  const input = (await readJson(req)) as AgentConfig[];
+  if (!Array.isArray(input)) {
+    sendJson(res, 400, { ok: false, message: "Request body must be an array of agent configs." });
+    return;
+  }
+
+  const errors = validateAgentConfigs(input);
+  if (errors.length > 0) {
+    sendJson(res, 400, { ok: false, message: errors.join(" ") });
+    return;
+  }
+
+  allConfigs = input;
+  configStore.save(workspace.id, allConfigs);
+  refreshEnabledAgents();
+  sendJson(res, 200, allConfigs);
 }
 
 function shutdown(): void {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -16,9 +16,11 @@ export type AgentRuntimeKind = "claude-code" | "codex" | "codebuddy";
 export type AgentConfig = {
   id: AgentId;
   name: string;
+  description?: string;
   role: AgentRole;
   runtime: AgentRuntimeKind;
   systemPrompt: string;
+  permissionProfile?: PermissionProfile;
   enabled: boolean;
 };
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -13,6 +13,15 @@ export type PermissionProfile = {
 
 export type AgentRuntimeKind = "claude-code" | "codex" | "codebuddy";
 
+export type AgentConfig = {
+  id: AgentId;
+  name: string;
+  role: AgentRole;
+  runtime: AgentRuntimeKind;
+  systemPrompt: string;
+  enabled: boolean;
+};
+
 export type AgentProfile = {
   id: AgentId;
   name: string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -13,6 +13,10 @@ export type PermissionProfile = {
 
 export type AgentRuntimeKind = "claude-code" | "codex" | "codebuddy";
 
+export type AgentConfigUi = {
+  label?: string;
+};
+
 export type AgentConfig = {
   id: AgentId;
   name: string;
@@ -22,6 +26,7 @@ export type AgentConfig = {
   systemPrompt: string;
   permissionProfile?: PermissionProfile;
   enabled: boolean;
+  ui?: AgentConfigUi;
 };
 
 export type AgentProfile = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -32,6 +32,7 @@ export type AgentConfig = {
 export type AgentProfile = {
   id: AgentId;
   name: string;
+  description?: string;
   role: AgentRole;
   runtime: AgentRuntimeKind;
   cwd: string;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -26,7 +26,7 @@ export function App() {
   const [selectedMentionIndex, setSelectedMentionIndex] = useState(0);
   const messagesRef = useRef<HTMLDivElement | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
-  const inputRef = useRef<HTMLInputElement | null>(null);
+  const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const [isNearBottom, setIsNearBottom] = useState(true);
   const [showNewMessageHint, setShowNewMessageHint] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
@@ -303,27 +303,39 @@ export function App() {
                 setIsNearBottom(true);
               }}
             >
-              ↓ 滚动到底部
+              <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M8 12V4m0 0L4 8m4-4l4 4" /></svg>
             </button>
           )}
         </div>
 
         <form className="composer" onSubmit={sendMessage}>
           <div className="composerInputWrap">
-            <input
+            <textarea
               ref={inputRef}
               value={content}
+              rows={1}
               onBlur={() => window.setTimeout(() => setInputFocused(false), 120)}
               onChange={(event) => {
                 setContent(event.target.value);
                 setCursorIndex(event.target.selectionStart ?? event.target.value.length);
+                event.target.style.height = "auto";
+                const maxRows = 6;
+                const lineHeight = 22;
+                event.target.style.height = `${Math.min(event.target.scrollHeight, lineHeight * maxRows)}px`;
               }}
               onClick={updateCursorFromInput}
               onFocus={(event) => {
                 setInputFocused(true);
                 setCursorIndex(event.target.selectionStart ?? event.target.value.length);
               }}
-              onKeyDown={handleComposerKeyDown}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && !event.shiftKey) {
+                  event.preventDefault();
+                  sendMessage(event as unknown as FormEvent<HTMLFormElement>);
+                  return;
+                }
+                handleComposerKeyDown(event as unknown as KeyboardEvent<HTMLInputElement>);
+              }}
               onKeyUp={updateCursorFromInput}
               placeholder={`@${selectedAgent}: Hello!`}
               aria-label="Message to agent"
@@ -339,7 +351,7 @@ export function App() {
             ) : null}
           </div>
           <button type="submit" disabled={!content.trim() || isSending}>
-            {isSending ? "Sending" : "Send"}
+            {isSending ? <span className="sendSpinner" aria-hidden="true" /> : "Send"}
           </button>
         </form>
       </section>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, KeyboardEvent, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { renderMarkdown } from "./markdown-renderer.ts";
-import type { AgentActivityEvent, AgentConfig, AgentId, AgentRole, AgentRuntimeKind, AgentState, AppState, ChatMessage, RuntimeEvent } from "../shared/types.ts";
+import type { AgentActivityEvent, AgentConfig, AgentId, AgentRole, AgentRuntimeKind, AgentState, AppState, ChatMessage, PermissionProfile, RuntimeEvent } from "../shared/types.ts";
 
 const initialState: AppState = {
   workspace: { id: "", name: "orbit", path: "" },
@@ -512,6 +512,43 @@ function ActivityList({ activity, status }: { activity: AgentActivityEvent[]; st
 
 const RUNTIMES: AgentRuntimeKind[] = ["claude-code", "codex", "codebuddy"];
 const ROLES: AgentRole[] = ["pm", "architect", "developer", "tester", "general"];
+const PERM_FLAGS: { key: keyof PermissionProfile; label: string }[] = [
+  { key: "canReadFiles", label: "Read files" },
+  { key: "canWriteFiles", label: "Write files" },
+  { key: "canRunCommands", label: "Run commands" },
+  { key: "canInstallDependencies", label: "Install deps" },
+  { key: "canGitCommit", label: "Git commit" },
+];
+
+function PermissionEditor({ config, onChange }: { config: AgentConfig; onChange: (pp: PermissionProfile) => void }) {
+  const [expanded, setExpanded] = useState(false);
+  const pp: PermissionProfile = config.permissionProfile ?? {
+    canReadFiles: true, canWriteFiles: false, canRunCommands: false,
+    canInstallDependencies: false, canGitCommit: false, allowedDirectories: ["."],
+  };
+
+  return (
+    <div className="permSection">
+      <button type="button" className="permToggle" onClick={() => setExpanded((v) => !v)}>
+        {expanded ? "▼" : "▶"} Permissions
+      </button>
+      {expanded ? (
+        <div className="permFields">
+          {PERM_FLAGS.map(({ key, label }) => (
+            <label key={key}>
+              <input type="checkbox" checked={pp[key] as boolean} onChange={(e) => onChange({ ...pp, [key]: e.target.checked })} /> {label}
+            </label>
+          ))}
+          <input
+            placeholder="Allowed directories (comma-separated)"
+            value={pp.allowedDirectories.join(", ")}
+            onChange={(e) => onChange({ ...pp, allowedDirectories: e.target.value.split(",").map((s) => s.trim()).filter(Boolean) })}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
 
 function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved: () => void }) {
   const [configs, setConfigs] = useState<AgentConfig[]>([]);
@@ -600,6 +637,7 @@ function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved
                 <div className="configFields">
                   <input placeholder="ID" value={config.id} onChange={(e) => updateConfig(i, { id: e.target.value })} />
                   <input placeholder="Name" value={config.name} onChange={(e) => updateConfig(i, { name: e.target.value })} />
+                  <input placeholder="Display label (optional)" value={config.ui?.label ?? ""} onChange={(e) => updateConfig(i, { ui: { ...config.ui, label: e.target.value || undefined } })} />
                   <input placeholder="Description" value={config.description ?? ""} onChange={(e) => updateConfig(i, { description: e.target.value })} />
                   <select value={config.role} onChange={(e) => updateConfig(i, { role: e.target.value as AgentRole })}>
                     {ROLES.map((r) => <option key={r} value={r}>{r}</option>)}
@@ -608,6 +646,7 @@ function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved
                     {RUNTIMES.map((r) => <option key={r} value={r}>{r}</option>)}
                   </select>
                   <textarea placeholder="System prompt" value={config.systemPrompt} onChange={(e) => updateConfig(i, { systemPrompt: e.target.value })} rows={3} />
+                  <PermissionEditor config={config} onChange={(pp) => updateConfig(i, { permissionProfile: pp })} />
                 </div>
               </div>
             ))}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -600,6 +600,7 @@ function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved
                 <div className="configFields">
                   <input placeholder="ID" value={config.id} onChange={(e) => updateConfig(i, { id: e.target.value })} />
                   <input placeholder="Name" value={config.name} onChange={(e) => updateConfig(i, { name: e.target.value })} />
+                  <input placeholder="Description" value={config.description ?? ""} onChange={(e) => updateConfig(i, { description: e.target.value })} />
                   <select value={config.role} onChange={(e) => updateConfig(i, { role: e.target.value as AgentRole })}>
                     {ROLES.map((r) => <option key={r} value={r}>{r}</option>)}
                   </select>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -235,7 +235,7 @@ export function App() {
         </nav>
 
         <div className="sidebarFooter">
-          <button className="settingsBtn" type="button" onClick={() => setShowSettings(true)} title="Agent settings">&#9881;</button>
+          <button className="settingsBtn" type="button" onClick={() => setShowSettings(true)} title="智能体设置">&#9881;</button>
         </div>
       </aside>
 
@@ -543,12 +543,12 @@ function ActivityList({ activity, status }: { activity: AgentActivityEvent[]; st
 
 const RUNTIMES: AgentRuntimeKind[] = ["claude-code", "codex", "codebuddy"];
 const ROLES: AgentRole[] = ["pm", "architect", "developer", "tester", "general"];
-const PERM_FLAGS: { key: keyof PermissionProfile; label: string }[] = [
-  { key: "canReadFiles", label: "Read files" },
-  { key: "canWriteFiles", label: "Write files" },
-  { key: "canRunCommands", label: "Run commands" },
-  { key: "canInstallDependencies", label: "Install deps" },
-  { key: "canGitCommit", label: "Git commit" },
+const PERM_FLAGS: { key: keyof PermissionProfile; label: string; hint: string }[] = [
+  { key: "canReadFiles", label: "读取文件", hint: "允许智能体读取工作区中的文件内容。" },
+  { key: "canWriteFiles", label: "写入文件", hint: "允许智能体创建、修改或删除工作区中的文件。" },
+  { key: "canRunCommands", label: "运行命令", hint: "允许智能体执行终端命令（如构建、测试等）。" },
+  { key: "canInstallDependencies", label: "安装依赖", hint: "允许智能体安装项目依赖包（如 npm install）。" },
+  { key: "canGitCommit", label: "Git 提交", hint: "允许智能体执行 git commit 和 git push 操作。" },
 ];
 
 function PermissionEditor({ config, onChange }: { config: AgentConfig; onChange: (pp: PermissionProfile) => void }) {
@@ -558,20 +558,24 @@ function PermissionEditor({ config, onChange }: { config: AgentConfig; onChange:
   return (
     <div className="permSection">
       <button type="button" className="permToggle" onClick={() => setExpanded((v) => !v)}>
-        {expanded ? "▼" : "▶"} Permissions
+        {expanded ? "▼" : "▶"} 权限设置
       </button>
       {expanded ? (
         <div className="permFields">
-          {PERM_FLAGS.map(({ key, label }) => (
-            <label key={key}>
+          {PERM_FLAGS.map(({ key, label, hint }) => (
+            <label key={key} className="permLabel">
               <input type="checkbox" checked={pp[key] as boolean} onChange={(e) => onChange({ ...pp, [key]: e.target.checked })} /> {label}
+              <span className="fieldHint" title={hint}>?</span>
             </label>
           ))}
-          <input
-            placeholder="Allowed directories (comma-separated)"
-            value={pp.allowedDirectories.join(", ")}
-            onChange={(e) => onChange({ ...pp, allowedDirectories: e.target.value.split(",").map((s) => s.trim()).filter(Boolean) })}
-          />
+          <div className="fieldWithHint">
+            <input
+              placeholder="允许访问的目录（逗号分隔）"
+              value={pp.allowedDirectories.join(", ")}
+              onChange={(e) => onChange({ ...pp, allowedDirectories: e.target.value.split(",").map((s) => s.trim()).filter(Boolean) })}
+            />
+            <span className="fieldHint" title="限制智能体只能访问指定目录。留空表示允许访问整个工作区。多个目录用逗号分隔。">?</span>
+          </div>
         </div>
       ) : null}
     </div>
@@ -589,7 +593,7 @@ function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved
     fetch("/api/agents")
       .then((r) => r.json())
       .then((data) => { setConfigs(data as AgentConfig[]); setLoading(false); })
-      .catch(() => { setError("Failed to load agent configs."); setLoading(false); });
+      .catch(() => { setError("加载智能体配置失败。"); setLoading(false); });
   }, []);
 
   function updateConfig(index: number, patch: Partial<AgentConfig>) {
@@ -622,12 +626,12 @@ function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved
       });
       if (!res.ok) {
         const body = await res.json() as { message?: string };
-        setError(body.message ?? `Save failed (${res.status})`);
+        setError(body.message ?? `保存失败 (${res.status})`);
         return;
       }
       onSaved();
     } catch {
-      setError("Network error saving configs.");
+      setError("网络错误，保存失败。");
     } finally {
       setSaving(false);
     }
@@ -639,14 +643,14 @@ function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved
     try {
       const res = await fetch("/api/agents/reset", { method: "POST" });
       if (!res.ok) {
-        setError("Reset failed.");
+        setError("重置失败。");
         return;
       }
       const data = await res.json() as AgentConfig[];
       setConfigs(data);
       onSaved();
     } catch {
-      setError("Network error resetting configs.");
+      setError("网络错误，重置失败。");
     } finally {
       setSaving(false);
     }
@@ -656,10 +660,10 @@ function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved
     <div className="modalOverlay" onClick={onClose}>
       <div className="modalPanel" onClick={(e) => e.stopPropagation()}>
         <div className="modalHeader">
-          <h2>Agent Settings</h2>
+          <h2>智能体设置</h2>
           <button type="button" onClick={onClose}>&times;</button>
         </div>
-        {loading ? <p className="settingsLoading">Loading...</p> : (
+        {loading ? <p className="settingsLoading">加载中...</p> : (
           <div className="settingsBody">
             {configs.map((config, i) => {
               const isExpanded = expandedIndex === i;
@@ -676,7 +680,7 @@ function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved
                       <span className="configCardPill configCardRuntime">{config.runtime}</span>
                     </div>
                     <div className="configCardActions">
-                      <button type="button" className="removeBtn" onClick={(e) => { e.stopPropagation(); removeConfig(i); }} title="Remove">&times;</button>
+                      <button type="button" className="removeBtn" onClick={(e) => { e.stopPropagation(); removeConfig(i); }} title="删除">&times;</button>
                       <span className={`configChevron ${isExpanded ? "configChevronOpen" : ""}`}>▶</span>
                     </div>
                   </div>
@@ -685,22 +689,22 @@ function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved
                       <div className="configFields">
                         <div className="fieldWithHint">
                           <input placeholder="ID" value={config.id} onChange={(e) => updateConfig(i, { id: e.target.value })} />
-                          <span className="fieldHint" title="Unique identifier for this agent. Used in @mention syntax (e.g. @developer:). Must be lowercase, no spaces.">?</span>
+                          <span className="fieldHint" title="智能体的唯一标识符，用于 @mention 语法（如 @developer:）。只能用小写字母，不能有空格。">?</span>
                         </div>
                         <div className="fieldWithHint">
                           <input placeholder="Name" value={config.name} onChange={(e) => updateConfig(i, { name: e.target.value })} />
-                          <span className="fieldHint" title="Human-readable display name shown in the sidebar and message headers.">?</span>
+                          <span className="fieldHint" title="显示在侧边栏和消息头中的可读名称。">?</span>
                         </div>
                         <div className="fieldWithHint">
                           <input placeholder="Display label (optional)" value={config.ui?.label ?? ""} onChange={(e) => updateConfig(i, { ui: { ...config.ui, label: e.target.value || undefined } })} />
-                          <span className="fieldHint" title="Override label shown in the sidebar. If empty, the Name field is used.">?</span>
+                          <span className="fieldHint" title="侧边栏显示的标签，为空则使用 Name 字段。">?</span>
                         </div>
                         <div className="fieldWithHint">
                           <input placeholder="Description" value={config.description ?? ""} onChange={(e) => updateConfig(i, { description: e.target.value })} />
-                          <span className="fieldHint" title="Short description of this agent's capabilities. Visible to other agents when they discover available collaborators.">?</span>
+                          <span className="fieldHint" title="智能体能力的简短描述。其他智能体发现可协作成员时会看到此内容。">?</span>
                         </div>
                         <div className="pillGroup">
-                          <span className="pillLabel">Role <span className="fieldHint" title="Determines default permissions and behavior. pm = planning, architect = design, developer = coding, tester = testing, general = custom.">?</span></span>
+                          <span className="pillLabel">Role <span className="fieldHint" title="决定默认权限和行为。pm = 规划，architect = 设计，developer = 编码，tester = 测试，general = 自定义。">?</span></span>
                           <div className="pillOptions">
                             {ROLES.map((r) => (
                               <button key={r} type="button" className={`pillBtn ${config.role === r ? "pillActive" : ""}`} onClick={() => updateConfig(i, { role: r })}>{r}</button>
@@ -708,7 +712,7 @@ function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved
                           </div>
                         </div>
                         <div className="pillGroup">
-                          <span className="pillLabel">Runtime <span className="fieldHint" title="Which CLI tool powers this agent. claude-code = Claude CLI, codex = OpenAI Codex, codebuddy = CodeBuddy CLI.">?</span></span>
+                          <span className="pillLabel">Runtime <span className="fieldHint" title="驱动该智能体的命令行工具。claude-code = Claude CLI，codex = OpenAI Codex，codebuddy = CodeBuddy CLI。">?</span></span>
                           <div className="pillOptions">
                             {RUNTIMES.map((r) => (
                               <button key={r} type="button" className={`pillBtn ${config.runtime === r ? "pillActive" : ""}`} onClick={() => updateConfig(i, { runtime: r })}>{r}</button>
@@ -717,7 +721,7 @@ function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved
                         </div>
                         <div className="fieldWithHint fieldFullWidth">
                           <textarea placeholder="System prompt" value={config.systemPrompt} onChange={(e) => updateConfig(i, { systemPrompt: e.target.value })} rows={3} />
-                          <span className="fieldHint fieldHintTop" title="Instructions sent to the agent on every run. Defines personality, expertise, and behavioral constraints.">?</span>
+                          <span className="fieldHint fieldHintTop" title="每次运行时发送给智能体的指令。定义其角色、专业能力和行为约束。">?</span>
                         </div>
                         <PermissionEditor config={config} onChange={(pp) => updateConfig(i, { permissionProfile: pp })} />
                       </div>
@@ -726,13 +730,13 @@ function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved
                 </div>
               );
             })}
-            <button type="button" className="addBtn" onClick={addConfig}>+ Add Agent</button>
+            <button type="button" className="addBtn" onClick={addConfig}>+ 添加智能体</button>
             {error ? <p className="settingsError">{error}</p> : null}
           </div>
         )}
         <div className="modalFooter">
-          <button type="button" onClick={resetDefaults} disabled={saving}>Reset Defaults</button>
-          <button type="button" onClick={save} disabled={saving}>{saving ? "Saving..." : "Save"}</button>
+          <button type="button" onClick={resetDefaults} disabled={saving}>恢复默认</button>
+          <button type="button" onClick={save} disabled={saving}>{saving ? "保存中..." : "保存"}</button>
         </div>
       </div>
     </div>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -251,18 +251,6 @@ export function App() {
             </h1>
             {state.workspace.path ? <p className="workspacePath">{state.workspace.path}</p> : null}
           </div>
-          <div className="quickActions" aria-label="Quick agent selection">
-            {agentIds.map((agentId) => (
-              <button
-                key={agentId}
-                className={`quickPill ${selectedAgent === agentId ? "active" : ""}`}
-                type="button"
-                onClick={() => chooseAgent(agentId)}
-              >
-                @{agentId}
-              </button>
-            ))}
-          </div>
         </header>
 
         <div ref={messagesRef} className="messages" role="log" aria-live="polite" aria-label="Message list" onScroll={handleMessagesScroll}>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -662,7 +662,7 @@ function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved
             {configs.map((config, i) => {
               const isExpanded = expandedIndex === i;
               return (
-                <div key={config.id} className={`configCard ${isExpanded ? "configCardExpanded" : ""} ${!config.enabled ? "configCardDisabled" : ""}`}>
+                <div key={`config-${i}`} className={`configCard ${isExpanded ? "configCardExpanded" : ""} ${!config.enabled ? "configCardDisabled" : ""}`}>
                   <div className="configCardHeader" onClick={() => setExpandedIndex(isExpanded ? null : i)}>
                     <div className="configCardSummary">
                       <label className="toggleSwitch" onClick={(e) => e.stopPropagation()}>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, KeyboardEvent, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { renderMarkdown } from "./markdown-renderer.ts";
-import type { AgentActivityEvent, AgentId, AgentState, AppState, ChatMessage, RuntimeEvent } from "../shared/types.ts";
+import type { AgentActivityEvent, AgentConfig, AgentId, AgentRole, AgentRuntimeKind, AgentState, AppState, ChatMessage, RuntimeEvent } from "../shared/types.ts";
 
 const initialState: AppState = {
   workspace: { id: "", name: "orbit", path: "" },
@@ -28,6 +28,7 @@ export function App() {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [isNearBottom, setIsNearBottom] = useState(true);
   const [showNewMessageHint, setShowNewMessageHint] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
   const isNearBottomRef = useRef(true);
 
   useEffect(() => {
@@ -218,7 +219,10 @@ export function App() {
       <aside className="sidebar" aria-label="Agent status">
         <div className="brandBlock">
           <div className="brandMark">orbit</div>
-          <div className={`connection ${connectionState}`}>{connectionLabel(connectionState)}</div>
+          <div style={{ display: "flex", gap: 6 }}>
+            <div className={`connection ${connectionState}`}>{connectionLabel(connectionState)}</div>
+            <button className="settingsBtn" type="button" onClick={() => setShowSettings(true)} title="Agent settings">&#9881;</button>
+          </div>
         </div>
 
         <nav className="agentList" aria-label="Choose agent">
@@ -316,6 +320,12 @@ export function App() {
           </button>
         </form>
       </section>
+      {showSettings ? (
+        <AgentSettingsPanel
+          onClose={() => setShowSettings(false)}
+          onSaved={() => { setShowSettings(false); window.location.reload(); }}
+        />
+      ) : null}
     </main>
   );
 }
@@ -495,6 +505,119 @@ function ActivityList({ activity, status }: { activity: AgentActivityEvent[]; st
             <time>{formatTime(item.timestamp)}</time>
           </div>
         ))}
+      </div>
+    </div>
+  );
+}
+
+const RUNTIMES: AgentRuntimeKind[] = ["claude-code", "codex", "codebuddy"];
+const ROLES: AgentRole[] = ["pm", "architect", "developer", "tester", "general"];
+
+function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved: () => void }) {
+  const [configs, setConfigs] = useState<AgentConfig[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    fetch("/api/agents")
+      .then((r) => r.json())
+      .then((data) => { setConfigs(data as AgentConfig[]); setLoading(false); })
+      .catch(() => { setError("Failed to load agent configs."); setLoading(false); });
+  }, []);
+
+  function updateConfig(index: number, patch: Partial<AgentConfig>) {
+    setConfigs((prev) => prev.map((c, i) => (i === index ? { ...c, ...patch } : c)));
+  }
+
+  function addConfig() {
+    setConfigs((prev) => [
+      ...prev,
+      { id: `agent-${Date.now()}`, name: "", role: "general", runtime: "claude-code", systemPrompt: "", enabled: true },
+    ]);
+  }
+
+  function removeConfig(index: number) {
+    setConfigs((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  async function save() {
+    setSaving(true);
+    setError("");
+    try {
+      const res = await fetch("/api/agents", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(configs),
+      });
+      if (!res.ok) {
+        const body = await res.json() as { message?: string };
+        setError(body.message ?? `Save failed (${res.status})`);
+        return;
+      }
+      onSaved();
+    } catch {
+      setError("Network error saving configs.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function resetDefaults() {
+    setSaving(true);
+    setError("");
+    try {
+      const res = await fetch("/api/agents/reset", { method: "POST" });
+      if (!res.ok) {
+        setError("Reset failed.");
+        return;
+      }
+      const data = await res.json() as AgentConfig[];
+      setConfigs(data);
+      onSaved();
+    } catch {
+      setError("Network error resetting configs.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="modalOverlay" onClick={onClose}>
+      <div className="modalPanel" onClick={(e) => e.stopPropagation()}>
+        <div className="modalHeader">
+          <h2>Agent Settings</h2>
+          <button type="button" onClick={onClose}>&times;</button>
+        </div>
+        {loading ? <p>Loading...</p> : (
+          <div className="settingsBody">
+            {configs.map((config, i) => (
+              <div key={config.id} className="configRow">
+                <div className="configRowHeader">
+                  <label><input type="checkbox" checked={config.enabled} onChange={() => updateConfig(i, { enabled: !config.enabled })} /> Enabled</label>
+                  <button type="button" className="removeBtn" onClick={() => removeConfig(i)} title="Remove">Remove</button>
+                </div>
+                <div className="configFields">
+                  <input placeholder="ID" value={config.id} onChange={(e) => updateConfig(i, { id: e.target.value })} />
+                  <input placeholder="Name" value={config.name} onChange={(e) => updateConfig(i, { name: e.target.value })} />
+                  <select value={config.role} onChange={(e) => updateConfig(i, { role: e.target.value as AgentRole })}>
+                    {ROLES.map((r) => <option key={r} value={r}>{r}</option>)}
+                  </select>
+                  <select value={config.runtime} onChange={(e) => updateConfig(i, { runtime: e.target.value as AgentRuntimeKind })}>
+                    {RUNTIMES.map((r) => <option key={r} value={r}>{r}</option>)}
+                  </select>
+                  <textarea placeholder="System prompt" value={config.systemPrompt} onChange={(e) => updateConfig(i, { systemPrompt: e.target.value })} rows={3} />
+                </div>
+              </div>
+            ))}
+            <button type="button" className="addBtn" onClick={addConfig}>+ Add Agent</button>
+            {error ? <p className="settingsError">{error}</p> : null}
+          </div>
+        )}
+        <div className="modalFooter">
+          <button type="button" onClick={resetDefaults} disabled={saving}>Reset Defaults</button>
+          <button type="button" onClick={save} disabled={saving}>{saving ? "Saving..." : "Save"}</button>
+        </div>
       </div>
     </div>
   );

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -570,6 +570,7 @@ function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
 
   useEffect(() => {
     fetch("/api/agents")
@@ -583,14 +584,18 @@ function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved
   }
 
   function addConfig() {
+    const newIndex = configs.length;
     setConfigs((prev) => [
       ...prev,
       { id: `agent-${Date.now()}`, name: "", role: "general", runtime: "claude-code", systemPrompt: "", enabled: true },
     ]);
+    setExpandedIndex(newIndex);
   }
 
   function removeConfig(index: number) {
     setConfigs((prev) => prev.filter((_, i) => i !== index));
+    if (expandedIndex === index) setExpandedIndex(null);
+    else if (expandedIndex !== null && expandedIndex > index) setExpandedIndex(expandedIndex - 1);
   }
 
   async function save() {
@@ -641,30 +646,58 @@ function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved
           <h2>Agent Settings</h2>
           <button type="button" onClick={onClose}>&times;</button>
         </div>
-        {loading ? <p>Loading...</p> : (
+        {loading ? <p className="settingsLoading">Loading...</p> : (
           <div className="settingsBody">
-            {configs.map((config, i) => (
-              <div key={config.id} className="configRow">
-                <div className="configRowHeader">
-                  <label><input type="checkbox" checked={config.enabled} onChange={() => updateConfig(i, { enabled: !config.enabled })} /> Enabled</label>
-                  <button type="button" className="removeBtn" onClick={() => removeConfig(i)} title="Remove">Remove</button>
+            {configs.map((config, i) => {
+              const isExpanded = expandedIndex === i;
+              return (
+                <div key={config.id} className={`configCard ${isExpanded ? "configCardExpanded" : ""} ${!config.enabled ? "configCardDisabled" : ""}`}>
+                  <div className="configCardHeader" onClick={() => setExpandedIndex(isExpanded ? null : i)}>
+                    <div className="configCardSummary">
+                      <label className="toggleSwitch" onClick={(e) => e.stopPropagation()}>
+                        <input type="checkbox" checked={config.enabled} onChange={() => updateConfig(i, { enabled: !config.enabled })} />
+                        <span className="toggleTrack" />
+                      </label>
+                      <span className="configCardName">{config.name || config.id}</span>
+                      <span className="configCardPill configCardRole">{config.role}</span>
+                      <span className="configCardPill configCardRuntime">{config.runtime}</span>
+                    </div>
+                    <div className="configCardActions">
+                      <button type="button" className="removeBtn" onClick={(e) => { e.stopPropagation(); removeConfig(i); }} title="Remove">&times;</button>
+                      <span className={`configChevron ${isExpanded ? "configChevronOpen" : ""}`}>▶</span>
+                    </div>
+                  </div>
+                  {isExpanded ? (
+                    <div className="configCardBody">
+                      <div className="configFields">
+                        <input placeholder="ID" value={config.id} onChange={(e) => updateConfig(i, { id: e.target.value })} />
+                        <input placeholder="Name" value={config.name} onChange={(e) => updateConfig(i, { name: e.target.value })} />
+                        <input placeholder="Display label (optional)" value={config.ui?.label ?? ""} onChange={(e) => updateConfig(i, { ui: { ...config.ui, label: e.target.value || undefined } })} />
+                        <input placeholder="Description" value={config.description ?? ""} onChange={(e) => updateConfig(i, { description: e.target.value })} />
+                        <div className="pillGroup">
+                          <span className="pillLabel">Role</span>
+                          <div className="pillOptions">
+                            {ROLES.map((r) => (
+                              <button key={r} type="button" className={`pillBtn ${config.role === r ? "pillActive" : ""}`} onClick={() => updateConfig(i, { role: r })}>{r}</button>
+                            ))}
+                          </div>
+                        </div>
+                        <div className="pillGroup">
+                          <span className="pillLabel">Runtime</span>
+                          <div className="pillOptions">
+                            {RUNTIMES.map((r) => (
+                              <button key={r} type="button" className={`pillBtn ${config.runtime === r ? "pillActive" : ""}`} onClick={() => updateConfig(i, { runtime: r })}>{r}</button>
+                            ))}
+                          </div>
+                        </div>
+                        <textarea placeholder="System prompt" value={config.systemPrompt} onChange={(e) => updateConfig(i, { systemPrompt: e.target.value })} rows={3} />
+                        <PermissionEditor config={config} onChange={(pp) => updateConfig(i, { permissionProfile: pp })} />
+                      </div>
+                    </div>
+                  ) : null}
                 </div>
-                <div className="configFields">
-                  <input placeholder="ID" value={config.id} onChange={(e) => updateConfig(i, { id: e.target.value })} />
-                  <input placeholder="Name" value={config.name} onChange={(e) => updateConfig(i, { name: e.target.value })} />
-                  <input placeholder="Display label (optional)" value={config.ui?.label ?? ""} onChange={(e) => updateConfig(i, { ui: { ...config.ui, label: e.target.value || undefined } })} />
-                  <input placeholder="Description" value={config.description ?? ""} onChange={(e) => updateConfig(i, { description: e.target.value })} />
-                  <select value={config.role} onChange={(e) => updateConfig(i, { role: e.target.value as AgentRole })}>
-                    {ROLES.map((r) => <option key={r} value={r}>{r}</option>)}
-                  </select>
-                  <select value={config.runtime} onChange={(e) => updateConfig(i, { runtime: e.target.value as AgentRuntimeKind })}>
-                    {RUNTIMES.map((r) => <option key={r} value={r}>{r}</option>)}
-                  </select>
-                  <textarea placeholder="System prompt" value={config.systemPrompt} onChange={(e) => updateConfig(i, { systemPrompt: e.target.value })} rows={3} />
-                  <PermissionEditor config={config} onChange={(pp) => updateConfig(i, { permissionProfile: pp })} />
-                </div>
-              </div>
-            ))}
+              );
+            })}
             <button type="button" className="addBtn" onClick={addConfig}>+ Add Agent</button>
             {error ? <p className="settingsError">{error}</p> : null}
           </div>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -683,12 +683,24 @@ function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved
                   {isExpanded ? (
                     <div className="configCardBody">
                       <div className="configFields">
-                        <input placeholder="ID" value={config.id} onChange={(e) => updateConfig(i, { id: e.target.value })} />
-                        <input placeholder="Name" value={config.name} onChange={(e) => updateConfig(i, { name: e.target.value })} />
-                        <input placeholder="Display label (optional)" value={config.ui?.label ?? ""} onChange={(e) => updateConfig(i, { ui: { ...config.ui, label: e.target.value || undefined } })} />
-                        <input placeholder="Description" value={config.description ?? ""} onChange={(e) => updateConfig(i, { description: e.target.value })} />
+                        <div className="fieldWithHint">
+                          <input placeholder="ID" value={config.id} onChange={(e) => updateConfig(i, { id: e.target.value })} />
+                          <span className="fieldHint" title="Unique identifier for this agent. Used in @mention syntax (e.g. @developer:). Must be lowercase, no spaces.">?</span>
+                        </div>
+                        <div className="fieldWithHint">
+                          <input placeholder="Name" value={config.name} onChange={(e) => updateConfig(i, { name: e.target.value })} />
+                          <span className="fieldHint" title="Human-readable display name shown in the sidebar and message headers.">?</span>
+                        </div>
+                        <div className="fieldWithHint">
+                          <input placeholder="Display label (optional)" value={config.ui?.label ?? ""} onChange={(e) => updateConfig(i, { ui: { ...config.ui, label: e.target.value || undefined } })} />
+                          <span className="fieldHint" title="Override label shown in the sidebar. If empty, the Name field is used.">?</span>
+                        </div>
+                        <div className="fieldWithHint">
+                          <input placeholder="Description" value={config.description ?? ""} onChange={(e) => updateConfig(i, { description: e.target.value })} />
+                          <span className="fieldHint" title="Short description of this agent's capabilities. Visible to other agents when they discover available collaborators.">?</span>
+                        </div>
                         <div className="pillGroup">
-                          <span className="pillLabel">Role</span>
+                          <span className="pillLabel">Role <span className="fieldHint" title="Determines default permissions and behavior. pm = planning, architect = design, developer = coding, tester = testing, general = custom.">?</span></span>
                           <div className="pillOptions">
                             {ROLES.map((r) => (
                               <button key={r} type="button" className={`pillBtn ${config.role === r ? "pillActive" : ""}`} onClick={() => updateConfig(i, { role: r })}>{r}</button>
@@ -696,14 +708,17 @@ function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved
                           </div>
                         </div>
                         <div className="pillGroup">
-                          <span className="pillLabel">Runtime</span>
+                          <span className="pillLabel">Runtime <span className="fieldHint" title="Which CLI tool powers this agent. claude-code = Claude CLI, codex = OpenAI Codex, codebuddy = CodeBuddy CLI.">?</span></span>
                           <div className="pillOptions">
                             {RUNTIMES.map((r) => (
                               <button key={r} type="button" className={`pillBtn ${config.runtime === r ? "pillActive" : ""}`} onClick={() => updateConfig(i, { runtime: r })}>{r}</button>
                             ))}
                           </div>
                         </div>
-                        <textarea placeholder="System prompt" value={config.systemPrompt} onChange={(e) => updateConfig(i, { systemPrompt: e.target.value })} rows={3} />
+                        <div className="fieldWithHint fieldFullWidth">
+                          <textarea placeholder="System prompt" value={config.systemPrompt} onChange={(e) => updateConfig(i, { systemPrompt: e.target.value })} rows={3} />
+                          <span className="fieldHint fieldHintTop" title="Instructions sent to the agent on every run. Defines personality, expertise, and behavioral constraints.">?</span>
+                        </div>
                         <PermissionEditor config={config} onChange={(pp) => updateConfig(i, { permissionProfile: pp })} />
                       </div>
                     </div>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -261,7 +261,24 @@ export function App() {
 
         <div ref={messagesRef} className="messages" role="log" aria-live="polite" aria-label="Message list" onScroll={handleMessagesScroll}>
           {state.messages.length === 0 ? (
-            <div className="emptyState">Choose an agent, then type a task.</div>
+            <div className="emptyState">
+              <div className="emptyOrbital" aria-hidden="true">
+                <svg viewBox="0 0 120 120" width="120" height="120">
+                  <circle className="orbitRing orbitRing1" cx="60" cy="60" r="48" fill="none" stroke="var(--border)" strokeWidth="1" />
+                  <circle className="orbitRing orbitRing2" cx="60" cy="60" r="34" fill="none" stroke="var(--border-light)" strokeWidth="1" />
+                  <circle className="orbitCore" cx="60" cy="60" r="8" fill="var(--accent)" opacity="0.2" />
+                  <circle className="orbitDot orbitDot1" cx="60" cy="12" r="4" fill="var(--accent)" />
+                  <circle className="orbitDot orbitDot2" cx="94" cy="60" r="3" fill="var(--secondary)" />
+                  <circle className="orbitDot orbitDot3" cx="60" cy="94" r="3.5" fill="var(--success)" />
+                </svg>
+              </div>
+              <p className="emptyTitle">Ready to launch</p>
+              <ol className="emptySteps">
+                <li><strong>1</strong> Select an agent from the sidebar</li>
+                <li><strong>2</strong> Type your task with <code>@agent:</code></li>
+                <li><strong>3</strong> Watch agents collaborate</li>
+              </ol>
+            </div>
           ) : (
             state.messages.map((message) => (
               <MessageRow

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, KeyboardEvent, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { renderMarkdown } from "./markdown-renderer.ts";
+import { permissionProfile } from "../core/agent-profiles.ts";
 import type { AgentActivityEvent, AgentConfig, AgentId, AgentRole, AgentRuntimeKind, AgentState, AppState, ChatMessage, PermissionProfile, RuntimeEvent } from "../shared/types.ts";
 
 const initialState: AppState = {
@@ -522,10 +523,7 @@ const PERM_FLAGS: { key: keyof PermissionProfile; label: string }[] = [
 
 function PermissionEditor({ config, onChange }: { config: AgentConfig; onChange: (pp: PermissionProfile) => void }) {
   const [expanded, setExpanded] = useState(false);
-  const pp: PermissionProfile = config.permissionProfile ?? {
-    canReadFiles: true, canWriteFiles: false, canRunCommands: false,
-    canInstallDependencies: false, canGitCommit: false, allowedDirectories: ["."],
-  };
+  const pp: PermissionProfile = config.permissionProfile ?? permissionProfile(config.role);
 
   return (
     <div className="permSection">

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -375,8 +375,10 @@ function MentionMenu(props: {
             onMouseDown={(event) => event.preventDefault()}
             onClick={() => props.onSelect(agentId)}
           >
-            <span className={`mentionDot ${status}`} aria-hidden="true" />
-            <span>@{agentId}</span>
+            <span className="mentionName">
+              <span className={`mentionDot ${status}`} aria-hidden="true" />
+              <span>@{agentId}</span>
+            </span>
             <small>{status}</small>
           </button>
         );

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -220,10 +220,7 @@ export function App() {
       <aside className="sidebar" aria-label="Agent status">
         <div className="brandBlock">
           <div className="brandMark">orbit</div>
-          <div style={{ display: "flex", gap: 6 }}>
-            <div className={`connection ${connectionState}`}>{connectionLabel(connectionState)}</div>
-            <button className="settingsBtn" type="button" onClick={() => setShowSettings(true)} title="Agent settings">&#9881;</button>
-          </div>
+          <div className={`connection ${connectionState}`}>{connectionLabel(connectionState)}</div>
         </div>
 
         <nav className="agentList" aria-label="Choose agent">
@@ -236,6 +233,10 @@ export function App() {
             />
           ))}
         </nav>
+
+        <div className="sidebarFooter">
+          <button className="settingsBtn" type="button" onClick={() => setShowSettings(true)} title="Agent settings">&#9881;</button>
+        </div>
       </aside>
 
       <section className="channel" aria-label="Chat channel">

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -242,14 +242,19 @@ export function App() {
         <header className="channelHeader">
           <div>
             <p className="eyebrow">workspace</p>
-            <h1>{state.workspace.name || "Orbit"}</h1>
+            <h1>
+              <svg className="workspaceIcon" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M2 4.5A1.5 1.5 0 0 1 3.5 3h2.672a.5.5 0 0 1 .39.188l1.633 2.041a.5.5 0 0 0 .39.188H12.5A1.5 1.5 0 0 1 14 6.916V11.5a1.5 1.5 0 0 1-1.5 1.5h-9A1.5 1.5 0 0 1 2 11.5V4.5Z" />
+              </svg>
+              {state.workspace.name || "Orbit"}
+            </h1>
             {state.workspace.path ? <p className="workspacePath">{state.workspace.path}</p> : null}
           </div>
           <div className="quickActions" aria-label="Quick agent selection">
             {agentIds.map((agentId) => (
               <button
                 key={agentId}
-                className={selectedAgent === agentId ? "active" : ""}
+                className={`quickPill ${selectedAgent === agentId ? "active" : ""}`}
                 type="button"
                 onClick={() => chooseAgent(agentId)}
               >
@@ -358,6 +363,7 @@ function MentionMenu(props: {
     <div className="mentionMenu" role="listbox" aria-label="Choose agent">
       {props.candidates.map((agentId, index) => {
         const agent = props.agentsById.get(agentId);
+        const status = agent?.status ?? "idle";
         return (
           <button
             key={agentId}
@@ -368,18 +374,22 @@ function MentionMenu(props: {
             onMouseDown={(event) => event.preventDefault()}
             onClick={() => props.onSelect(agentId)}
           >
+            <span className={`mentionDot ${status}`} aria-hidden="true" />
             <span>@{agentId}</span>
-            <small>{agent?.status ?? "idle"}</small>
+            <small>{status}</small>
           </button>
         );
       })}
+      <div className="mentionHint">↑↓ select · Tab/Enter confirm · Esc close</div>
     </div>
   );
 }
 
 function AgentButton(props: { agent: AgentState; selected: boolean; onClick: () => void }) {
+  const isRunning = props.agent.status === "running" || props.agent.status === "starting";
   return (
-    <button className={`agentButton ${props.selected ? "selected" : ""}`} onClick={props.onClick} type="button">
+    <button className={`agentButton ${props.selected ? "selected" : ""} ${isRunning ? "agentRunning" : ""}`} onClick={props.onClick} type="button">
+      {isRunning ? <span className="agentProgressBar" aria-hidden="true" /> : null}
       <span className={`statusDot ${props.agent.status}`} aria-hidden="true" />
       <span className="agentText">
         <strong>
@@ -388,7 +398,7 @@ function AgentButton(props: { agent: AgentState; selected: boolean; onClick: () 
         </strong>
         <small>{props.agent.id}</small>
       </span>
-      <span className="agentStatus">{props.agent.status}</span>
+      <span className={`agentStatusPill ${props.agent.status}`}>{props.agent.status}</span>
     </button>
   );
 }

--- a/src/ui/markdown-renderer.ts
+++ b/src/ui/markdown-renderer.ts
@@ -35,6 +35,11 @@ marked.use({
       if (!safeHref) return escapeHtml(text);
       return `<img src="${escapeHtml(safeHref)}" alt="${escapeHtml(text)}" />`;
     },
+    code({ text, lang }: { text: string; lang?: string }): string {
+      const language = lang || "";
+      const langLabel = language ? `<span class="codeLang">${escapeHtml(language)}</span>` : "";
+      return `<div class="codeBlock"><div class="codeHeader">${langLabel}<button class="codeCopyBtn" type="button" onclick="(function(btn){var c=btn.closest('.codeBlock').querySelector('code');navigator.clipboard.writeText(c.textContent);btn.textContent='✓';btn.classList.add('copied');setTimeout(function(){btn.textContent='Copy';btn.classList.remove('copied');},1500)})(this)">Copy</button></div><pre><code class="language-${escapeHtml(language)}">${escapeHtml(text)}</code></pre></div>`;
+    },
   },
 });
 

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1756,6 +1756,54 @@ button:active:not(:disabled) {
   resize: vertical;
 }
 
+/* ── Field Tooltip Hints ────────────────────────────────────── */
+
+.fieldWithHint {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  position: relative;
+}
+
+.fieldWithHint input,
+.fieldWithHint textarea {
+  flex: 1;
+  min-width: 0;
+}
+
+.fieldFullWidth {
+  grid-column: 1 / -1;
+}
+
+.fieldHint {
+  flex: 0 0 auto;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--bg-muted);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: help;
+  transition: all var(--transition-fast);
+}
+
+.fieldHint:hover {
+  background: var(--accent-subtle);
+  border-color: var(--accent-border);
+  color: var(--accent);
+}
+
+.fieldHintTop {
+  align-self: flex-start;
+  margin-top: 7px;
+}
+
 .permSection {
   grid-column: 1 / -1;
 }

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1318,7 +1318,6 @@ button:active:not(:disabled) {
 .mentionMenu button {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 10px;
   min-height: 38px;
   border: 0;
@@ -1337,7 +1336,16 @@ button:active:not(:disabled) {
   color: var(--accent);
 }
 
+.mentionMenu .mentionName {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+
 .mentionMenu small {
+  flex: 0 0 auto;
   color: var(--text-muted);
   font-size: 11.5px;
   font-weight: 500;

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -487,41 +487,6 @@ button:active:not(:disabled) {
   max-width: 300px;
 }
 
-.quickActions {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 5px;
-  min-width: 0;
-}
-
-.quickPill {
-  min-height: 32px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-full);
-  padding: 0 14px;
-  color: var(--text-secondary);
-  background: var(--bg-surface);
-  font-size: 12.5px;
-  font-weight: 600;
-  box-shadow: var(--shadow-xs);
-  letter-spacing: -0.01em;
-  transition: all var(--transition-fast);
-}
-
-.quickPill:hover {
-  border-color: var(--accent-border);
-  color: var(--accent);
-  background: var(--accent-subtle);
-}
-
-.quickPill.active {
-  border-color: var(--accent);
-  color: var(--text-inverse);
-  background: var(--accent);
-  box-shadow: var(--shadow-sm), 0 0 0 1px rgba(15, 118, 110, 0.2);
-}
-
 /* ── Messages ──────────────────────────────────────────────── */
 
 .messages {
@@ -1992,10 +1957,6 @@ button:active:not(:disabled) {
   .channelHeader {
     align-items: flex-start;
     flex-direction: column;
-  }
-
-  .quickActions {
-    display: none;
   }
 
   .message {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -149,6 +149,7 @@ button:active:not(:disabled) {
   padding: 20px 16px;
   border-right: 1px solid var(--border);
   background:
+    radial-gradient(ellipse at 50% 100%, rgba(15, 118, 110, 0.06) 0%, transparent 50%),
     radial-gradient(ellipse at 20% 0%, rgba(15, 118, 110, 0.04) 0%, transparent 60%),
     linear-gradient(180deg, #f0ede8 0%, #e8e4dd 100%);
 }
@@ -523,35 +524,42 @@ button:active:not(:disabled) {
   overflow-y: auto;
   padding: 24px 28px;
   background: var(--bg-base);
-  /* Subtle warm atmospheric gradients */
+  /* Subtle dot grid pattern + warm atmospheric gradients */
   background-image:
-    radial-gradient(circle at 80% 20%, rgba(15, 118, 110, 0.02) 0%, transparent 50%),
-    radial-gradient(circle at 20% 80%, rgba(194, 65, 12, 0.015) 0%, transparent 50%);
+    radial-gradient(circle, rgba(26, 24, 21, 0.04) 1px, transparent 1px),
+    radial-gradient(circle at 80% 20%, rgba(15, 118, 110, 0.025) 0%, transparent 50%),
+    radial-gradient(circle at 20% 80%, rgba(194, 65, 12, 0.018) 0%, transparent 50%);
+  background-size: 24px 24px, 100% 100%, 100% 100%;
 }
 
 .scrollToBottomHint {
   position: sticky;
   bottom: 8px;
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   margin: 0 auto 8px;
-  padding: 7px 18px;
+  width: 38px;
+  height: 38px;
+  padding: 0;
   background: var(--accent);
   color: var(--text-inverse);
   border: none;
-  border-radius: var(--radius-full);
-  font-size: 13px;
-  font-weight: 600;
+  border-radius: 50%;
   cursor: pointer;
   box-shadow: var(--shadow-md), 0 0 0 1px rgba(15, 118, 110, 0.3);
   z-index: 10;
   transition: all var(--transition-base);
-  letter-spacing: -0.01em;
 }
 
 .scrollToBottomHint:hover {
   opacity: 0.92;
   transform: translateY(-2px);
   box-shadow: var(--shadow-lg);
+}
+
+.scrollToBottomHint svg {
+  display: block;
 }
 
 .emptyState {
@@ -701,8 +709,7 @@ button:active:not(:disabled) {
 .message.user {
   align-self: flex-end;
   border-color: var(--accent-border);
-  border-right: 3px solid var(--accent);
-  border-radius: var(--radius-lg) var(--radius-lg) 4px var(--radius-lg);
+  border-top: 3px solid var(--accent);
   background:
     linear-gradient(135deg, rgba(15, 118, 110, 0.02) 0%, rgba(15, 118, 110, 0.04) 100%),
     var(--bg-surface);
@@ -710,8 +717,7 @@ button:active:not(:disabled) {
 
 .message.agent {
   align-self: flex-start;
-  border-left: 3px solid var(--success);
-  border-radius: var(--radius-lg) var(--radius-lg) var(--radius-lg) 4px;
+  border-top: 3px solid var(--success);
 }
 
 .message.system {
@@ -1091,13 +1097,68 @@ button:active:not(:disabled) {
   background: #1c1917;
   color: #d6d3d1;
   padding: 16px 20px;
-  border-radius: var(--radius-md);
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
   overflow-x: auto;
   font-family: var(--font-mono);
   font-size: 13px;
   line-height: 1.65;
   border: 1px solid #292524;
+  border-top: 0;
   box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.15);
+  margin: 0;
+}
+
+.codeBlock {
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  margin: 0;
+}
+
+.codeBlock pre {
+  margin: 0;
+}
+
+.codeHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 14px;
+  background: #292524;
+  border: 1px solid #3a3633;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+}
+
+.codeLang {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: #a8a29e;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.codeCopyBtn {
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  color: #a8a29e;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  padding: 2px 10px;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  line-height: 1.4;
+}
+
+.codeCopyBtn:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: #e7e5e4;
+}
+
+.codeCopyBtn.copied {
+  color: var(--success);
+  border-color: var(--success);
 }
 
 .markdown pre code {
@@ -1186,27 +1247,30 @@ button:active:not(:disabled) {
   min-width: 0;
 }
 
-.composer input {
+.composer textarea {
   width: 100%;
   min-width: 0;
   min-height: 46px;
+  max-height: calc(22px * 6 + 16px);
   border: 1.5px solid var(--border);
   border-radius: var(--radius-lg);
-  padding: 0 16px;
+  padding: 12px 16px;
   color: var(--text-primary);
   background: var(--bg-input);
   outline: none;
   font-size: 14px;
   font-weight: 500;
+  line-height: 22px;
+  resize: none;
   transition: all var(--transition-base);
 }
 
-.composer input::placeholder {
+.composer textarea::placeholder {
   color: var(--text-muted);
   font-weight: 400;
 }
 
-.composer input:focus {
+.composer textarea:focus {
   border-color: var(--accent);
   background: var(--bg-surface);
   box-shadow:
@@ -1232,6 +1296,20 @@ button:active:not(:disabled) {
   background: var(--accent-hover);
   box-shadow: var(--shadow-md), 0 0 0 1px rgba(15, 118, 110, 0.4);
   transform: translateY(-1px);
+}
+
+.sendSpinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
 }
 
 /* ── Mention Menu ──────────────────────────────────────────── */
@@ -1874,10 +1952,37 @@ button:active:not(:disabled) {
   .sidebar {
     border-right: 0;
     border-bottom: 1px solid var(--border);
+    gap: 12px;
+    padding: 12px 14px;
   }
 
   .agentList {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px;
+  }
+
+  /* Compact horizontal agent strip */
+  .agentButton {
+    min-height: 40px;
+    grid-template-columns: 8px 1fr;
+    grid-template-areas: "dot text";
+    gap: 0 8px;
+    padding: 6px 10px;
+    border-left-width: 3px;
+  }
+
+  .agentStatusPill,
+  .agentProgressBar {
+    display: none;
+  }
+
+  .agentText strong {
+    font-size: 12.5px;
+  }
+
+  .agentText small,
+  .runtimeBadge {
+    display: none;
   }
 }
 
@@ -1888,8 +1993,7 @@ button:active:not(:disabled) {
   }
 
   .quickActions {
-    justify-content: flex-start;
-    width: 100%;
+    display: none;
   }
 
   .message {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1844,6 +1844,16 @@ button:active:not(:disabled) {
   font-weight: 500;
 }
 
+.permLabel .fieldHint {
+  width: 14px;
+  height: 14px;
+  font-size: 9px;
+}
+
+.permFields .fieldWithHint {
+  grid-column: 1 / -1;
+}
+
 .permFields input[type="text"],
 .permFields input:not([type]) {
   grid-column: 1 / -1;

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1,10 +1,87 @@
+/* ═══════════════════════════════════════════════════════════════
+   Orbit — "Warm Observatory" Design System
+   A mission-control aesthetic with warm tones, deep teal accents,
+   and layered depth. Distinctively NOT generic AI purple.
+   ═══════════════════════════════════════════════════════════════ */
+
+@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&display=swap');
+
+/* ── Design Tokens ─────────────────────────────────────────── */
+
 :root {
-  color: #18202a;
-  background: #f4f5f7;
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  /* Surface — warm cream palette */
+  --bg-base: #f5f3ef;
+  --bg-sidebar: #eeebe5;
+  --bg-surface: #ffffff;
+  --bg-elevated: #ffffff;
+  --bg-muted: #f9f7f4;
+  --bg-hover: #f0ede7;
+  --bg-input: #faf9f6;
+
+  /* Text — warm darks */
+  --text-primary: #1a1815;
+  --text-secondary: #6b6560;
+  --text-muted: #a39e97;
+  --text-inverse: #faf9f7;
+
+  /* Accent — deep teal (primary) + burnt sienna (secondary) */
+  --accent: #0f766e;
+  --accent-hover: #0d6660;
+  --accent-subtle: #e6f5f3;
+  --accent-border: #b2e0db;
+  --secondary: #c2410c;
+  --secondary-subtle: #fff4ed;
+
+  /* Status */
+  --success: #15803d;
+  --success-subtle: #ecfdf5;
+  --success-border: #a7f3d0;
+  --warning: #b45309;
+  --warning-subtle: #fffbeb;
+  --warning-border: #fde68a;
+  --error: #dc2626;
+  --error-subtle: #fef2f2;
+  --error-border: #fecaca;
+
+  /* Borders — warm */
+  --border: #e5e1db;
+  --border-light: #edeae4;
+
+  /* Shadows — warm-tinted */
+  --shadow-xs: 0 1px 2px rgba(26, 24, 21, 0.04);
+  --shadow-sm: 0 1px 3px rgba(26, 24, 21, 0.06), 0 1px 2px rgba(26, 24, 21, 0.04);
+  --shadow-md: 0 4px 12px rgba(26, 24, 21, 0.07), 0 2px 4px rgba(26, 24, 21, 0.04);
+  --shadow-lg: 0 8px 24px rgba(26, 24, 21, 0.1), 0 4px 8px rgba(26, 24, 21, 0.06);
+  --shadow-xl: 0 16px 48px rgba(26, 24, 21, 0.14), 0 8px 16px rgba(26, 24, 21, 0.08);
+
+  /* Radii */
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --radius-xl: 20px;
+  --radius-full: 999px;
+
+  /* Transitions */
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --transition-fast: 120ms var(--ease-out);
+  --transition-base: 200ms var(--ease-out);
+  --transition-slow: 320ms var(--ease-out);
+
+  /* Typography */
+  --font-body: "Plus Jakarta Sans", "Segoe UI", system-ui, -apple-system, sans-serif;
+  --font-mono: "SF Mono", "Cascadia Code", "Fira Code", Consolas, "Liberation Mono", monospace;
+
+  color: var(--text-primary);
+  background: var(--bg-base);
+  font-family: var(--font-body);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
+
+/* ── Reset ─────────────────────────────────────────────────── */
 
 * {
   box-sizing: border-box;
@@ -24,38 +101,56 @@ body {
 }
 
 button,
-input {
+input,
+select,
+textarea {
   font: inherit;
 }
 
 button {
   cursor: pointer;
+  transition:
+    background var(--transition-base),
+    border-color var(--transition-base),
+    box-shadow var(--transition-base),
+    transform 120ms var(--ease-out),
+    color var(--transition-fast);
 }
 
 button:disabled {
   cursor: not-allowed;
-  opacity: 0.55;
+  opacity: 0.45;
 }
+
+button:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+/* ── Layout ────────────────────────────────────────────────── */
 
 .shell {
   display: grid;
-  grid-template-columns: 220px minmax(0, 1fr);
+  grid-template-columns: 248px minmax(0, 1fr);
   width: 100vw;
   height: 100vh;
   min-width: 0;
   min-height: 0;
-  background: #ffffff;
+  background: var(--bg-base);
 }
+
+/* ── Sidebar ───────────────────────────────────────────────── */
 
 .sidebar {
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 20px;
   min-width: 0;
   min-height: 0;
-  padding: 18px 14px;
-  border-right: 1px solid #dde1e7;
-  background: #f7f8fa;
+  padding: 20px 16px;
+  border-right: 1px solid var(--border);
+  background:
+    radial-gradient(ellipse at 20% 0%, rgba(15, 118, 110, 0.04) 0%, transparent 60%),
+    linear-gradient(180deg, #f0ede8 0%, #e8e4dd 100%);
 }
 
 .brandBlock {
@@ -67,34 +162,46 @@ button:disabled {
 
 .brandMark {
   font-size: 22px;
-  font-weight: 700;
+  font-weight: 800;
   line-height: 1;
-  color: #151a21;
+  letter-spacing: -0.03em;
+  color: var(--text-primary);
+  position: relative;
+}
+
+.brandMark::first-letter {
+  background: linear-gradient(135deg, var(--accent) 0%, #2dd4bf 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 .connection {
   max-width: 88px;
   overflow: hidden;
-  border: 1px solid #d6dbe2;
-  border-radius: 999px;
-  padding: 3px 8px;
-  color: #5b6675;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  padding: 3px 9px;
+  color: var(--text-muted);
   font-size: 11px;
+  font-weight: 600;
   line-height: 1.3;
   text-overflow: ellipsis;
   white-space: nowrap;
+  background: var(--bg-surface);
+  transition: all var(--transition-fast);
 }
 
 .connection.live {
-  border-color: #b8d7c1;
-  color: #1e6b3a;
-  background: #edf8f0;
+  border-color: var(--success-border);
+  color: var(--success);
+  background: var(--success-subtle);
 }
 
 .connection.offline {
-  border-color: #e4c4c4;
-  color: #a03838;
-  background: #fff1f1;
+  border-color: var(--error-border);
+  color: var(--error);
+  background: var(--error-subtle);
 }
 
 .agentList {
@@ -109,22 +216,39 @@ button:disabled {
   grid-template-areas:
     "dot text"
     ". status";
-  gap: 4px 10px;
+  gap: 3px 12px;
   width: 100%;
   min-height: 64px;
-  border: 1px solid #dce1e7;
-  border-radius: 8px;
-  padding: 10px;
-  color: #202834;
-  background: #ffffff;
+  border: 1px solid var(--border);
+  border-left: 3px solid transparent;
+  border-radius: var(--radius-md);
+  padding: 12px 14px;
+  color: var(--text-secondary);
+  background: var(--bg-surface);
   text-align: left;
+  box-shadow: var(--shadow-xs);
+  transition: all var(--transition-base);
+  position: relative;
 }
 
-.agentButton:hover,
-.agentButton.selected {
-  border-color: #9aa8ba;
-  background: #f0f3f7;
+.agentButton:hover {
+  border-color: var(--accent-border);
+  border-left-color: var(--accent-border);
+  background: var(--accent-subtle);
+  box-shadow: var(--shadow-sm);
+  transform: translateY(-1px);
 }
+
+.agentButton.selected {
+  border-color: var(--accent-border);
+  border-left-color: var(--accent);
+  background: var(--accent-subtle);
+  box-shadow:
+    var(--shadow-sm),
+    inset 0 0 0 1px rgba(15, 118, 110, 0.06);
+}
+
+/* ── Status Dot ────────────────────────────────────────────── */
 
 .statusDot {
   grid-area: dot;
@@ -132,21 +256,31 @@ button:disabled {
   height: 9px;
   margin-top: 5px;
   border-radius: 50%;
-  background: #aab2bd;
+  background: var(--border);
+  transition: all var(--transition-base);
 }
 
 .statusDot.idle {
-  background: #5dbb7f;
+  background: var(--success);
+  box-shadow: 0 0 0 3px rgba(21, 128, 61, 0.12);
 }
 
 .statusDot.running,
 .statusDot.starting {
-  background: #f0b84b;
+  background: var(--warning);
+  box-shadow: 0 0 0 3px rgba(180, 83, 9, 0.12);
+  animation: statusPulse 2s ease-in-out infinite;
 }
 
 .statusDot.error,
 .statusDot.stopped {
-  background: #d45b5b;
+  background: var(--error);
+  box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.12);
+}
+
+@keyframes statusPulse {
+  0%, 100% { box-shadow: 0 0 0 3px rgba(180, 83, 9, 0.12); }
+  50% { box-shadow: 0 0 0 7px rgba(180, 83, 9, 0.04); }
 }
 
 .agentText {
@@ -169,7 +303,10 @@ button:disabled {
   align-items: center;
   gap: 6px;
   min-width: 0;
-  font-size: 14px;
+  font-size: 13.5px;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
 }
 
 .agentText strong .runtimeBadge {
@@ -178,30 +315,38 @@ button:disabled {
 
 .agentText small,
 .agentStatus {
-  color: #687386;
+  color: var(--text-muted);
   font-size: 12px;
+  font-weight: 500;
 }
 
 .agentStatus {
   grid-area: status;
+  text-transform: capitalize;
 }
+
+/* ── Channel ───────────────────────────────────────────────── */
 
 .channel {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
   min-width: 0;
   min-height: 0;
-  background: #ffffff;
+  background: var(--bg-base);
 }
 
 .channelHeader {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 14px;
+  gap: 16px;
   min-width: 0;
-  padding: 18px 22px;
-  border-bottom: 1px solid #dde1e7;
+  padding: 16px 28px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface);
+  box-shadow: var(--shadow-xs);
+  position: relative;
+  z-index: 1;
 }
 
 .channelHeader h1,
@@ -211,28 +356,29 @@ button:disabled {
 
 .channelHeader h1 {
   overflow: hidden;
-  color: #141a22;
-  font-size: 18px;
-  font-weight: 700;
+  color: var(--text-primary);
+  font-size: 19px;
+  font-weight: 800;
   line-height: 1.25;
   text-overflow: ellipsis;
   white-space: nowrap;
+  letter-spacing: -0.02em;
 }
 
 .eyebrow {
-  margin-bottom: 3px;
-  color: #6b7584;
-  font-size: 11px;
+  margin-bottom: 2px;
+  color: var(--accent);
+  font-size: 10.5px;
   font-weight: 700;
-  letter-spacing: 0;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
 .workspacePath {
   margin: 2px 0 0;
-  color: #8b949e;
-  font-size: 11px;
-  font-weight: 400;
+  color: var(--text-muted);
+  font-size: 11.5px;
+  font-weight: 500;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -242,26 +388,37 @@ button:disabled {
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
-  gap: 8px;
+  gap: 6px;
   min-width: 0;
 }
 
-.quickActions button,
-.composer > button {
-  min-height: 36px;
-  border: 1px solid #cfd6df;
-  border-radius: 7px;
-  padding: 0 12px;
-  color: #1e2631;
-  background: #ffffff;
+.quickActions button {
+  min-height: 34px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0 14px;
+  color: var(--text-secondary);
+  background: var(--bg-surface);
+  font-size: 13px;
+  font-weight: 600;
+  box-shadow: var(--shadow-xs);
+  letter-spacing: -0.01em;
 }
 
-.quickActions button:hover,
-.quickActions button.active,
-.composer > button:hover:not(:disabled) {
-  border-color: #9aa8ba;
-  background: #f3f5f8;
+.quickActions button:hover {
+  border-color: var(--accent-border);
+  color: var(--accent);
+  background: var(--accent-subtle);
 }
+
+.quickActions button.active {
+  border-color: var(--accent);
+  color: var(--text-inverse);
+  background: var(--accent);
+  box-shadow: var(--shadow-md), 0 0 0 1px rgba(15, 118, 110, 0.2);
+}
+
+/* ── Messages ──────────────────────────────────────────────── */
 
 .messages {
   display: flex;
@@ -270,8 +427,12 @@ button:disabled {
   min-width: 0;
   min-height: 0;
   overflow-y: auto;
-  padding: 22px;
-  background: #fbfcfd;
+  padding: 24px 28px;
+  background: var(--bg-base);
+  /* Subtle warm atmospheric gradients */
+  background-image:
+    radial-gradient(circle at 80% 20%, rgba(15, 118, 110, 0.02) 0%, transparent 50%),
+    radial-gradient(circle at 20% 80%, rgba(194, 65, 12, 0.015) 0%, transparent 50%);
 }
 
 .scrollToBottomHint {
@@ -279,58 +440,93 @@ button:disabled {
   bottom: 8px;
   display: block;
   margin: 0 auto 8px;
-  padding: 6px 16px;
-  background: #6366f1;
-  color: #fff;
+  padding: 7px 18px;
+  background: var(--accent);
+  color: var(--text-inverse);
   border: none;
-  border-radius: 16px;
+  border-radius: var(--radius-full);
   font-size: 13px;
+  font-weight: 600;
   cursor: pointer;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-md), 0 0 0 1px rgba(15, 118, 110, 0.3);
   z-index: 10;
-  transition: opacity 0.2s;
+  transition: all var(--transition-base);
+  letter-spacing: -0.01em;
 }
 
 .scrollToBottomHint:hover {
-  opacity: 0.9;
+  opacity: 0.92;
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
 }
 
 .emptyState {
   width: fit-content;
   max-width: 100%;
-  border: 1px solid #dfe4ea;
-  border-radius: 8px;
-  padding: 12px 14px;
-  color: #5f6c7c;
-  background: #ffffff;
-  line-height: 1.5;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-lg);
+  padding: 28px 32px;
+  color: var(--text-muted);
+  background: var(--bg-surface);
+  line-height: 1.6;
+  font-size: 14px;
+  text-align: center;
+  box-shadow: var(--shadow-xs);
 }
 
+/* ── Message Cards ─────────────────────────────────────────── */
+
 .message {
-  max-width: min(760px, 88%);
+  max-width: min(740px, 86%);
   min-width: 0;
-  border: 1px solid #dfe4ea;
-  border-radius: 8px;
-  padding: 12px 14px;
-  background: #ffffff;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 16px 18px;
+  background: var(--bg-surface);
+  box-shadow: var(--shadow-sm);
+  animation: messageIn 280ms var(--ease-out) both;
+  transition: box-shadow var(--transition-base);
+}
+
+.message:hover {
+  box-shadow: var(--shadow-md);
 }
 
 .message.user {
   align-self: flex-end;
-  border-color: #cdd9e8;
-  background: #f2f6fb;
+  border-color: var(--accent-border);
+  border-right: 3px solid var(--accent);
+  border-radius: var(--radius-lg) var(--radius-lg) 4px var(--radius-lg);
+  background:
+    linear-gradient(135deg, rgba(15, 118, 110, 0.02) 0%, rgba(15, 118, 110, 0.04) 100%),
+    var(--bg-surface);
 }
 
 .message.agent {
   align-self: flex-start;
+  border-left: 3px solid var(--success);
+  border-radius: var(--radius-lg) var(--radius-lg) var(--radius-lg) 4px;
 }
 
 .message.system {
   align-self: center;
-  max-width: min(720px, 100%);
+  max-width: min(700px, 100%);
   border-style: dashed;
-  color: #555f70;
-  background: #fafafa;
+  border-color: var(--border-light);
+  color: var(--text-secondary);
+  background: var(--bg-muted);
+  animation: messageIn 200ms var(--ease-out) both;
+}
+
+@keyframes messageIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .messageMeta {
@@ -339,19 +535,24 @@ button:disabled {
   align-items: center;
   gap: 8px;
   min-width: 0;
-  margin-bottom: 7px;
-  color: #697587;
+  margin-bottom: 8px;
+  color: var(--text-muted);
   font-size: 12px;
+  font-weight: 500;
 }
 
 .messageMeta strong {
-  color: #222a35;
+  color: var(--text-primary);
+  font-weight: 700;
+  font-size: 12.5px;
 }
 
 .messageMeta span {
-  border-radius: 999px;
-  padding: 2px 7px;
-  background: #eef2f6;
+  border-radius: var(--radius-full);
+  padding: 2px 8px;
+  background: var(--bg-muted);
+  color: var(--text-secondary);
+  font-weight: 500;
 }
 
 .runtimeBadge {
@@ -359,91 +560,104 @@ button:disabled {
   align-items: center;
   max-width: 92px;
   overflow: hidden;
-  border: 1px solid #d7dee8;
-  border-radius: 999px;
-  padding: 1px 7px;
-  color: #4f5b6b;
-  background: #f5f7fa;
-  font-size: 11px;
-  font-weight: 600;
-  line-height: 1.45;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  padding: 1px 8px;
+  color: var(--text-muted);
+  background: var(--bg-muted);
+  font-size: 10.5px;
+  font-weight: 700;
+  line-height: 1.5;
   text-overflow: ellipsis;
   white-space: nowrap;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
 }
 
 .runtimeBadge.codebuddy {
-  border-color: #c9ded5;
-  color: #276247;
-  background: #edf8f2;
+  border-color: var(--success-border);
+  color: var(--success);
+  background: var(--success-subtle);
 }
 
 .runtimeBadge.codex {
-  border-color: #d7d8ef;
-  color: #4c4d8e;
-  background: #f2f3ff;
+  border-color: var(--accent-border);
+  color: var(--accent);
+  background: var(--accent-subtle);
 }
 
 .messageMeta .durationArrow {
   padding: 0;
   background: none;
-  color: #8a95a5;
+  color: var(--border);
 }
 
 .messageMeta .durationElapsed {
   padding: 0;
   background: none;
-  color: #5f6c7c;
+  color: var(--text-muted);
   font-variant-numeric: tabular-nums;
 }
 
 .messageMeta .durationRunning {
   padding: 0;
   background: none;
-  color: #c08530;
+  color: var(--warning);
+  font-weight: 600;
   font-variant-numeric: tabular-nums;
-  animation: pulse-opacity 2s ease-in-out infinite;
+  animation: pulseOpacity 2s ease-in-out infinite;
 }
 
-@keyframes pulse-opacity {
+@keyframes pulseOpacity {
   0%, 100% { opacity: 1; }
-  50% { opacity: 0.65; }
+  50% { opacity: 0.5; }
 }
 
 .sessionInfo {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   margin-bottom: 4px;
-  color: #8a95a5;
+  color: var(--text-muted);
   font-size: 11px;
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-family: var(--font-mono);
+  font-weight: 500;
 }
 
 .sessionInfo span {
-  border: 1px solid #e6eaef;
+  border: 1px solid var(--border-light);
   border-radius: 4px;
   padding: 1px 6px;
-  background: #f6f8fa;
+  background: var(--bg-muted);
+  color: var(--text-muted);
 }
 
 .messageBody {
   overflow-wrap: anywhere;
-  color: #18202a;
+  color: var(--text-secondary);
   font-size: 14px;
-  line-height: 1.55;
+  line-height: 1.65;
 }
+
+/* ── Activity Panel ────────────────────────────────────────── */
 
 .activityPanel {
   display: grid;
   gap: 8px;
-  margin-bottom: 10px;
-  border: 1px solid #d8dee7;
-  border-radius: 7px;
-  padding: 9px;
-  color: #465162;
-  background: #f8fafc;
+  margin-bottom: 12px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  padding: 12px 14px;
+  color: var(--text-secondary);
+  background: var(--bg-muted);
   font-size: 12px;
+  transition: all var(--transition-base);
+}
+
+.activityPanel:hover {
+  border-color: var(--border);
+  box-shadow: var(--shadow-xs);
 }
 
 .activityHeader {
@@ -463,42 +677,48 @@ button:disabled {
 }
 
 .activitySummary strong {
-  color: #242d39;
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 700;
 }
 
 .activitySummary span {
-  border: 1px solid #dbe2eb;
-  border-radius: 999px;
-  padding: 1px 7px;
-  color: #5d6877;
-  background: #ffffff;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  padding: 1px 8px;
+  color: var(--text-secondary);
+  background: var(--bg-surface);
+  font-size: 10.5px;
+  font-weight: 600;
 }
 
 .activitySummary .activityErrorCount {
-  border-color: #efc8c8;
-  color: #a33838;
-  background: #fff5f5;
+  border-color: var(--error-border);
+  color: var(--error);
+  background: var(--error-subtle);
 }
 
 .activityHeader button {
   flex: 0 0 auto;
   min-height: 26px;
-  border: 1px solid #ccd5e0;
-  border-radius: 6px;
-  padding: 0 8px;
-  color: #2c3745;
-  background: #ffffff;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0 10px;
+  color: var(--text-secondary);
+  background: var(--bg-surface);
   font-size: 12px;
+  font-weight: 600;
 }
 
 .activityHeader button:hover {
-  border-color: #9aa8ba;
-  background: #f1f4f8;
+  border-color: var(--accent-border);
+  background: var(--accent-subtle);
+  color: var(--accent);
 }
 
 .activityLatest {
   overflow: hidden;
-  color: #303a48;
+  color: var(--text-primary);
   font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -506,12 +726,13 @@ button:disabled {
 
 .activityTimeline {
   display: grid;
-  gap: 6px;
+  gap: 0;
   min-width: 0;
   max-height: 210px;
   overflow-y: auto;
   padding-right: 4px;
   scrollbar-gutter: stable;
+  position: relative;
 }
 
 .activityPanel.collapsed .activityTimeline {
@@ -521,51 +742,76 @@ button:disabled {
 
 .activityItem {
   display: grid;
-  grid-template-columns: 8px minmax(0, 1fr) auto;
+  grid-template-columns: 20px minmax(0, 1fr) auto;
   align-items: baseline;
-  gap: 8px;
+  gap: 0;
   min-width: 0;
-  color: #596577;
+  color: var(--text-secondary);
+  position: relative;
+  padding: 4px 0;
+}
+
+.activityItem::before {
+  content: "";
+  position: absolute;
+  left: 6px;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--border-light);
+}
+
+.activityItem:last-child::before {
+  bottom: 50%;
 }
 
 .activityDot {
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: #94a3b8;
+  background: var(--border);
+  position: relative;
+  z-index: 1;
+  margin: 5px 6px 0 3px;
+  justify-self: center;
 }
 
 .activityItem.tool-started .activityDot {
-  background: #4d7fd6;
+  background: var(--accent);
+  box-shadow: 0 0 0 2px rgba(15, 118, 110, 0.15);
 }
 
 .activityItem.tool-completed .activityDot {
-  background: #50a46f;
+  background: var(--success);
+  box-shadow: 0 0 0 2px rgba(21, 128, 61, 0.15);
 }
 
-.activityItem.tool-failed .activityDot {
-  background: #d45b5b;
-}
-
+.activityItem.tool-failed .activityDot,
 .activityItem.error .activityDot {
-  background: #c94b4b;
+  background: var(--error);
+  box-shadow: 0 0 0 2px rgba(220, 38, 38, 0.15);
 }
 
 .activityText {
   min-width: 0;
   overflow-wrap: anywhere;
+  padding-left: 8px;
 }
 
 .activityItem time {
-  color: #8a95a5;
+  color: var(--text-muted);
   font-size: 11px;
   white-space: nowrap;
+  padding-left: 8px;
+  font-variant-numeric: tabular-nums;
 }
 
 .activityItem.error .activityText,
 .activityItem.tool-failed .activityText {
-  color: #a33838;
+  color: var(--error);
 }
+
+/* ── Markdown ──────────────────────────────────────────────── */
 
 .plainText {
   white-space: pre-wrap;
@@ -588,17 +834,25 @@ button:disabled {
 .markdown h1 {
   font-size: 20px;
   line-height: 1.35;
+  font-weight: 800;
+  color: var(--text-primary);
+  letter-spacing: -0.02em;
 }
 
 .markdown h2 {
   font-size: 18px;
   line-height: 1.35;
+  font-weight: 800;
+  color: var(--text-primary);
+  letter-spacing: -0.015em;
 }
 
 .markdown h3,
 .markdown h4 {
   font-size: 15px;
   line-height: 1.4;
+  font-weight: 700;
+  color: var(--text-primary);
 }
 
 .markdown ul {
@@ -609,14 +863,34 @@ button:disabled {
   margin-top: 4px;
 }
 
+.markdown a {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent-border);
+  transition: all var(--transition-fast);
+}
+
+.markdown a:hover {
+  color: var(--accent-hover);
+  border-bottom-color: var(--accent);
+}
+
+.markdown strong {
+  color: var(--text-primary);
+  font-weight: 700;
+}
+
 .markdown pre {
-  background: #1e1e2e;
-  color: #cdd6f4;
-  padding: 12px 16px;
-  border-radius: 6px;
+  background: #1c1917;
+  color: #d6d3d1;
+  padding: 16px 20px;
+  border-radius: var(--radius-md);
   overflow-x: auto;
+  font-family: var(--font-mono);
   font-size: 13px;
-  line-height: 1.5;
+  line-height: 1.65;
+  border: 1px solid #292524;
+  box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.15);
 }
 
 .markdown pre code {
@@ -629,18 +903,19 @@ button:disabled {
 
 .markdown hr {
   border: none;
-  border-top: 1px solid #e2e8f0;
-  margin: 12px 0;
+  border-top: 1px solid var(--border);
+  margin: 16px 0;
 }
 
 .markdown code {
-  border: 1px solid #d8dee7;
+  border: 1px solid var(--border);
   border-radius: 5px;
-  padding: 1px 5px;
-  color: #273242;
-  background: #f3f6f9;
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  font-size: 0.92em;
+  padding: 2px 7px;
+  color: var(--secondary);
+  background: var(--secondary-subtle);
+  font-family: var(--font-mono);
+  font-size: 0.88em;
+  font-weight: 600;
 }
 
 .markdownTableWrap {
@@ -657,28 +932,46 @@ button:disabled {
 
 .markdown th,
 .markdown td {
-  border: 1px solid #dfe4ea;
-  padding: 7px 9px;
+  border: 1px solid var(--border);
+  padding: 8px 12px;
   text-align: left;
   vertical-align: top;
 }
 
 .markdown th {
-  background: #f4f6f8;
+  background: var(--bg-muted);
   font-weight: 700;
+  color: var(--text-primary);
 }
+
+.markdown td {
+  color: var(--text-secondary);
+}
+
+.markdown blockquote {
+  margin: 0;
+  border-left: 3px solid var(--accent);
+  padding: 8px 16px;
+  color: var(--text-secondary);
+  background: var(--accent-subtle);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  font-style: italic;
+}
+
+/* ── Composer ──────────────────────────────────────────────── */
 
 .composer {
   position: sticky;
   bottom: 0;
   z-index: 2;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 88px;
+  grid-template-columns: minmax(0, 1fr) 92px;
   gap: 10px;
   min-width: 0;
-  padding: 16px 22px;
-  border-top: 1px solid #dde1e7;
-  background: #ffffff;
+  padding: 16px 28px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-surface);
+  box-shadow: 0 -2px 16px rgba(26, 24, 21, 0.05);
 }
 
 .composerInputWrap {
@@ -689,19 +982,52 @@ button:disabled {
 .composer input {
   width: 100%;
   min-width: 0;
-  min-height: 42px;
-  border: 1px solid #cfd6df;
-  border-radius: 7px;
-  padding: 0 12px;
-  color: #17202b;
-  background: #ffffff;
+  min-height: 46px;
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 0 16px;
+  color: var(--text-primary);
+  background: var(--bg-input);
   outline: none;
+  font-size: 14px;
+  font-weight: 500;
+  transition: all var(--transition-base);
+}
+
+.composer input::placeholder {
+  color: var(--text-muted);
+  font-weight: 400;
 }
 
 .composer input:focus {
-  border-color: #7f8fa4;
-  box-shadow: 0 0 0 3px #dce5f0;
+  border-color: var(--accent);
+  background: var(--bg-surface);
+  box-shadow:
+    0 0 0 3px rgba(15, 118, 110, 0.1),
+    var(--shadow-sm);
 }
+
+.composer > button {
+  min-width: 0;
+  min-height: 46px;
+  color: var(--text-inverse);
+  border: none;
+  border-radius: var(--radius-lg);
+  background: var(--accent);
+  font-weight: 700;
+  font-size: 14px;
+  letter-spacing: -0.01em;
+  box-shadow: var(--shadow-sm), 0 0 0 1px rgba(15, 118, 110, 0.3);
+  transition: all var(--transition-base);
+}
+
+.composer > button:hover:not(:disabled) {
+  background: var(--accent-hover);
+  box-shadow: var(--shadow-md), 0 0 0 1px rgba(15, 118, 110, 0.4);
+  transform: translateY(-1px);
+}
+
+/* ── Mention Menu ──────────────────────────────────────────── */
 
 .mentionMenu {
   position: absolute;
@@ -709,13 +1035,25 @@ button:disabled {
   bottom: calc(100% + 8px);
   z-index: 5;
   display: grid;
-  gap: 4px;
-  width: min(240px, 100%);
-  border: 1px solid #d6dce4;
-  border-radius: 8px;
+  gap: 2px;
+  width: min(260px, 100%);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
   padding: 6px;
-  background: #ffffff;
-  box-shadow: 0 10px 24px rgb(20 26 34 / 12%);
+  background: var(--bg-surface);
+  box-shadow: var(--shadow-xl);
+  animation: menuIn 180ms var(--ease-out);
+}
+
+@keyframes menuIn {
+  from {
+    opacity: 0;
+    transform: translateY(4px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 
 .mentionMenu button {
@@ -723,53 +1061,50 @@ button:disabled {
   align-items: center;
   justify-content: space-between;
   gap: 10px;
-  min-height: 34px;
+  min-height: 38px;
   border: 0;
-  border-radius: 6px;
-  padding: 0 9px;
-  color: #1e2631;
+  border-radius: var(--radius-sm);
+  padding: 0 12px;
+  color: var(--text-primary);
   background: transparent;
   text-align: left;
+  font-size: 13px;
+  font-weight: 600;
 }
 
 .mentionMenu button:hover,
 .mentionMenu button.selected {
-  background: #f0f3f7;
+  background: var(--accent-subtle);
+  color: var(--accent);
 }
 
 .mentionMenu small {
-  color: #687386;
-  font-size: 12px;
+  color: var(--text-muted);
+  font-size: 11.5px;
+  font-weight: 500;
 }
 
-.composer > button {
-  min-width: 0;
-  color: #ffffff;
-  border-color: #202936;
-  background: #202936;
-}
-
-.composer button:hover:not(:disabled) {
-  color: #ffffff;
-  border-color: #111820;
-  background: #111820;
-}
+/* ── Settings Button ───────────────────────────────────────── */
 
 .settingsBtn {
-  border: 1px solid #d6dbe2;
-  border-radius: 999px;
-  padding: 1px 7px;
-  color: #5b6675;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  padding: 2px 8px;
+  color: var(--text-muted);
   font-size: 14px;
   line-height: 1.3;
-  background: #f7f8fa;
+  background: var(--bg-surface);
   cursor: pointer;
+  transition: all var(--transition-fast);
 }
 
 .settingsBtn:hover {
-  border-color: #9aa8ba;
-  background: #edf0f4;
+  border-color: var(--accent-border);
+  color: var(--accent);
+  background: var(--accent-subtle);
 }
+
+/* ── Modal / Settings ──────────────────────────────────────── */
 
 .modalOverlay {
   position: fixed;
@@ -777,58 +1112,103 @@ button:disabled {
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(26, 24, 21, 0.35);
+  backdrop-filter: blur(6px) saturate(1.2);
   z-index: 100;
   display: flex;
   align-items: center;
   justify-content: center;
+  animation: overlayIn 200ms var(--ease-out);
+}
+
+@keyframes overlayIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 .modalPanel {
-  background: #fff;
-  border-radius: 10px;
-  width: min(640px, 90vw);
-  max-height: 80vh;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  width: min(680px, 90vw);
+  max-height: 82vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 8px 32px rgba(0,0,0,0.18);
+  box-shadow: var(--shadow-xl);
+  animation: modalIn 280ms var(--ease-spring);
+}
+
+@keyframes modalIn {
+  from {
+    opacity: 0;
+    transform: scale(0.96) translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
 }
 
 .modalHeader {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 18px;
-  border-bottom: 1px solid #dde1e7;
+  padding: 18px 22px;
+  border-bottom: 1px solid var(--border-light);
 }
 
 .modalHeader h2 {
   margin: 0;
-  font-size: 16px;
+  font-size: 17px;
+  font-weight: 800;
+  color: var(--text-primary);
+  letter-spacing: -0.02em;
 }
 
 .modalHeader button {
   background: none;
   border: 0;
-  font-size: 20px;
+  font-size: 22px;
   cursor: pointer;
-  color: #5f6c7c;
+  color: var(--text-muted);
+  width: 34px;
+  height: 34px;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--transition-fast);
+}
+
+.modalHeader button:hover {
+  background: var(--bg-muted);
+  color: var(--text-primary);
 }
 
 .settingsBody {
   flex: 1;
   overflow-y: auto;
-  padding: 14px 18px;
+  padding: 18px 22px;
   display: grid;
   gap: 14px;
 }
 
+.settingsBody > p {
+  color: var(--text-muted);
+}
+
 .configRow {
-  border: 1px solid #dde1e7;
-  border-radius: 6px;
-  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 14px;
   display: grid;
-  gap: 8px;
+  gap: 10px;
+  background: var(--bg-muted);
+  transition: all var(--transition-fast);
+}
+
+.configRow:hover {
+  border-color: var(--accent-border);
 }
 
 .configRowHeader {
@@ -842,40 +1222,57 @@ button:disabled {
   align-items: center;
   gap: 6px;
   font-size: 13px;
-  color: #242d39;
+  font-weight: 700;
+  color: var(--text-primary);
   cursor: pointer;
 }
 
 .removeBtn {
   font-size: 11px;
-  color: #a33838;
+  font-weight: 600;
+  color: var(--error);
   background: none;
   border: 0;
   cursor: pointer;
-  padding: 2px 6px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  transition: all var(--transition-fast);
+}
+
+.removeBtn:hover {
+  background: var(--error-subtle);
 }
 
 .configFields {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 6px;
+  gap: 8px;
 }
 
 .configFields input,
 .configFields select,
 .configFields textarea {
   font: inherit;
-  font-size: 12px;
-  border: 1px solid #d0d6de;
-  border-radius: 4px;
-  padding: 5px 8px;
+  font-size: 13px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 7px 10px;
   outline: none;
+  color: var(--text-primary);
+  background: var(--bg-surface);
+  transition: all var(--transition-fast);
+}
+
+.configFields input::placeholder,
+.configFields textarea::placeholder {
+  color: var(--text-muted);
 }
 
 .configFields input:focus,
 .configFields select:focus,
 .configFields textarea:focus {
-  border-color: #7f8fa4;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(15, 118, 110, 0.08);
 }
 
 .configFields textarea {
@@ -890,85 +1287,155 @@ button:disabled {
 .permToggle {
   background: none;
   border: 0;
-  font-size: 11px;
-  color: #5d6877;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
   cursor: pointer;
   padding: 0;
+  transition: color var(--transition-fast);
+}
+
+.permToggle:hover {
+  color: var(--accent);
 }
 
 .permFields {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 4px 12px;
-  margin-top: 6px;
-  padding: 6px 8px;
-  border: 1px solid #e8ecf0;
-  border-radius: 4px;
-  background: #fafbfc;
+  margin-top: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
 }
 
 .permFields label {
   display: flex;
   align-items: center;
-  gap: 4px;
-  font-size: 11px;
-  color: #3d4756;
+  gap: 5px;
+  font-size: 12px;
+  color: var(--text-secondary);
   cursor: pointer;
+  font-weight: 500;
 }
 
 .permFields input[type="text"],
 .permFields input:not([type]) {
   grid-column: 1 / -1;
   font: inherit;
-  font-size: 11px;
-  border: 1px solid #d0d6de;
-  border-radius: 4px;
-  padding: 4px 7px;
+  font-size: 12px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 5px 8px;
   outline: none;
+  color: var(--text-primary);
+  background: var(--bg-surface);
+}
+
+.permFields input[type="text"]::placeholder,
+.permFields input:not([type])::placeholder {
+  color: var(--text-muted);
 }
 
 .addBtn {
   justify-self: start;
   font: inherit;
-  font-size: 12px;
-  border: 1px dashed #b0b8c4;
-  border-radius: 6px;
-  padding: 8px 14px;
-  background: #f8fafc;
+  font-size: 13px;
+  font-weight: 600;
+  border: 1.5px dashed var(--border);
+  border-radius: var(--radius-md);
+  padding: 10px 18px;
+  background: var(--bg-surface);
   cursor: pointer;
-  color: #465162;
+  color: var(--text-muted);
+  transition: all var(--transition-base);
+}
+
+.addBtn:hover {
+  border-color: var(--accent);
+  border-style: solid;
+  color: var(--accent);
+  background: var(--accent-subtle);
 }
 
 .settingsError {
-  color: #a33838;
-  font-size: 12px;
+  color: var(--error);
+  font-size: 13px;
   margin: 0;
+  font-weight: 600;
 }
 
 .modalFooter {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
-  padding: 12px 18px;
-  border-top: 1px solid #dde1e7;
+  padding: 14px 22px;
+  border-top: 1px solid var(--border-light);
 }
 
 .modalFooter button {
   font: inherit;
-  font-size: 12px;
-  border: 1px solid #cfd6df;
-  border-radius: 6px;
-  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 18px;
   cursor: pointer;
-  background: #fff;
-  color: #1e2631;
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  transition: all var(--transition-fast);
+}
+
+.modalFooter button:hover {
+  border-color: var(--accent-border);
+  background: var(--accent-subtle);
+  color: var(--accent);
 }
 
 .modalFooter button:last-child {
-  background: #202936;
-  color: #fff;
-  border-color: #202936;
+  background: var(--accent);
+  color: var(--text-inverse);
+  border-color: var(--accent);
+  box-shadow: var(--shadow-sm), 0 0 0 1px rgba(15, 118, 110, 0.2);
 }
+
+.modalFooter button:last-child:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+}
+
+/* ── Scrollbar ─────────────────────────────────────────────── */
+
+.messages::-webkit-scrollbar,
+.activityTimeline::-webkit-scrollbar,
+.settingsBody::-webkit-scrollbar {
+  width: 5px;
+}
+
+.messages::-webkit-scrollbar-track,
+.activityTimeline::-webkit-scrollbar-track,
+.settingsBody::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.messages::-webkit-scrollbar-thumb,
+.activityTimeline::-webkit-scrollbar-thumb,
+.settingsBody::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+  transition: background var(--transition-fast);
+}
+
+.messages::-webkit-scrollbar-thumb:hover,
+.activityTimeline::-webkit-scrollbar-thumb:hover,
+.settingsBody::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
+}
+
+/* ── Responsive ────────────────────────────────────────────── */
 
 @media (max-width: 860px) {
   body {
@@ -983,7 +1450,7 @@ button:disabled {
 
   .sidebar {
     border-right: 0;
-    border-bottom: 1px solid #dde1e7;
+    border-bottom: 1px solid var(--border);
   }
 
   .agentList {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1528,7 +1528,6 @@ button:active:not(:disabled) {
   border-radius: var(--radius-md);
   background: var(--bg-muted);
   transition: all var(--transition-base);
-  overflow: hidden;
 }
 
 .configCard:hover {
@@ -1616,14 +1615,8 @@ button:active:not(:disabled) {
 }
 
 .configCardBody {
-  padding: 0 14px 14px;
+  padding: 14px;
   border-top: 1px solid var(--border-light);
-  animation: cardExpand 200ms var(--ease-out);
-}
-
-@keyframes cardExpand {
-  from { opacity: 0; max-height: 0; }
-  to { opacity: 1; max-height: 800px; }
 }
 
 .removeBtn {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -273,6 +273,15 @@ button:active:not(:disabled) {
   to { background-position: 0 0; }
 }
 
+.sidebarFooter {
+  margin-top: auto;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-light);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 /* ── Status Dot ────────────────────────────────────────────── */
 
 .statusDot {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -883,6 +883,50 @@ button:disabled {
   resize: vertical;
 }
 
+.permSection {
+  grid-column: 1 / -1;
+}
+
+.permToggle {
+  background: none;
+  border: 0;
+  font-size: 11px;
+  color: #5d6877;
+  cursor: pointer;
+  padding: 0;
+}
+
+.permFields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px 12px;
+  margin-top: 6px;
+  padding: 6px 8px;
+  border: 1px solid #e8ecf0;
+  border-radius: 4px;
+  background: #fafbfc;
+}
+
+.permFields label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  color: #3d4756;
+  cursor: pointer;
+}
+
+.permFields input[type="text"],
+.permFields input:not([type]) {
+  grid-column: 1 / -1;
+  font: inherit;
+  font-size: 11px;
+  border: 1px solid #d0d6de;
+  border-radius: 4px;
+  padding: 4px 7px;
+  outline: none;
+}
+
 .addBtn {
   justify-self: start;
   font: inherit;

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -755,6 +755,177 @@ button:disabled {
   background: #111820;
 }
 
+.settingsBtn {
+  border: 1px solid #d6dbe2;
+  border-radius: 999px;
+  padding: 1px 7px;
+  color: #5b6675;
+  font-size: 14px;
+  line-height: 1.3;
+  background: #f7f8fa;
+  cursor: pointer;
+}
+
+.settingsBtn:hover {
+  border-color: #9aa8ba;
+  background: #edf0f4;
+}
+
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modalPanel {
+  background: #fff;
+  border-radius: 10px;
+  width: min(640px, 90vw);
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.18);
+}
+
+.modalHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid #dde1e7;
+}
+
+.modalHeader h2 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.modalHeader button {
+  background: none;
+  border: 0;
+  font-size: 20px;
+  cursor: pointer;
+  color: #5f6c7c;
+}
+
+.settingsBody {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px 18px;
+  display: grid;
+  gap: 14px;
+}
+
+.configRow {
+  border: 1px solid #dde1e7;
+  border-radius: 6px;
+  padding: 10px;
+  display: grid;
+  gap: 8px;
+}
+
+.configRowHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.configRowHeader label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #242d39;
+  cursor: pointer;
+}
+
+.removeBtn {
+  font-size: 11px;
+  color: #a33838;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  padding: 2px 6px;
+}
+
+.configFields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+
+.configFields input,
+.configFields select,
+.configFields textarea {
+  font: inherit;
+  font-size: 12px;
+  border: 1px solid #d0d6de;
+  border-radius: 4px;
+  padding: 5px 8px;
+  outline: none;
+}
+
+.configFields input:focus,
+.configFields select:focus,
+.configFields textarea:focus {
+  border-color: #7f8fa4;
+}
+
+.configFields textarea {
+  grid-column: 1 / -1;
+  resize: vertical;
+}
+
+.addBtn {
+  justify-self: start;
+  font: inherit;
+  font-size: 12px;
+  border: 1px dashed #b0b8c4;
+  border-radius: 6px;
+  padding: 8px 14px;
+  background: #f8fafc;
+  cursor: pointer;
+  color: #465162;
+}
+
+.settingsError {
+  color: #a33838;
+  font-size: 12px;
+  margin: 0;
+}
+
+.modalFooter {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 18px;
+  border-top: 1px solid #dde1e7;
+}
+
+.modalFooter button {
+  font: inherit;
+  font-size: 12px;
+  border: 1px solid #cfd6df;
+  border-radius: 6px;
+  padding: 6px 14px;
+  cursor: pointer;
+  background: #fff;
+  color: #1e2631;
+}
+
+.modalFooter button:last-child {
+  background: #202936;
+  color: #fff;
+  border-color: #202936;
+}
+
 @media (max-width: 860px) {
   body {
     overflow: auto;

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -234,18 +234,42 @@ button:active:not(:disabled) {
 .agentButton:hover {
   border-color: var(--accent-border);
   border-left-color: var(--accent-border);
+  border-left-width: 4px;
   background: var(--accent-subtle);
   box-shadow: var(--shadow-sm);
-  transform: translateY(-1px);
+  transform: translateY(-1px) scale(1.01);
 }
 
 .agentButton.selected {
   border-color: var(--accent-border);
   border-left-color: var(--accent);
+  border-left-width: 4px;
   background: var(--accent-subtle);
   box-shadow:
     var(--shadow-sm),
     inset 0 0 0 1px rgba(15, 118, 110, 0.06);
+}
+
+/* Running progress bar */
+.agentRunning {
+  overflow: hidden;
+}
+
+.agentProgressBar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent), var(--success), var(--accent));
+  background-size: 200% 100%;
+  animation: progressFlow 2s linear infinite;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+}
+
+@keyframes progressFlow {
+  from { background-position: 200% 0; }
+  to { background-position: 0 0; }
 }
 
 /* ── Status Dot ────────────────────────────────────────────── */
@@ -320,9 +344,64 @@ button:active:not(:disabled) {
   font-weight: 500;
 }
 
-.agentStatus {
+.agentStatusPill {
   grid-area: status;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  width: fit-content;
+  border-radius: var(--radius-full);
+  padding: 2px 8px;
+  font-size: 10.5px;
+  font-weight: 600;
   text-transform: capitalize;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  background: var(--bg-muted);
+}
+
+.agentStatusPill::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  flex: 0 0 auto;
+}
+
+.agentStatusPill.idle {
+  border-color: var(--success-border);
+  color: var(--success);
+  background: var(--success-subtle);
+}
+
+.agentStatusPill.idle::before {
+  background: var(--success);
+}
+
+.agentStatusPill.running,
+.agentStatusPill.starting {
+  border-color: var(--warning-border);
+  color: var(--warning);
+  background: var(--warning-subtle);
+}
+
+.agentStatusPill.running::before,
+.agentStatusPill.starting::before {
+  background: var(--warning);
+  animation: statusPulse 2s ease-in-out infinite;
+}
+
+.agentStatusPill.error,
+.agentStatusPill.stopped {
+  border-color: var(--error-border);
+  color: var(--error);
+  background: var(--error-subtle);
+}
+
+.agentStatusPill.error::before,
+.agentStatusPill.stopped::before {
+  background: var(--error);
 }
 
 /* ── Channel ───────────────────────────────────────────────── */
@@ -363,6 +442,14 @@ button:active:not(:disabled) {
   text-overflow: ellipsis;
   white-space: nowrap;
   letter-spacing: -0.02em;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.workspaceIcon {
+  flex: 0 0 auto;
+  color: var(--text-muted);
 }
 
 .eyebrow {
@@ -379,43 +466,50 @@ button:active:not(:disabled) {
   color: var(--text-muted);
   font-size: 11.5px;
   font-weight: 500;
+  font-family: var(--font-mono);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  background: var(--bg-muted);
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 3px;
+  max-width: 300px;
 }
 
 .quickActions {
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
-  gap: 6px;
+  gap: 5px;
   min-width: 0;
 }
 
-.quickActions button {
-  min-height: 34px;
+.quickPill {
+  min-height: 32px;
   border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-full);
   padding: 0 14px;
   color: var(--text-secondary);
   background: var(--bg-surface);
-  font-size: 13px;
+  font-size: 12.5px;
   font-weight: 600;
   box-shadow: var(--shadow-xs);
   letter-spacing: -0.01em;
+  transition: all var(--transition-fast);
 }
 
-.quickActions button:hover {
+.quickPill:hover {
   border-color: var(--accent-border);
   color: var(--accent);
   background: var(--accent-subtle);
 }
 
-.quickActions button.active {
+.quickPill.active {
   border-color: var(--accent);
   color: var(--text-inverse);
   background: var(--accent);
-  box-shadow: var(--shadow-md), 0 0 0 1px rgba(15, 118, 110, 0.2);
+  box-shadow: var(--shadow-sm), 0 0 0 1px rgba(15, 118, 110, 0.2);
 }
 
 /* ── Messages ──────────────────────────────────────────────── */
@@ -1195,6 +1289,39 @@ button:active:not(:disabled) {
   color: var(--text-muted);
   font-size: 11.5px;
   font-weight: 500;
+}
+
+.mentionDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--border);
+  flex: 0 0 auto;
+}
+
+.mentionDot.idle {
+  background: var(--success);
+}
+
+.mentionDot.running,
+.mentionDot.starting {
+  background: var(--warning);
+}
+
+.mentionDot.error,
+.mentionDot.stopped {
+  background: var(--error);
+}
+
+.mentionHint {
+  padding: 5px 10px 2px;
+  color: var(--text-muted);
+  font-size: 10.5px;
+  font-weight: 500;
+  text-align: center;
+  border-top: 1px solid var(--border-light);
+  margin-top: 2px;
+  letter-spacing: 0.02em;
 }
 
 /* ── Settings Button ───────────────────────────────────────── */

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -461,17 +461,129 @@ button:active:not(:disabled) {
 }
 
 .emptyState {
-  width: fit-content;
-  max-width: 100%;
+  align-self: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+  max-width: 320px;
+  padding: 36px 32px 32px;
   border: 1px dashed var(--border);
-  border-radius: var(--radius-lg);
-  padding: 28px 32px;
-  color: var(--text-muted);
+  border-radius: var(--radius-xl);
   background: var(--bg-surface);
-  line-height: 1.6;
-  font-size: 14px;
+  box-shadow: var(--shadow-sm);
   text-align: center;
-  box-shadow: var(--shadow-xs);
+  animation: fadeIn 400ms var(--ease-out);
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: scale(0.97); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+.emptyOrbital {
+  margin-bottom: 4px;
+}
+
+.orbitCore {
+  animation: orbitPulse 3s ease-in-out infinite;
+}
+
+@keyframes orbitPulse {
+  0%, 100% { r: 8; opacity: 0.15; }
+  50% { r: 10; opacity: 0.25; }
+}
+
+.orbitDot1 {
+  animation: orbitSpin1 8s linear infinite;
+  transform-origin: 60px 60px;
+}
+
+.orbitDot2 {
+  animation: orbitSpin2 12s linear infinite reverse;
+  transform-origin: 60px 60px;
+}
+
+.orbitDot3 {
+  animation: orbitSpin3 10s linear infinite;
+  transform-origin: 60px 60px;
+}
+
+@keyframes orbitSpin1 {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes orbitSpin2 {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes orbitSpin3 {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.emptyTitle {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 800;
+  color: var(--text-primary);
+  letter-spacing: -0.02em;
+}
+
+.emptySteps {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 8px;
+  width: 100%;
+  text-align: left;
+  color: var(--text-secondary);
+  font-size: 13.5px;
+  line-height: 1.5;
+  font-weight: 500;
+}
+
+.emptySteps li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-muted);
+  border: 1px solid var(--border-light);
+  transition: all var(--transition-fast);
+}
+
+.emptySteps li:hover {
+  background: var(--accent-subtle);
+  border-color: var(--accent-border);
+}
+
+.emptySteps strong {
+  flex: 0 0 auto;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: var(--text-inverse);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.emptySteps code {
+  font-family: var(--font-mono);
+  font-size: 0.88em;
+  color: var(--secondary);
+  background: var(--secondary-subtle);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-weight: 600;
 }
 
 /* ── Message Cards ─────────────────────────────────────────── */

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -866,11 +866,12 @@ button:active:not(:disabled) {
 .activityItem::before {
   content: "";
   position: absolute;
-  left: 6px;
+  left: 5.5px;
   top: 0;
   bottom: 0;
-  width: 1px;
-  background: var(--border-light);
+  width: 1.5px;
+  background: linear-gradient(180deg, var(--accent-border) 0%, var(--success-border) 100%);
+  opacity: 0.6;
 }
 
 .activityItem:last-child::before {
@@ -1302,57 +1303,240 @@ button:active:not(:disabled) {
   overflow-y: auto;
   padding: 18px 22px;
   display: grid;
-  gap: 14px;
+  gap: 10px;
+}
+
+.settingsLoading {
+  color: var(--text-muted);
+  padding: 32px;
+  text-align: center;
 }
 
 .settingsBody > p {
   color: var(--text-muted);
 }
 
-.configRow {
+/* ── Config Card (collapsible) ──────────────────────────────── */
+
+.configCard {
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
-  padding: 14px;
-  display: grid;
-  gap: 10px;
   background: var(--bg-muted);
-  transition: all var(--transition-fast);
+  transition: all var(--transition-base);
+  overflow: hidden;
 }
 
-.configRow:hover {
+.configCard:hover {
   border-color: var(--accent-border);
 }
 
-.configRowHeader {
+.configCardExpanded {
+  border-color: var(--accent-border);
+  box-shadow: var(--shadow-sm);
+}
+
+.configCardDisabled {
+  opacity: 0.55;
+}
+
+.configCardHeader {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 10px;
+  padding: 12px 14px;
+  cursor: pointer;
+  user-select: none;
+  transition: background var(--transition-fast);
 }
 
-.configRowHeader label {
+.configCardHeader:hover {
+  background: var(--bg-hover);
+}
+
+.configCardSummary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.configCardName {
+  font-size: 13.5px;
+  font-weight: 700;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.configCardPill {
+  flex: 0 0 auto;
+  border-radius: var(--radius-full);
+  padding: 2px 8px;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+}
+
+.configCardRole {
+  border: 1px solid var(--accent-border);
+  color: var(--accent);
+  background: var(--accent-subtle);
+}
+
+.configCardRuntime {
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  background: var(--bg-surface);
+}
+
+.configCardActions {
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 13px;
-  font-weight: 700;
-  color: var(--text-primary);
-  cursor: pointer;
+  flex: 0 0 auto;
+}
+
+.configChevron {
+  font-size: 10px;
+  color: var(--text-muted);
+  transition: transform 200ms var(--ease-out);
+  display: inline-block;
+}
+
+.configChevronOpen {
+  transform: rotate(90deg);
+}
+
+.configCardBody {
+  padding: 0 14px 14px;
+  border-top: 1px solid var(--border-light);
+  animation: cardExpand 200ms var(--ease-out);
+}
+
+@keyframes cardExpand {
+  from { opacity: 0; max-height: 0; }
+  to { opacity: 1; max-height: 800px; }
 }
 
 .removeBtn {
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--error);
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1;
+  color: var(--text-muted);
   background: none;
   border: 0;
   cursor: pointer;
-  padding: 2px 8px;
+  padding: 4px 6px;
   border-radius: 4px;
   transition: all var(--transition-fast);
 }
 
 .removeBtn:hover {
   background: var(--error-subtle);
+  color: var(--error);
+}
+
+/* ── Toggle Switch ──────────────────────────────────────────── */
+
+.toggleSwitch {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  position: relative;
+}
+
+.toggleSwitch input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggleTrack {
+  width: 36px;
+  height: 20px;
+  border-radius: 10px;
+  background: var(--border);
+  position: relative;
+  transition: background var(--transition-fast);
+}
+
+.toggleTrack::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--bg-surface);
+  box-shadow: var(--shadow-xs);
+  transition: transform var(--transition-fast);
+}
+
+.toggleSwitch input:checked + .toggleTrack {
+  background: var(--accent);
+}
+
+.toggleSwitch input:checked + .toggleTrack::after {
+  transform: translateX(16px);
+}
+
+/* ── Pill Selectors ─────────────────────────────────────────── */
+
+.pillGroup {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.pillLabel {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.pillOptions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.pillBtn {
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  padding: 4px 12px;
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.pillBtn:hover {
+  border-color: var(--accent-border);
+  color: var(--accent);
+  background: var(--accent-subtle);
+}
+
+.pillActive {
+  border-color: var(--accent);
+  color: var(--text-inverse);
+  background: var(--accent);
+  box-shadow: 0 0 0 1px rgba(15, 118, 110, 0.2);
+}
+
+.pillActive:hover {
+  color: var(--text-inverse);
+  background: var(--accent-hover);
 }
 
 .configFields {

--- a/tests/agent-config-store.test.ts
+++ b/tests/agent-config-store.test.ts
@@ -264,6 +264,30 @@ test("rejects permissionProfile with non-boolean canReadFiles", () => {
   assert.ok(errors.some((e) => e.includes("canReadFiles")));
 });
 
+test("rejects invalid role", () => {
+  const configs: AgentConfig[] = [
+    { id: "agent1", name: "A", role: "bad-role" as AgentConfig["role"], runtime: "claude-code", systemPrompt: "do stuff", enabled: true },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("role") && e.includes("agent1")), `Expected a role error, got: ${JSON.stringify(errors)}`);
+});
+
+test("rejects non-boolean enabled field", () => {
+  const configs: AgentConfig[] = [
+    { id: "agent1", name: "A", role: "general", runtime: "claude-code", systemPrompt: "do stuff", enabled: "false" as unknown as boolean },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("enabled") && e.includes("boolean")), `Expected an enabled/boolean error, got: ${JSON.stringify(errors)}`);
+});
+
+test("rejects missing enabled field", () => {
+  const configs: AgentConfig[] = [
+    { id: "agent1", name: "A", role: "general", runtime: "claude-code", systemPrompt: "do stuff", enabled: undefined as unknown as boolean },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("enabled")), `Expected an enabled error, got: ${JSON.stringify(errors)}`);
+});
+
 test("rejects permissionProfile with missing boolean fields", () => {
   const configs: AgentConfig[] = [
     {

--- a/tests/agent-config-store.test.ts
+++ b/tests/agent-config-store.test.ts
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { AgentConfigStore, DEFAULT_AGENT_CONFIGS, validateAgentConfigs, type AgentConfig } from "../src/core/agent-config-store.ts";
+
+function tempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "orbit-test-config-"));
+}
+
+test("DEFAULT_AGENT_CONFIGS seeds four built-in agents", () => {
+  assert.equal(DEFAULT_AGENT_CONFIGS.length, 4);
+  const ids = DEFAULT_AGENT_CONFIGS.map((c) => c.id);
+  assert.ok(ids.includes("pm"));
+  assert.ok(ids.includes("architect"));
+  assert.ok(ids.includes("developer"));
+  assert.ok(ids.includes("tester"));
+  for (const config of DEFAULT_AGENT_CONFIGS) {
+    assert.ok(config.enabled, `${config.id} should be enabled by default`);
+    assert.ok(config.systemPrompt.length > 0, `${config.id} should have a systemPrompt`);
+  }
+});
+
+test("load returns seed configs when no file exists", () => {
+  const dir = tempDir();
+  try {
+    const store = new AgentConfigStore(dir);
+    const configs = store.load("ws1");
+    assert.equal(configs.length, 4);
+    assert.equal(configs[0].id, "pm");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("save then load round-trips configs", () => {
+  const dir = tempDir();
+  try {
+    const store = new AgentConfigStore(dir);
+    const configs: AgentConfig[] = [
+      { id: "custom", name: "Custom Agent", role: "general", runtime: "claude-code", systemPrompt: "You are custom.", enabled: true },
+    ];
+    store.save("ws1", configs);
+    const loaded = store.load("ws1");
+    assert.equal(loaded.length, 1);
+    assert.equal(loaded[0].id, "custom");
+    assert.equal(loaded[0].name, "Custom Agent");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("save creates parent directories", () => {
+  const dir = path.join(tempDir(), "nested", "deep");
+  try {
+    const store = new AgentConfigStore(dir);
+    store.save("ws1", DEFAULT_AGENT_CONFIGS);
+    assert.ok(fs.existsSync(path.join(dir, "workspaces", "ws1", "agents.json")));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("reset restores seed configs", () => {
+  const dir = tempDir();
+  try {
+    const store = new AgentConfigStore(dir);
+    store.save("ws1", [{ id: "x", name: "X", role: "general", runtime: "claude-code", systemPrompt: "x", enabled: true }]);
+    const reset = store.reset("ws1");
+    assert.equal(reset.length, 4);
+    assert.equal(reset[0].id, "pm");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("different workspaces have independent configs", () => {
+  const dir = tempDir();
+  try {
+    const store = new AgentConfigStore(dir);
+    store.save("ws1", [{ id: "a", name: "A", role: "general", runtime: "claude-code", systemPrompt: "a", enabled: true }]);
+    store.save("ws2", [{ id: "b", name: "B", role: "general", runtime: "codex", systemPrompt: "b", enabled: true }]);
+    assert.equal(store.load("ws1")[0].id, "a");
+    assert.equal(store.load("ws2")[0].id, "b");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("load handles corrupted file gracefully", () => {
+  const dir = tempDir();
+  try {
+    const store = new AgentConfigStore(dir);
+    const filePath = path.join(dir, "workspaces", "ws1", "agents.json");
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, "not valid json{{{");
+    const configs = store.load("ws1");
+    assert.equal(configs.length, 4);
+    assert.equal(configs[0].id, "pm");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// --- Validation tests ---
+
+test("validates ok for seed configs", () => {
+  const errors = validateAgentConfigs(DEFAULT_AGENT_CONFIGS);
+  assert.deepEqual(errors, []);
+});
+
+test("rejects duplicate ids", () => {
+  const configs: AgentConfig[] = [
+    { id: "a", name: "A", role: "general", runtime: "claude-code", systemPrompt: "x", enabled: true },
+    { id: "a", name: "A2", role: "general", runtime: "codex", systemPrompt: "y", enabled: true },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.toLowerCase().includes("duplicate")));
+});
+
+test("rejects id 'all'", () => {
+  const configs: AgentConfig[] = [
+    { id: "all", name: "All", role: "general", runtime: "claude-code", systemPrompt: "x", enabled: true },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("reserved")));
+});
+
+test("rejects invalid id format", () => {
+  const configs: AgentConfig[] = [
+    { id: "bad id!", name: "Bad", role: "general", runtime: "claude-code", systemPrompt: "x", enabled: true },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("format")));
+});
+
+test("rejects invalid runtime", () => {
+  const configs: AgentConfig[] = [
+    { id: "agent1", name: "A", role: "general", runtime: "invalid-runtime" as AgentConfig["runtime"], systemPrompt: "x", enabled: true },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("runtime")));
+});
+
+test("rejects empty systemPrompt", () => {
+  const configs: AgentConfig[] = [
+    { id: "agent1", name: "A", role: "general", runtime: "claude-code", systemPrompt: "  ", enabled: true },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("systemPrompt")));
+});
+
+test("rejects empty name", () => {
+  const configs: AgentConfig[] = [
+    { id: "agent1", name: "  ", role: "general", runtime: "claude-code", systemPrompt: "do stuff", enabled: true },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("name")));
+});
+
+test("rejects config with no enabled agents", () => {
+  const configs: AgentConfig[] = DEFAULT_AGENT_CONFIGS.map((c) => ({ ...c, enabled: false }));
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("enabled")));
+});
+
+test("rejects empty config list", () => {
+  const errors = validateAgentConfigs([]);
+  assert.ok(errors.length > 0);
+});

--- a/tests/agent-config-store.test.ts
+++ b/tests/agent-config-store.test.ts
@@ -104,6 +104,54 @@ test("load handles corrupted file gracefully", () => {
   }
 });
 
+test("load returns defaults for valid JSON with invalid runtime", () => {
+  const dir = tempDir();
+  try {
+    const store = new AgentConfigStore(dir);
+    const filePath = path.join(dir, "workspaces", "ws1", "agents.json");
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify([{ id: "a", name: "A", role: "general", runtime: "not-a-runtime", systemPrompt: "x", enabled: true }]));
+    const configs = store.load("ws1");
+    assert.equal(configs.length, 4);
+    assert.equal(configs[0].id, "pm");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("load returns defaults for valid JSON with duplicate ids", () => {
+  const dir = tempDir();
+  try {
+    const store = new AgentConfigStore(dir);
+    const filePath = path.join(dir, "workspaces", "ws1", "agents.json");
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify([
+      { id: "dup", name: "A", role: "general", runtime: "claude-code", systemPrompt: "x", enabled: true },
+      { id: "dup", name: "B", role: "general", runtime: "codex", systemPrompt: "y", enabled: true },
+    ]));
+    const configs = store.load("ws1");
+    assert.equal(configs.length, 4);
+    assert.equal(configs[0].id, "pm");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("load returns defaults for valid JSON with no enabled agents", () => {
+  const dir = tempDir();
+  try {
+    const store = new AgentConfigStore(dir);
+    const filePath = path.join(dir, "workspaces", "ws1", "agents.json");
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify([{ id: "a", name: "A", role: "general", runtime: "claude-code", systemPrompt: "x", enabled: false }]));
+    const configs = store.load("ws1");
+    assert.equal(configs.length, 4);
+    assert.equal(configs[0].id, "pm");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 // --- Validation tests ---
 
 test("validates ok for seed configs", () => {

--- a/tests/agent-config-store.test.ts
+++ b/tests/agent-config-store.test.ts
@@ -160,6 +160,36 @@ test("rejects empty name", () => {
   assert.ok(errors.some((e) => e.includes("name")));
 });
 
+test("rejects permissionProfile with empty allowedDirectories", () => {
+  const configs: AgentConfig[] = [
+    {
+      id: "agent1", name: "A", role: "general", runtime: "claude-code",
+      systemPrompt: "do stuff", enabled: true,
+      permissionProfile: {
+        canReadFiles: true, canWriteFiles: false, canRunCommands: false,
+        canInstallDependencies: false, canGitCommit: false, allowedDirectories: [],
+      },
+    },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("allowedDirectories")));
+});
+
+test("accepts config with valid permissionProfile", () => {
+  const configs: AgentConfig[] = [
+    {
+      id: "agent1", name: "A", role: "general", runtime: "claude-code",
+      systemPrompt: "do stuff", enabled: true,
+      permissionProfile: {
+        canReadFiles: true, canWriteFiles: true, canRunCommands: true,
+        canInstallDependencies: false, canGitCommit: false, allowedDirectories: ["."],
+      },
+    },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.deepEqual(errors, []);
+});
+
 test("rejects config with no enabled agents", () => {
   const configs: AgentConfig[] = DEFAULT_AGENT_CONFIGS.map((c) => ({ ...c, enabled: false }));
   const errors = validateAgentConfigs(configs);

--- a/tests/agent-config-store.test.ts
+++ b/tests/agent-config-store.test.ts
@@ -328,3 +328,13 @@ test("rejects non-string systemPrompt without throwing", () => {
   const errors = validateAgentConfigs(configs);
   assert.ok(errors.some((e) => e.includes("systemPrompt")), `Expected a systemPrompt error, got: ${JSON.stringify(errors)}`);
 });
+
+test("rejects null array element without throwing", () => {
+  const errors = validateAgentConfigs([null] as unknown as AgentConfig[]);
+  assert.ok(errors.some((e) => e.includes("object")), `Expected an object error, got: ${JSON.stringify(errors)}`);
+});
+
+test("rejects non-object array element without throwing", () => {
+  const errors = validateAgentConfigs(["bad"] as unknown as AgentConfig[]);
+  assert.ok(errors.some((e) => e.includes("object")), `Expected an object error, got: ${JSON.stringify(errors)}`);
+});

--- a/tests/agent-config-store.test.ts
+++ b/tests/agent-config-store.test.ts
@@ -200,3 +200,35 @@ test("rejects empty config list", () => {
   const errors = validateAgentConfigs([]);
   assert.ok(errors.length > 0);
 });
+
+test("rejects permissionProfile with non-boolean canReadFiles", () => {
+  const configs: AgentConfig[] = [
+    {
+      id: "agent1", name: "A", role: "general", runtime: "claude-code",
+      systemPrompt: "do stuff", enabled: true,
+      permissionProfile: {
+        canReadFiles: "yes" as unknown as boolean, canWriteFiles: false, canRunCommands: false,
+        canInstallDependencies: false, canGitCommit: false, allowedDirectories: ["."],
+      },
+    },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("canReadFiles")));
+});
+
+test("rejects permissionProfile with missing boolean fields", () => {
+  const configs: AgentConfig[] = [
+    {
+      id: "agent1", name: "A", role: "general", runtime: "claude-code",
+      systemPrompt: "do stuff", enabled: true,
+      permissionProfile: {
+        canReadFiles: true, allowedDirectories: ["."],
+      } as unknown as AgentConfig["permissionProfile"],
+    },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("canWriteFiles")));
+  assert.ok(errors.some((e) => e.includes("canRunCommands")));
+  assert.ok(errors.some((e) => e.includes("canInstallDependencies")));
+  assert.ok(errors.some((e) => e.includes("canGitCommit")));
+});

--- a/tests/agent-config-store.test.ts
+++ b/tests/agent-config-store.test.ts
@@ -304,3 +304,27 @@ test("rejects permissionProfile with missing boolean fields", () => {
   assert.ok(errors.some((e) => e.includes("canInstallDependencies")));
   assert.ok(errors.some((e) => e.includes("canGitCommit")));
 });
+
+test("rejects non-string id without throwing", () => {
+  const configs = [
+    { id: 123, name: "A", role: "general", runtime: "claude-code", systemPrompt: "x", enabled: true },
+  ] as unknown as AgentConfig[];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("id")), `Expected an id error, got: ${JSON.stringify(errors)}`);
+});
+
+test("rejects non-string name without throwing", () => {
+  const configs = [
+    { id: "a", name: 123, role: "general", runtime: "claude-code", systemPrompt: "x", enabled: true },
+  ] as unknown as AgentConfig[];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("name")), `Expected a name error, got: ${JSON.stringify(errors)}`);
+});
+
+test("rejects non-string systemPrompt without throwing", () => {
+  const configs = [
+    { id: "a", name: "A", role: "general", runtime: "claude-code", systemPrompt: 123, enabled: true },
+  ] as unknown as AgentConfig[];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("systemPrompt")), `Expected a systemPrompt error, got: ${JSON.stringify(errors)}`);
+});

--- a/tests/agent-session.test.ts
+++ b/tests/agent-session.test.ts
@@ -319,3 +319,64 @@ test("resume failure clears stale session and retries without resume", async () 
   assert.equal(calls[1]!.resumeSessionId, undefined);
   assert.equal(store.load("codebuddy", "default", "default", "developer")!.sessionId, "fresh-session");
 });
+
+test("Claude API deserialize failure clears stale resume session and retries without resume", async () => {
+  const dir = tmpDir();
+  const store = new SessionStore(dir);
+  store.save("claude-code", "default", "default", "developer", {
+    agentId: "developer",
+    channelId: "default",
+    runtime: "claude-code",
+    sessionId: "bad-claude-session",
+    lastRunAt: new Date().toISOString(),
+    runCount: 1,
+  });
+
+  const calls: AgentRuntimeRunOptions[] = [];
+  const runtime: AgentRuntime = {
+    kind: "claude-code",
+    run(options) {
+      calls.push(options);
+      return {
+        process: {
+          kill() {
+            return true;
+          },
+        },
+        result: calls.length === 1
+          ? Promise.reject(new Error("unknown API Error: 400 Failed to deserialize the JSON body into the target type: messages[1].role: unknown variant `system`, expected `user` or `assistant` at line 1 column 15698"))
+          : Promise.resolve("clean final"),
+        sessionId: Promise.resolve(calls.length === 1 ? null : "fresh-claude-session"),
+      };
+    },
+  };
+
+  const session = new AgentSession({
+    id: "developer",
+    label: "Developer",
+    cwd: "D:/workspace",
+    permissionProfile: {
+      canReadFiles: true,
+      canWriteFiles: true,
+      canRunCommands: true,
+      canInstallDependencies: true,
+      canGitCommit: false,
+      allowedDirectories: ["."],
+    },
+    runtime,
+    eventBus: new EventBus(),
+    sessionStore: store,
+    channelId: "default",
+    conversationId: "default",
+  });
+
+  session.start();
+  const result = await session.send("run-1", "hello");
+
+  assert.equal(result.content, "clean final");
+  assert.equal(result.sessionId, "fresh-claude-session");
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0]!.resumeSessionId, "bad-claude-session");
+  assert.equal(calls[1]!.resumeSessionId, undefined);
+  assert.equal(store.load("claude-code", "default", "default", "developer")!.sessionId, "fresh-claude-session");
+});

--- a/tests/channel-context-builder.test.ts
+++ b/tests/channel-context-builder.test.ts
@@ -14,10 +14,23 @@ test("builds structured context for current agent", () => {
 
   assert.ok(context.includes("[Orbit Context]"));
   assert.ok(context.includes("Current agent: Developer (@developer)"));
-  assert.ok(context.includes("@tester: Tester"));
+  assert.ok(context.includes("@tester: Tester — Validates behavior, runs tests, reports risks."));
   assert.ok(context.includes("[Full channel message]"));
   assert.ok(context.includes("@developer: implement queue @tester: verify it"));
   assert.ok(context.includes("Permission profile:"));
   assert.ok(context.includes("Orbit has already scheduled the other agents"));
   assert.ok(context.includes("Do not start by repeating the full channel message"));
+});
+
+test("includes description in available agents list", () => {
+  const profiles = createDefaultAgentProfiles("D:/project");
+  const context = buildChannelContext({
+    agentId: "developer",
+    profiles,
+    channelMessage: "@developer: test",
+  });
+
+  assert.ok(context.includes("@pm: Product Manager — Clarifies requirements, defines scope and acceptance criteria."));
+  assert.ok(context.includes("@architect: Architect — Designs technical boundaries, reviews implementation risk."));
+  assert.ok(context.includes("@developer: Developer — Implements features with TDD, creates branches and draft PRs."));
 });

--- a/tests/terminal-transcript-store.test.ts
+++ b/tests/terminal-transcript-store.test.ts
@@ -62,6 +62,28 @@ test("persisted store appends to existing transcripts", () => {
   }
 });
 
+test("persisted store survives Windows rename failures while saving transcript chunks", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orbit-transcript-test-"));
+  const originalRenameSync = fs.renameSync;
+  try {
+    fs.renameSync = (() => {
+      const error = new Error("operation not permitted, rename") as NodeJS.ErrnoException;
+      error.code = "EPERM";
+      throw error;
+    }) as typeof fs.renameSync;
+
+    const store = new TerminalTranscriptStore(dir);
+    assert.doesNotThrow(() => store.append("ux", "output"));
+    assert.equal(store.get("ux"), "output");
+
+    const loaded = new TerminalTranscriptStore(dir);
+    assert.equal(loaded.get("ux"), "output");
+  } finally {
+    fs.renameSync = originalRenameSync;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("persisted store strips ANSI before saving", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orbit-transcript-test-"));
   try {

--- a/tests/terminal-transcript-store.test.ts
+++ b/tests/terminal-transcript-store.test.ts
@@ -6,6 +6,13 @@ import path from "node:path";
 
 import { TerminalTranscriptStore } from "../src/core/terminal-transcript-store.ts";
 
+function cleanupTranscriptTest(dir: string, stores: TerminalTranscriptStore[]): void {
+  for (const store of stores) {
+    store.dispose();
+  }
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
 test("appends cleaned terminal chunks by agent", () => {
   const store = new TerminalTranscriptStore();
 
@@ -34,37 +41,44 @@ test("unknown agent transcript starts empty", () => {
 
 test("persisted store round-trips transcripts to directory", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orbit-transcript-test-"));
+  const stores: TerminalTranscriptStore[] = [];
   try {
     const store = new TerminalTranscriptStore(dir);
+    stores.push(store);
     store.append("developer", "output A");
     store.append("architect", "output B");
 
     const loaded = new TerminalTranscriptStore(dir);
+    stores.push(loaded);
     assert.equal(loaded.get("developer"), "output A");
     assert.equal(loaded.get("architect"), "output B");
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true });
+    cleanupTranscriptTest(dir, stores);
   }
 });
 
 test("persisted store appends to existing transcripts", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orbit-transcript-test-"));
+  const stores: TerminalTranscriptStore[] = [];
   try {
     const store = new TerminalTranscriptStore(dir);
+    stores.push(store);
     store.append("developer", "part1 ");
 
     const loaded = new TerminalTranscriptStore(dir);
+    stores.push(loaded);
     loaded.append("developer", "part2");
 
     assert.equal(loaded.get("developer"), "part1 part2");
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true });
+    cleanupTranscriptTest(dir, stores);
   }
 });
 
 test("persisted store survives Windows rename failures while saving transcript chunks", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orbit-transcript-test-"));
   const originalRenameSync = fs.renameSync;
+  const stores: TerminalTranscriptStore[] = [];
   try {
     fs.renameSync = (() => {
       const error = new Error("operation not permitted, rename") as NodeJS.ErrnoException;
@@ -73,38 +87,42 @@ test("persisted store survives Windows rename failures while saving transcript c
     }) as typeof fs.renameSync;
 
     const store = new TerminalTranscriptStore(dir);
+    stores.push(store);
     assert.doesNotThrow(() => store.append("ux", "output"));
     assert.equal(store.get("ux"), "output");
 
     const loaded = new TerminalTranscriptStore(dir);
+    stores.push(loaded);
     assert.equal(loaded.get("ux"), "output");
   } finally {
     fs.renameSync = originalRenameSync;
-    fs.rmSync(dir, { recursive: true, force: true });
+    cleanupTranscriptTest(dir, stores);
   }
 });
 
-test("persisted store queues transcript chunks and retries after the log file is busy", async () => {
+test("persisted store retries busy writes without a separate pending buffer", async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orbit-transcript-test-"));
-  const originalAppendFileSync = fs.appendFileSync;
+  const originalWriteSync = fs.writeSync;
   const originalWarn = console.warn;
   const warnings: string[] = [];
   let attempts = 0;
+  const stores: TerminalTranscriptStore[] = [];
   try {
-    fs.appendFileSync = ((...args: Parameters<typeof fs.appendFileSync>) => {
+    fs.writeSync = ((...args: Parameters<typeof fs.writeSync>) => {
       attempts += 1;
       if (attempts <= 2) {
         const error = new Error("resource busy or locked") as NodeJS.ErrnoException;
         error.code = "EBUSY";
         throw error;
       }
-      return originalAppendFileSync(...args);
-    }) as typeof fs.appendFileSync;
+      return originalWriteSync(...args);
+    }) as typeof fs.writeSync;
     console.warn = (message?: unknown) => {
       warnings.push(String(message));
     };
 
     const store = new TerminalTranscriptStore(dir);
+    stores.push(store);
     assert.doesNotThrow(() => store.append("ux", "first "));
     assert.doesNotThrow(() => store.append("ux", "second"));
     assert.equal(store.get("ux"), "first second");
@@ -112,26 +130,63 @@ test("persisted store queues transcript chunks and retries after the log file is
     await new Promise((resolve) => setTimeout(resolve, 150));
 
     const loaded = new TerminalTranscriptStore(dir);
+    stores.push(loaded);
     assert.equal(loaded.get("ux"), "first second");
     assert.equal(warnings.length, 1);
     assert.match(warnings[0], /failed to persist terminal transcript for ux/);
   } finally {
-    fs.appendFileSync = originalAppendFileSync;
+    fs.writeSync = originalWriteSync;
     console.warn = originalWarn;
-    fs.rmSync(dir, { recursive: true, force: true });
+    cleanupTranscriptTest(dir, stores);
+  }
+});
+
+test("persisted store keeps an append handle open for realtime log viewing", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orbit-transcript-test-"));
+  const originalOpenSync = fs.openSync;
+  let openCount = 0;
+  const stores: TerminalTranscriptStore[] = [];
+  try {
+    fs.openSync = ((...args: Parameters<typeof fs.openSync>) => {
+      openCount += 1;
+      if (openCount > 1) {
+        const error = new Error("resource busy or locked") as NodeJS.ErrnoException;
+        error.code = "EBUSY";
+        throw error;
+      }
+      return originalOpenSync(...args);
+    }) as typeof fs.openSync;
+
+    const store = new TerminalTranscriptStore(dir);
+    stores.push(store);
+    store.append("ux", "first ");
+    store.append("ux", "second");
+
+    assert.equal(store.get("ux"), "first second");
+    assert.equal(openCount, 1);
+
+    const loaded = new TerminalTranscriptStore(dir);
+    stores.push(loaded);
+    assert.equal(loaded.get("ux"), "first second");
+  } finally {
+    fs.openSync = originalOpenSync;
+    cleanupTranscriptTest(dir, stores);
   }
 });
 
 test("persisted store strips ANSI before saving", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orbit-transcript-test-"));
+  const stores: TerminalTranscriptStore[] = [];
   try {
     const store = new TerminalTranscriptStore(dir);
+    stores.push(store);
     store.append("developer", "[32mhello[0m");
 
     const loaded = new TerminalTranscriptStore(dir);
+    stores.push(loaded);
     assert.equal(loaded.get("developer"), "hello");
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true });
+    cleanupTranscriptTest(dir, stores);
   }
 });
 
@@ -139,29 +194,34 @@ test("different directories keep transcripts isolated", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orbit-transcript-test-"));
   const dirA = path.join(dir, "a");
   const dirB = path.join(dir, "b");
+  const stores: TerminalTranscriptStore[] = [];
   try {
     const storeA = new TerminalTranscriptStore(dirA);
     const storeB = new TerminalTranscriptStore(dirB);
+    stores.push(storeA, storeB);
     storeA.append("developer", "workspace A");
     storeB.append("developer", "workspace B");
 
     const loadedA = new TerminalTranscriptStore(dirA);
     const loadedB = new TerminalTranscriptStore(dirB);
+    stores.push(loadedA, loadedB);
     assert.equal(loadedA.get("developer"), "workspace A");
     assert.equal(loadedB.get("developer"), "workspace B");
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true });
+    cleanupTranscriptTest(dir, stores);
   }
 });
 
 test("persisted store ignores non-log files in directory", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orbit-transcript-test-"));
+  const stores: TerminalTranscriptStore[] = [];
   try {
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(path.join(dir, "readme.txt"), "ignore me");
     const store = new TerminalTranscriptStore(dir);
+    stores.push(store);
     assert.equal(store.get("readme"), "");
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true });
+    cleanupTranscriptTest(dir, stores);
   }
 });

--- a/tests/terminal-transcript-store.test.ts
+++ b/tests/terminal-transcript-store.test.ts
@@ -84,6 +84,44 @@ test("persisted store survives Windows rename failures while saving transcript c
   }
 });
 
+test("persisted store queues transcript chunks and retries after the log file is busy", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orbit-transcript-test-"));
+  const originalAppendFileSync = fs.appendFileSync;
+  const originalWarn = console.warn;
+  const warnings: string[] = [];
+  let attempts = 0;
+  try {
+    fs.appendFileSync = ((...args: Parameters<typeof fs.appendFileSync>) => {
+      attempts += 1;
+      if (attempts <= 2) {
+        const error = new Error("resource busy or locked") as NodeJS.ErrnoException;
+        error.code = "EBUSY";
+        throw error;
+      }
+      return originalAppendFileSync(...args);
+    }) as typeof fs.appendFileSync;
+    console.warn = (message?: unknown) => {
+      warnings.push(String(message));
+    };
+
+    const store = new TerminalTranscriptStore(dir);
+    assert.doesNotThrow(() => store.append("ux", "first "));
+    assert.doesNotThrow(() => store.append("ux", "second"));
+    assert.equal(store.get("ux"), "first second");
+
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const loaded = new TerminalTranscriptStore(dir);
+    assert.equal(loaded.get("ux"), "first second");
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /failed to persist terminal transcript for ux/);
+  } finally {
+    fs.appendFileSync = originalAppendFileSync;
+    console.warn = originalWarn;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("persisted store strips ANSI before saving", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orbit-transcript-test-"));
   try {


### PR DESCRIPTION
Closes #16

## What changed
- New `AgentConfig` type for persistence/UI model, separate from runtime `AgentProfile`
- `AgentConfigStore` with per-workspace load/save/reset, atomic writes, seed defaults
- `validateAgentConfigs` checks id format, uniqueness, reserved names, runtime, systemPrompt, enabled count
- Server loads configs from store, filters to enabled agents, converts to profiles
- `configsToProfiles()` converts `AgentConfig` → `AgentProfile` with role-based permission mapping
- API endpoints: `GET /api/agents`, `PUT /api/agents` (409 if agent running), `POST /api/agents/reset`
- Registry and router refresh on config save
- Settings modal UI with agent list, add/remove/edit, enable/disable, save with validation, reset defaults

## Verification
- 16 new tests for config store and validation
- `npm run test` — 145 tests pass
- `npm run build` — clean

## Design decisions
- Disabled agents are excluded from routing (not just hidden)
- Save returns 409 if any agent is running — no hot-swap of active runs
- Built-in agents (pm, architect, developer, tester) are seed defaults, can be modified or removed
- `AgentRole` "general" maps to a sensible default permission profile

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>