### PR TITLE
feat: support @all: assignment and ignore unknown @xx: mentions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,5 +144,5 @@ When modifying UI: use CSS variables, never hardcode colors. Keep all changes in
 - `@agent:` with a colon assigns work; plain `@agent` is just a reference
 - Multiple assignments in one message are allowed
 - Self-assignments are ignored
-- `@all` is explicitly unsupported
+- `@all:` assigns work to all registered agents (sender excluded); expands at route time, not a real agent profile
 - Route depth capped at 5 to prevent infinite delegation loops

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,8 +90,9 @@ This ensures routing and run dispatch use the current agent configuration. A 409
 ## Routing Rules
 
 - Only `@agent:` with a colon assigns work.
+- `@all:` assigns work to all registered agents (sender excluded); it expands at route time into individual agent assignments, not a real agent profile.
 - Plain `@agent` mentions are references and do not trigger routing.
-- Unknown placeholders such as `@agent:` are treated as normal text.
+- Unknown `@xx:` mentions are silently ignored (no error, no routing).
 - A message can assign work to multiple agents.
 - Each assigned agent receives the full channel message as context.
 - Agent replies can also contain assignments, but self-assignments are ignored.

--- a/src/core/channel-router.ts
+++ b/src/core/channel-router.ts
@@ -35,8 +35,6 @@ export class ChannelRouter {
         this.options.markMessageRouted(message.id, "ignored");
         break;
 
-      case "all_unsupported":
-      case "unknown":
       case "self":
       case "empty_assignment":
         this.options.createSystemMessage(result.message, message.id);

--- a/src/core/mention-router.ts
+++ b/src/core/mention-router.ts
@@ -70,25 +70,19 @@ export function routeMention(
     };
   }
 
-  // Deduplicate by agentId while preserving order
-  const seen = new Set<AgentId>();
-  const dedupedAssignments = knownAssignments.filter((assignment) => {
-    if (seen.has(assignment.agentId)) return false;
-    seen.add(assignment.agentId);
-    return true;
-  });
-
-  // Check for empty assignments — only check non-@all markers for empty task text
-  // @all: markers are always considered to have content (they inherit the shared prompt)
-  for (const assignment of dedupedAssignments) {
+  // Check for empty assignments on raw known markers before dedup.
+  // This ensures duplicate markers like "@agent1: @agent1: task" correctly
+  // block on the first empty marker, and "@all: review @agent1:" blocks
+  // on the explicit empty @agent1:.
+  for (const assignment of knownAssignments) {
     // Skip empty-check for markers that originated from @all: expansion
     // (they all share the same start/end from the @all marker)
     if (hasAllMarker && rawAssignments.some((raw) => raw.agentName.toLowerCase() === "all" && raw.start === assignment.start)) {
       continue;
     }
 
-    const nextMarker = findNextMarker(assignment.end, dedupedAssignments);
-    const taskText = content.slice(assignment.end, nextMarker).trim();
+    const nextEnd = findNextMarkerEnd(assignment.end, knownAssignments);
+    const taskText = content.slice(assignment.end, nextEnd).trim();
     if (!taskText) {
       return {
         kind: "empty_assignment",
@@ -97,6 +91,14 @@ export function routeMention(
       };
     }
   }
+
+  // Deduplicate by agentId while preserving order
+  const seen = new Set<AgentId>();
+  const dedupedAssignments = knownAssignments.filter((assignment) => {
+    if (seen.has(assignment.agentId)) return false;
+    seen.add(assignment.agentId);
+    return true;
+  });
 
   return {
     kind: "assignments",
@@ -109,7 +111,7 @@ export function routeMention(
  * Find the start position of the next assignment marker after the given position,
  * or return the content length if there is no next marker.
  */
-function findNextMarker(afterEnd: number, assignments: Array<{ start: number }>): number {
+function findNextMarkerEnd(afterEnd: number, assignments: Array<{ start: number }>): number {
   let next = Infinity;
   for (const assignment of assignments) {
     if (assignment.start > afterEnd && assignment.start < next) {

--- a/src/core/mention-router.ts
+++ b/src/core/mention-router.ts
@@ -4,8 +4,6 @@ export type MentionRouteResult =
   | { kind: "assignments"; agentIds: AgentId[]; prompt: string }
   | { kind: "empty_assignment"; agentId: AgentId; message: string }
   | { kind: "none"; message: string }
-  | { kind: "all_unsupported"; message: string }
-  | { kind: "unknown"; message: string }
   | { kind: "self"; message: string };
 
 type AssignmentMarker = {
@@ -14,14 +12,14 @@ type AssignmentMarker = {
   end: number;
 };
 
-const assignmentPattern = /@([A-Za-z0-9_-]+)\s*(?::|\uFF1A)/g;
+const assignmentPattern = /@([A-Za-z0-9_-]+)\s*(?::|：)/g;
 
 export function routeMention(
   content: string,
   availableAgents: readonly AgentId[],
   senderAgentId?: AgentId,
 ): MentionRouteResult {
-  const assignments = Array.from(content.matchAll(assignmentPattern), (match): AssignmentMarker => {
+  const rawAssignments = Array.from(content.matchAll(assignmentPattern), (match): AssignmentMarker => {
     const start = match.index ?? 0;
     return {
       agentName: match[1],
@@ -30,21 +28,34 @@ export function routeMention(
     };
   });
 
-  if (assignments.length === 0) {
+  if (rawAssignments.length === 0) {
     return {
       kind: "none",
       message: `Use ${formatAssignmentList(availableAgents)} to assign work to an agent.`,
     };
   }
 
-  if (assignments.some((assignment) => assignment.agentName.toLowerCase() === "all")) {
-    return {
-      kind: "all_unsupported",
-      message: `This version does not support @all. Choose ${formatAssignmentList(availableAgents)}.`,
-    };
+  // Expand @all: into individual agent assignments
+  const expandedAssignments: AssignmentMarker[] = [];
+  let hasAllMarker = false;
+
+  for (const assignment of rawAssignments) {
+    if (assignment.agentName.toLowerCase() === "all") {
+      hasAllMarker = true;
+      for (const agentId of availableAgents) {
+        expandedAssignments.push({
+          agentName: agentId,
+          start: assignment.start,
+          end: assignment.end,
+        });
+      }
+    } else {
+      expandedAssignments.push(assignment);
+    }
   }
 
-  const knownAssignments = assignments
+  // Filter to known agents and exclude sender self-assignments
+  const knownAssignments = expandedAssignments
     .filter((assignment) => isAgentId(assignment.agentName, availableAgents))
     .filter((assignment) => assignment.agentName !== senderAgentId)
     .map((assignment) => ({
@@ -59,10 +70,25 @@ export function routeMention(
     };
   }
 
-  for (let index = 0; index < knownAssignments.length; index += 1) {
-    const assignment = knownAssignments[index];
-    const nextAssignment = knownAssignments[index + 1];
-    const taskText = content.slice(assignment.end, nextAssignment?.start ?? content.length).trim();
+  // Deduplicate by agentId while preserving order
+  const seen = new Set<AgentId>();
+  const dedupedAssignments = knownAssignments.filter((assignment) => {
+    if (seen.has(assignment.agentId)) return false;
+    seen.add(assignment.agentId);
+    return true;
+  });
+
+  // Check for empty assignments — only check non-@all markers for empty task text
+  // @all: markers are always considered to have content (they inherit the shared prompt)
+  for (const assignment of dedupedAssignments) {
+    // Skip empty-check for markers that originated from @all: expansion
+    // (they all share the same start/end from the @all marker)
+    if (hasAllMarker && rawAssignments.some((raw) => raw.agentName.toLowerCase() === "all" && raw.start === assignment.start)) {
+      continue;
+    }
+
+    const nextMarker = findNextMarker(assignment.end, dedupedAssignments);
+    const taskText = content.slice(assignment.end, nextMarker).trim();
     if (!taskText) {
       return {
         kind: "empty_assignment",
@@ -74,9 +100,23 @@ export function routeMention(
 
   return {
     kind: "assignments",
-    agentIds: Array.from(new Set(knownAssignments.map((assignment) => assignment.agentId))),
+    agentIds: dedupedAssignments.map((assignment) => assignment.agentId),
     prompt: content.trim(),
   };
+}
+
+/**
+ * Find the start position of the next assignment marker after the given position,
+ * or return the content length if there is no next marker.
+ */
+function findNextMarker(afterEnd: number, assignments: Array<{ start: number }>): number {
+  let next = Infinity;
+  for (const assignment of assignments) {
+    if (assignment.start > afterEnd && assignment.start < next) {
+      next = assignment.start;
+    }
+  }
+  return next === Infinity ? Infinity : next;
 }
 
 function isAgentId(value: string, availableAgents: readonly AgentId[]): value is AgentId {

--- a/src/core/mention-router.ts
+++ b/src/core/mention-router.ts
@@ -35,6 +35,20 @@ export function routeMention(
     };
   }
 
+  // Check @all: markers for empty task content before expansion
+  for (const assignment of rawAssignments) {
+    if (assignment.agentName.toLowerCase() !== "all") continue;
+    const nextRawEnd = findNextMarkerEnd(assignment.end, rawAssignments);
+    const taskText = content.slice(assignment.end, nextRawEnd).trim();
+    if (!taskText) {
+      return {
+        kind: "empty_assignment",
+        agentId: "all" as AgentId,
+        message: "Add task content after @all:.",
+      };
+    }
+  }
+
   // Expand @all: into individual agent assignments
   const expandedAssignments: AssignmentMarker[] = [];
   let hasAllMarker = false;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -93,7 +93,12 @@ export function App() {
       return [];
     }
 
-    return agentIds.filter((agentId) => agentId.toLowerCase().startsWith(mentionDraft.query.toLowerCase()));
+    const query = mentionDraft.query.toLowerCase();
+    const matched = agentIds.filter((agentId) => agentId.toLowerCase().startsWith(query));
+    if ("all".startsWith(query) && !matched.includes("all")) {
+      matched.push("all" as AgentId);
+    }
+    return matched;
   }, [agentIds, inputFocused, mentionDraft]);
 
   useEffect(() => {
@@ -177,7 +182,9 @@ export function App() {
 
     const nextContent = `${content.slice(0, mentionDraft.start)}@${agentId}: ${content.slice(mentionDraft.end)}`;
     const nextCursorIndex = mentionDraft.start + agentId.length + 3;
-    setSelectedAgent(agentId);
+    if (agentId !== "all") {
+      setSelectedAgent(agentId);
+    }
     setContent(nextContent);
     setCursorIndex(nextCursorIndex);
     window.setTimeout(() => {
@@ -363,6 +370,7 @@ function MentionMenu(props: {
   return (
     <div className="mentionMenu" role="listbox" aria-label="Choose agent">
       {props.candidates.map((agentId, index) => {
+        const isAll = agentId === "all";
         const agent = props.agentsById.get(agentId);
         const status = agent?.status ?? "idle";
         return (
@@ -376,10 +384,10 @@ function MentionMenu(props: {
             onClick={() => props.onSelect(agentId)}
           >
             <span className="mentionName">
-              <span className={`mentionDot ${status}`} aria-hidden="true" />
+              <span className={`mentionDot ${isAll ? "idle" : status}`} aria-hidden="true" />
               <span>@{agentId}</span>
             </span>
-            <small>{status}</small>
+            <small>{isAll ? "all agents" : status}</small>
           </button>
         );
       })}

--- a/tests/channel-router.test.ts
+++ b/tests/channel-router.test.ts
@@ -137,14 +137,32 @@ test("agent self-assignment does not block peer assignment", () => {
   assert.equal(routeStates[0]?.state, "routed");
 });
 
-test("@all assignment is blocked with system message", () => {
-  const { router, systemMessages, agentRuns, routeStates } = createRouter();
+test("@all: assignment routes to all agents", () => {
+  const { router, agentRuns, routeStates } = createRouter();
   router.process(createUserMessage("@all: summarize project"));
 
+  assert.equal(agentRuns.length, 2);
+  assert.deepEqual(agentRuns.map((run) => run.agentId).sort(), ["agent1", "agent2"]);
+  assert.ok(agentRuns.every((run) => run.prompt === "@all: summarize project"));
+  assert.equal(routeStates[0]?.state, "routed");
+});
+
+test("@all: from agent excludes self from routing", () => {
+  const { router, agentRuns, routeStates } = createRouter();
+  router.process(createAgentMessage("agent1", "@all: everyone help"));
+
+  assert.equal(agentRuns.length, 1);
+  assert.equal(agentRuns[0].agentId, "agent2");
+  assert.equal(routeStates[0]?.state, "routed");
+});
+
+test("unknown @xx: from user is silently ignored with hint", () => {
+  const { router, systemMessages, agentRuns, routeStates } = createRouter();
+  router.process(createUserMessage("@nonexistent: do something"));
+
   assert.equal(agentRuns.length, 0);
-  assert.equal(systemMessages.length, 1);
-  assert.ok(systemMessages[0].content.includes("does not support @all"));
-  assert.equal(routeStates[0]?.state, "blocked");
+  assert.equal(routeStates[0]?.state, "ignored");
+  assert.ok(systemMessages[0].content.includes("@agent1:"));
 });
 
 test("already routed message is skipped", () => {

--- a/tests/mention-router.test.ts
+++ b/tests/mention-router.test.ts
@@ -94,7 +94,7 @@ test("@all: from agent excludes self", () => {
   }
 });
 
-test("@all: with no other agents returns none", () => {
+test("@all: from sender excludes self, routes to remaining agents", () => {
   const result = routeMention("@all: help", agents, "agent1");
   // agent1 is the sender, only 2 agents total -> only agent2 left
   assert.equal(result.kind, "assignments");
@@ -164,6 +164,22 @@ test("empty_assignment: @agent1 colon alone is blocked", () => {
 
 test("empty_assignment: one empty assignment blocks the whole message", () => {
   const result = routeMention("@agent1: @agent2: implement code", agents);
+  assert.equal(result.kind, "empty_assignment");
+  if (result.kind === "empty_assignment") {
+    assert.equal(result.agentId, "agent1");
+  }
+});
+
+test("empty_assignment: duplicate same-agent marker with first empty blocks", () => {
+  const result = routeMention("@agent1: @agent1: do code", agents);
+  assert.equal(result.kind, "empty_assignment");
+  if (result.kind === "empty_assignment") {
+    assert.equal(result.agentId, "agent1");
+  }
+});
+
+test("empty_assignment: @all mixed with explicit empty assignment blocks", () => {
+  const result = routeMention("@all: review @agent1:", agents);
   assert.equal(result.kind, "empty_assignment");
   if (result.kind === "empty_assignment") {
     assert.equal(result.agentId, "agent1");

--- a/tests/mention-router.test.ts
+++ b/tests/mention-router.test.ts
@@ -185,3 +185,28 @@ test("empty_assignment: @all mixed with explicit empty assignment blocks", () =>
     assert.equal(result.agentId, "agent1");
   }
 });
+
+test("empty_assignment: @all: alone with no content blocks", () => {
+  const result = routeMention("@all:", agents);
+  assert.equal(result.kind, "empty_assignment");
+  if (result.kind === "empty_assignment") {
+    assert.equal(result.agentId, "all");
+    assert.ok(result.message.includes("@all"));
+  }
+});
+
+test("empty_assignment: @all: with only whitespace blocks", () => {
+  const result = routeMention("@all:   ", agents);
+  assert.equal(result.kind, "empty_assignment");
+  if (result.kind === "empty_assignment") {
+    assert.equal(result.agentId, "all");
+  }
+});
+
+test("empty_assignment: @all: with only unknown mentions blocks", () => {
+  const result = routeMention("@all: @unknown: @fake:", agents);
+  assert.equal(result.kind, "empty_assignment");
+  if (result.kind === "empty_assignment") {
+    assert.equal(result.agentId, "all");
+  }
+});

--- a/tests/mention-router.test.ts
+++ b/tests/mention-router.test.ts
@@ -60,11 +60,71 @@ test("unknown: known assignments still route when ordinary text contains unknown
   }
 });
 
-test("all_unsupported: @all colon assignment returns unsupported message", () => {
+test("@all: expands to all available agents", () => {
   const result = routeMention("@all: summarize project", agents);
-  assert.equal(result.kind, "all_unsupported");
-  if (result.kind === "all_unsupported") {
-    assert.ok(result.message.includes("does not support @all"));
+  assert.equal(result.kind, "assignments");
+  if (result.kind === "assignments") {
+    assert.deepEqual(result.agentIds, ["agent1", "agent2"]);
+  }
+});
+
+test("@all：with Chinese colon expands to all available agents", () => {
+  const result = routeMention("@all：总结这个项目", agents);
+  assert.equal(result.kind, "assignments");
+  if (result.kind === "assignments") {
+    assert.deepEqual(result.agentIds, ["agent1", "agent2"]);
+  }
+});
+
+test("@all: mixed with specific agents deduplicates", () => {
+  const content = "@all: review everything; @agent1: focus on docs";
+  const result = routeMention(content, agents);
+  assert.equal(result.kind, "assignments");
+  if (result.kind === "assignments") {
+    assert.deepEqual(result.agentIds, ["agent1", "agent2"]);
+    assert.equal(result.prompt, content);
+  }
+});
+
+test("@all: from agent excludes self", () => {
+  const result = routeMention("@all: everyone help", agents, "agent1");
+  assert.equal(result.kind, "assignments");
+  if (result.kind === "assignments") {
+    assert.deepEqual(result.agentIds, ["agent2"]);
+  }
+});
+
+test("@all: with no other agents returns none", () => {
+  const result = routeMention("@all: help", agents, "agent1");
+  // agent1 is the sender, only 2 agents total -> only agent2 left
+  assert.equal(result.kind, "assignments");
+  if (result.kind === "assignments") {
+    assert.deepEqual(result.agentIds, ["agent2"]);
+  }
+});
+
+test("@all: with single agent who is sender returns none", () => {
+  const singleAgent = ["agent1"] as const;
+  const result = routeMention("@all: do it", singleAgent, "agent1");
+  assert.equal(result.kind, "none");
+});
+
+test("unknown @xx: is silently ignored without error", () => {
+  const result = routeMention("@nonexistent: do something", agents);
+  assert.equal(result.kind, "none");
+  if (result.kind === "none") {
+    assert.ok(result.message.includes("@agent1:"));
+    assert.ok(result.message.includes("@agent2:"));
+  }
+});
+
+test("unknown @xx: mixed with known assignment still routes", () => {
+  const content = "@agent1: do work @unknown: ignored part";
+  const result = routeMention(content, agents);
+  assert.equal(result.kind, "assignments");
+  if (result.kind === "assignments") {
+    assert.deepEqual(result.agentIds, ["agent1"]);
+    assert.equal(result.prompt, content);
   }
 });
 


### PR DESCRIPTION
## Summary

Implements #27 — Support `@all:` assignment and gracefully ignore unknown `@xx:` mentions.

### Changes

**`src/core/mention-router.ts`**
- `@all:` and `@all：` (Chinese colon) now expand to all registered agents
- Sender is excluded from `@all:` expansion (no self-assignment)
- Deduplication when `@all:` is mixed with specific `@agent:` mentions
- Unknown `@xx:` markers are silently filtered out (no blocking)
- Removed `all_unsupported` and `unknown` result kinds

**`src/core/channel-router.ts`**
- Removed `all_unsupported` and `unknown` switch cases (no longer produced)

### Tests Added

- `@all:` expands to all available agents
- `@all：` with Chinese colon works
- `@all:` mixed with specific agents deduplicates
- `@all:` from agent excludes self
- `@all:` with single agent who is sender returns `none`
- Unknown `@xx:` silently ignored with hint message
- Unknown `@xx:` mixed with known assignment still routes
- Channel-router: `@all:` routes to all agents
- Channel-router: `@all:` from agent excludes self
- Channel-router: unknown `@xx:` from user silently ignored

### Verification

```
npm run test   → 190 tests pass, 0 fail
npm run build  → ✓ built in 270ms
```

Closes #27