### PR TITLE
feat: workspace and conversation management MVP (#22, #23)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Port is configurable via `ORBIT_PORT` env var (default 4317).
 
 ## Architecture Overview
 
-Orbit is a local-first chat control surface that coordinates multiple Claude Code CLI agents in one shared channel. Users type messages with `@agent:` assignment syntax; the system routes tasks to agents, manages run queues, and streams results to a React UI via SSE.
+Orbit is a local-first chat control surface that coordinates multiple Claude Code CLI agents in one shared conversation. Users type messages with `@agent:` assignment syntax; the system routes tasks to agents, manages run queues, and streams results to a React UI via SSE.
 
 ### Tech Stack
 
@@ -55,9 +55,9 @@ Orbit is a local-first chat control surface that coordinates multiple Claude Cod
 
 ```
 User message (POST /api/messages)
-  → ChannelRouter → mention-router (parses @agent: markers)
+  → MessageRouter → mention-router (parses @agent: markers)
     → RunManager (per-agent serial queue)
-      → AgentSession → buildChannelContext() → claude CLI (stream-json)
+      → AgentSession → buildAgentContext() → claude CLI (stream-json)
         → EventBus → SseHub → browser (EventSource)
         → RunManager classifies activities (tool.started, etc.)
           → on completion: next queued run starts, agent replies can trigger further routing
@@ -68,16 +68,17 @@ Agent replies can contain `@other_agent:` assignments, enabling delegation chain
 ### Key Modules
 
 - **`src/server/index.ts`** — Composition root: wires all components, HTTP routes, starts server
+- **`src/server/conversation-context.ts`** — Per-conversation context (messages, agents, run manager, message router)
 - **`src/shared/types.ts`** — All shared type definitions for the system
-- **`src/core/channel-router.ts`** + **`mention-router.ts`** — Message routing and @mention parsing
+- **`src/core/message-router.ts`** + **`mention-router.ts`** — Message routing and @mention parsing
 - **`src/core/run-manager.ts`** — Per-agent FIFO run queue, lifecycle events, activity classification
 - **`src/core/claude-cli-runtime.ts`** — Spawns `claude --print --output-format stream-json`, parses stdout
 - **`src/core/codex-cli-runtime.ts`** — Spawns Codex CLI in JSONL mode, parses output
 - **`src/core/codebuddy-cli-runtime.ts`** — Spawns CodeBuddy CLI in stream-json mode, parses output
 - **`src/core/agent-runtime.ts`** — Shared runtime interface for all CLI adapters
 - **`src/core/agent-config-store.ts`** — Persistent agent configuration (load/save/reset via JSON file)
-- **`src/core/channel-context-builder.ts`** — Builds private system prompt injected into each Claude run
-- **`src/core/channel-history.ts`** — Builds scoped channel history (messages since agent's last completed run)
+- **`src/core/agent-context-builder.ts`** — Builds private system prompt injected into each agent run
+- **`src/core/agent-history-builder.ts`** — Builds scoped conversation history (messages since agent's last completed run)
 - **`src/core/session-store.ts`** — Per-agent session persistence for `--resume`
 - **`src/core/agent-profiles.ts`** — Four built-in agent profiles (pm, architect, developer, tester)
 - **`src/core/agent-session.ts`** — Manages one agent's lifecycle (idle/running/error/stopped)
@@ -86,9 +87,11 @@ Agent replies can contain `@other_agent:` assignments, enabling delegation chain
 - **`src/core/event-bus.ts`** — Typed pub/sub event bus for runtime events
 - **`src/core/terminal-transcript-store.ts`** — Per-agent terminal output logging with ANSI stripping
 - **`src/core/workspace-store.ts`** — Workspace resolution and metadata (path-based isolation)
+- **`src/core/conversation-store.ts`** — Conversation CRUD and metadata
 - **`src/core/claude-output-detector.ts`** — Detects tool.started/completed/failed from Claude stream events
 - **`src/core/ansi-text-extractor.ts`** — Strips ANSI codes and extracts readable text
 - **`src/core/agent-prompt.ts`** — Prompt templates for agent role instructions
+- **`src/core/migrate-channel-layer.ts`** — One-time migration for flattening legacy directory structure
 
 ### UI Module
 
@@ -116,6 +119,16 @@ The developer agent creates feature branches, commits, pushes, and opens draft P
 | GET | `/api/agents` | List agent configurations |
 | PUT | `/api/agents` | Update agent configurations |
 | POST | `/api/agents/reset` | Reset agents to default configuration |
+| GET | `/api/workspaces` | List workspaces |
+| POST | `/api/workspaces` | Create workspace |
+| PUT | `/api/workspaces/:id` | Update workspace |
+| DELETE | `/api/workspaces/:id` | Delete workspace |
+| POST | `/api/workspaces/:id/switch` | Switch active workspace |
+| GET | `/api/workspaces/:id/conversations` | List conversations for a workspace |
+| POST | `/api/conversations` | Create conversation |
+| PUT | `/api/conversations/:id` | Update conversation |
+| DELETE | `/api/conversations/:id` | Delete conversation |
+| POST | `/api/conversations/:id/switch` | Switch active conversation |
 | GET | `/events` | SSE stream of all runtime events |
 | GET | `/*` | Static files from `dist/ui/` |
 
@@ -124,7 +137,19 @@ The developer agent creates feature branches, commits, pushes, and opens draft P
 - **EventBus pub/sub**: `SseHub`, `TerminalTranscriptStore`, and `RunManager` all subscribe to `RuntimeEvent` variants on a shared bus
 - **Per-agent serial queue**: Each agent runs one CLI process at a time; additional tasks queue automatically
 - **Private context injection**: Each agent prompt is wrapped with a private routing context block; leaked markers are stripped from replies
-- **In-memory state**: All state (messages, agent statuses, queued runs) lives in memory with no persistence layer
+- **Multi-conversation parallel**: Multiple conversations can run agents simultaneously via a context map with LRU eviction
+- **In-memory state**: Messages and agent state live in memory per conversation context; file-based persistence for messages, sessions, and transcripts
+
+### Data Directory Structure
+
+```
+~/.orbit/
+├── conversations/{workspaceId}/{conversationId}/messages.json
+├── conversations/{workspaceId}/conversations.json
+├── transcripts/{workspaceId}/{conversationId}/{agentId}.log
+├── sessions/{workspaceId}/{runtime}/{conversationId}/{agentId}.json
+└── workspaces/{workspaceId}/workspace.json
+```
 
 ### UI Design System ("Warm Observatory")
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,12 +41,14 @@ The runtime no longer uses PTY sessions or CLI hooks. A run is considered comple
 | `src/core/mention-router.ts` | Parses `@agent:` assignment markers |
 | `src/core/channel-context-builder.ts` | Builds private context passed into each agent run |
 | `src/core/channel-history.ts` | Builds scoped channel history for each agent run |
+| `src/core/conversation-store.ts` | Conversation metadata persistence per workspace |
 | `src/core/message-store.ts` | Workspace-persisted channel messages |
 | `src/core/session-store.ts` | Per-agent session persistence for `--resume` |
-| `src/core/workspace-store.ts` | Workspace isolation and user directory persistence |
+| `src/core/workspace-store.ts` | Workspace CRUD, isolation, and user directory persistence |
 | `src/core/terminal-transcript-store.ts` | Workspace-persisted runtime activity transcripts |
 | `src/core/claude-output-detector.ts` | Clean final answer validation and stream event mapping |
-| `src/ui/App.tsx` | Chat UI, agent buttons, composer, markdown, activity panel |
+| `src/server/conversation-context.ts` | Bundles per-conversation runtime state (stores, agents, router) |
+| `src/ui/App.tsx` | Chat UI, agent buttons, composer, workspace/conversation selectors |
 
 ## Agents
 
@@ -129,12 +131,23 @@ Each project directory gets its own isolated workspace via `src/core/workspace-s
 - **Workspace ID**: deterministic 12-char hex derived from the project's absolute cwd using SHA-256. On Windows the path is lowercased before hashing to handle case-insensitive filesystems; on Linux/macOS the original case is preserved.
 - **Data directory**: `~/.orbit/` organized by data type, with workspace as an isolation dimension:
   - `workspaces/<workspace-id>/workspace.json` — metadata (id, name, path, createdAt, lastOpenedAt)
+  - `workspaces/<workspace-id>/agents.json` — per-workspace agent configurations (`AgentConfigStore`)
   - `sessions/<workspace-id>/<runtime>/<channelId>/<conversationId>/<agentId>.json` — per-agent session records (`SessionStore`)
   - `channels/<workspace-id>/<channelId>/<conversationId>/messages.json` — persisted channel messages (`MessageStore`)
+  - `channels/<workspace-id>/<channelId>/conversations.json` — conversation metadata (`ConversationStore`)
   - `transcripts/<workspace-id>/<channelId>/<conversationId>/<agentId>.log` — per-agent terminal transcripts (`TerminalTranscriptStore`)
-- **Lifecycle**: on startup, the server calls `WorkspaceStore.resolve(cwd)` which creates the workspace directory and metadata on first run, or updates `lastOpenedAt` on subsequent runs.
+  - `last-active.json` — last active workspace and conversation for restart recovery
+- **Lifecycle**: on startup, the server checks `last-active.json` for the previously active workspace/conversation, falling back to `WorkspaceStore.resolve(cwd)` for first-run. Switching is blocked while agents are running.
 
-The current implementation does not migrate data from the legacy `.orbit/` directory inside the project. Old session data there is ignored once this version is active.
+## Workspace & Conversation Management
+
+The server maintains a single active context at a time, managed through `src/server/conversation-context.ts`:
+
+- **ConversationContext**: bundles per-conversation runtime state (MessageStore, TerminalTranscriptStore, AgentRegistry, RunManager, ChannelRouter). Created when switching workspace or conversation, disposed on the next switch.
+- **WorkspaceStore CRUD**: list, create, update, delete workspaces. Deleting a workspace removes all associated sessions, channels, and transcripts.
+- **ConversationStore**: manages conversation metadata per workspace stored in `channels/<workspaceId>/default/conversations.json`. Auto-migrates existing "default" conversations on first load.
+- **Switch protection**: switching workspace or conversation is blocked while any agent is running (409 response).
+- **Delete protection**: cannot delete the active workspace or conversation.
 
 Codex uses the user's normal Codex CLI home. Orbit does not create per-agent `CODEX_HOME` directories; agent-level continuity is handled by the session store above, which passes each agent's own saved session ID back to the runtime on the next run.
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "tsx src/server/index.ts",
     "build": "tsc --noEmit && vite build",
-    "test": "node --test --import tsx tests/mention-router.test.ts tests/message-store.test.ts tests/channel-router.test.ts tests/ansi-text-extractor.test.ts tests/terminal-transcript-store.test.ts tests/claude-output-detector.test.ts tests/claude-cli-runtime.test.ts tests/codex-cli-runtime.test.ts tests/codebuddy-cli-runtime.test.ts tests/agent-profiles.test.ts tests/agent-registry.test.ts tests/channel-context-builder.test.ts tests/channel-history.test.ts tests/run-manager.test.ts tests/session-store.test.ts tests/agent-session.test.ts tests/workspace-store.test.ts tests/conversation-store.test.ts tests/markdown-renderer.test.ts tests/agent-config-store.test.ts",
+    "test": "node --test --import tsx tests/mention-router.test.ts tests/message-store.test.ts tests/message-router.test.ts tests/ansi-text-extractor.test.ts tests/terminal-transcript-store.test.ts tests/claude-output-detector.test.ts tests/claude-cli-runtime.test.ts tests/codex-cli-runtime.test.ts tests/codebuddy-cli-runtime.test.ts tests/agent-profiles.test.ts tests/agent-registry.test.ts tests/agent-context-builder.test.ts tests/agent-history-builder.test.ts tests/run-manager.test.ts tests/session-store.test.ts tests/agent-session.test.ts tests/workspace-store.test.ts tests/conversation-store.test.ts tests/markdown-renderer.test.ts tests/agent-config-store.test.ts",
     "test:glob": "node --test --import tsx tests/*.test.ts"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "tsx src/server/index.ts",
     "build": "tsc --noEmit && vite build",
-    "test": "node --test --import tsx tests/mention-router.test.ts tests/message-store.test.ts tests/channel-router.test.ts tests/ansi-text-extractor.test.ts tests/terminal-transcript-store.test.ts tests/claude-output-detector.test.ts tests/claude-cli-runtime.test.ts tests/codex-cli-runtime.test.ts tests/codebuddy-cli-runtime.test.ts tests/agent-profiles.test.ts tests/agent-registry.test.ts tests/channel-context-builder.test.ts tests/channel-history.test.ts tests/run-manager.test.ts tests/session-store.test.ts tests/agent-session.test.ts tests/workspace-store.test.ts tests/markdown-renderer.test.ts tests/agent-config-store.test.ts",
+    "test": "node --test --import tsx tests/mention-router.test.ts tests/message-store.test.ts tests/channel-router.test.ts tests/ansi-text-extractor.test.ts tests/terminal-transcript-store.test.ts tests/claude-output-detector.test.ts tests/claude-cli-runtime.test.ts tests/codex-cli-runtime.test.ts tests/codebuddy-cli-runtime.test.ts tests/agent-profiles.test.ts tests/agent-registry.test.ts tests/channel-context-builder.test.ts tests/channel-history.test.ts tests/run-manager.test.ts tests/session-store.test.ts tests/agent-session.test.ts tests/workspace-store.test.ts tests/conversation-store.test.ts tests/markdown-renderer.test.ts tests/agent-config-store.test.ts",
     "test:glob": "node --test --import tsx tests/*.test.ts"
   },
   "dependencies": {

--- a/src/core/agent-config-store.ts
+++ b/src/core/agent-config-store.ts
@@ -19,7 +19,7 @@ export const DEFAULT_AGENT_CONFIGS: AgentConfig[] = [
     runtime: "codex",
     systemPrompt:
       "You are Orbit's product manager. Clarify requirements, define scope, acceptance criteria, and review whether implementation matches user needs. Do not edit code unless explicitly assigned.",
-    enabled: true,
+    enabled: false,
   },
   {
     id: "architect",
@@ -29,7 +29,7 @@ export const DEFAULT_AGENT_CONFIGS: AgentConfig[] = [
     runtime: "codex",
     systemPrompt:
       "You are Orbit's architect. Design technical boundaries, module responsibilities, migration plans, and review implementation risk. Prefer scoped, testable changes.",
-    enabled: true,
+    enabled: false,
   },
   {
     id: "developer",
@@ -39,7 +39,7 @@ export const DEFAULT_AGENT_CONFIGS: AgentConfig[] = [
     runtime: "claude-code",
     systemPrompt:
       "You are Orbit's developer. Follow strict TDD: write failing tests first, then implement the minimal code to pass them. Before writing any code, always create a feature branch from main (e.g. feat/issue-N-description). Run npm run test && npm run build after each meaningful change. Commit, push, and open a draft PR. Never commit directly to main.",
-    enabled: true,
+    enabled: false,
   },
   {
     id: "tester",
@@ -49,7 +49,7 @@ export const DEFAULT_AGENT_CONFIGS: AgentConfig[] = [
     runtime: "codebuddy",
     systemPrompt:
       "You are Orbit's tester. Validate behavior, run tests, inspect regressions, and report risks. Do not modify production code unless explicitly assigned.",
-    enabled: true,
+    enabled: false,
   },
 ];
 
@@ -114,10 +114,6 @@ export function validateAgentConfigs(configs: AgentConfig[]): string[] {
         errors.push(`Agent "${config.id}" permissionProfile.allowedDirectories must be non-empty.`);
       }
     }
-  }
-
-  if (!configs.some((c) => c && typeof c === "object" && c.enabled)) {
-    errors.push("At least one agent must be enabled.");
   }
 
   return errors;

--- a/src/core/agent-context-builder.ts
+++ b/src/core/agent-context-builder.ts
@@ -1,25 +1,25 @@
 import type { AgentId, AgentProfile } from "../shared/types.ts";
 
-export type ChannelHistoryEntry = {
+export type AgentHistoryEntry = {
   sender: string;
   content: string;
 };
 
-export type ChannelContextInput = {
+export type AgentContextInput = {
   agentId: AgentId;
   profiles: readonly AgentProfile[];
-  channelMessage: string;
-  history?: ChannelHistoryEntry[];
+  agentMessage: string;
+  history?: AgentHistoryEntry[];
 };
 
-function renderHistory(entries: ChannelHistoryEntry[]): string[] {
+function renderHistory(entries: AgentHistoryEntry[]): string[] {
   return [
-    "[Channel history]",
+    "[Conversation history]",
     ...entries.map((entry) => `[${entry.sender}]: ${entry.content}`),
   ];
 }
 
-export function buildChannelContext(input: ChannelContextInput): string {
+export function buildAgentContext(input: AgentContextInput): string {
   const profile = input.profiles.find((agent) => agent.id === input.agentId);
   const availableAgents = input.profiles.map((agent) => {
     const desc = agent.description ? ` — ${agent.description}` : "";
@@ -49,10 +49,10 @@ export function buildChannelContext(input: ChannelContextInput): string {
     "",
     "Collaboration rules:",
     "- Execute only the assignment addressed to your own @agent: marker.",
-    "- The full channel message may contain assignments for multiple agents. Orbit has already scheduled the other agents.",
-    "- Use other agents' assignments as shared context, not as your own work, and do not repeat or forward assignments that already exist in the same channel message.",
+    "- The conversation may contain assignments for multiple agents. Orbit has already scheduled the other agents.",
+    "- Use other agents' assignments as shared context, not as your own work, and do not repeat or forward assignments that already exist in the same conversation.",
     "- Plain @agent mentions without a colon are references only.",
-    "- Only create a new @agent: assignment when it is genuinely new follow-up work that is not already present in the full channel message.",
+    "- Only create a new @agent: assignment when it is genuinely new follow-up work that is not already present in the conversation.",
     "- If you need another agent to continue, use that agent's @agent: assignment marker with a clear task.",
     "",
     "Collaboration examples:",
@@ -76,13 +76,13 @@ export function buildChannelContext(input: ChannelContextInput): string {
     "",
     "Final answer rules:",
     "- Return only your useful result, question, or concise status.",
-    "- Do not start by repeating the full channel message, the private context, or your own @agent: assignment marker.",
+    "- Do not start by repeating the conversation, the private context, or your own @agent: assignment marker.",
     "- Do not include terminal UI noise, hook output, API errors, or thinking/status text.",
     "- If the task is complete, provide a concise final answer and stop.",
     "",
     ...(input.history?.length ? [...renderHistory(input.history), ""] : []),
-    "[Full channel message]",
-    input.channelMessage,
+    "[Current task]",
+    input.agentMessage,
   ]
     .filter((line) => line !== "")
     .join("\n");

--- a/src/core/agent-history-builder.ts
+++ b/src/core/agent-history-builder.ts
@@ -1,5 +1,5 @@
 import type { AgentId, ChatMessage } from "../shared/types.ts";
-import type { ChannelHistoryEntry } from "./channel-context-builder.ts";
+import type { AgentHistoryEntry } from "./agent-context-builder.ts";
 
 const MAX_HISTORY_CHARS = 12000;
 const RECENT_UNTRUNCATED_COUNT = 6;
@@ -7,7 +7,7 @@ const OLDER_ENTRY_MAX_CHARS = 500;
 
 export { MAX_HISTORY_CHARS, OLDER_ENTRY_MAX_CHARS, RECENT_UNTRUNCATED_COUNT };
 
-export function buildHistoryForAgent(agentId: AgentId, allMessages: ChatMessage[]): ChannelHistoryEntry[] {
+export function buildHistoryForAgent(agentId: AgentId, allMessages: ChatMessage[]): AgentHistoryEntry[] {
   let cutoffIndex = -1;
   for (let i = allMessages.length - 1; i >= 0; i--) {
     const msg = allMessages[i];
@@ -36,7 +36,7 @@ export function buildHistoryForAgent(agentId: AgentId, allMessages: ChatMessage[
 
   // Phase 1: Reserve budget for recent entries (newest → oldest within recent)
   // These are the most critical — user assignments, latest agent feedback.
-  const recentEntries: ChannelHistoryEntry[] = [];
+  const recentEntries: AgentHistoryEntry[] = [];
   let recentChars = 0;
   for (let i = recent.length - 1; i >= 0; i--) {
     const msg = recent[i];
@@ -48,7 +48,7 @@ export function buildHistoryForAgent(agentId: AgentId, allMessages: ChatMessage[
 
   // Phase 2: Fill remaining budget with older entries (newest → oldest)
   const remainingBudget = MAX_HISTORY_CHARS - recentChars;
-  const olderEntries: ChannelHistoryEntry[] = [];
+  const olderEntries: AgentHistoryEntry[] = [];
   let olderChars = 0;
   for (let i = older.length - 1; i >= 0; i--) {
     const msg = older[i];

--- a/src/core/agent-registry.ts
+++ b/src/core/agent-registry.ts
@@ -20,7 +20,6 @@ export class AgentRegistry {
     private readonly profiles: readonly AgentProfile[],
     eventBus: EventBus,
     sessionStore: SessionStore,
-    channelId: string,
     conversationId: string,
     runtimes: ReadonlyMap<AgentRuntime["kind"], AgentRuntime> = DEFAULT_RUNTIMES,
   ) {
@@ -40,7 +39,6 @@ export class AgentRegistry {
           runtime,
           eventBus,
           sessionStore,
-          channelId,
           conversationId,
         }),
       );

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -120,6 +120,7 @@ export class AgentSession {
       onOutput: (text) => {
         this.options.eventBus.publish({
           type: "terminal.chunk",
+          conversationId: this.options.conversationId,
           agentId: this.id,
           runId,
           text,
@@ -132,6 +133,7 @@ export class AgentSession {
       if (sessionId && this.activeRun?.runId === runId) {
         this.options.eventBus.publish({
           type: "run.sessionId",
+          conversationId: this.options.conversationId,
           agentId: this.id,
           runId,
           sessionId,
@@ -183,6 +185,7 @@ export class AgentSession {
     this.status = status;
     this.options.eventBus.publish({
       type: "agent.status",
+      conversationId: this.options.conversationId,
       agentId: this.id,
       status,
     });

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -14,7 +14,6 @@ export type AgentSessionOptions = {
   eventBus: EventBus;
   quietWindowMs?: number;
   sessionStore: SessionStore;
-  channelId: string;
   conversationId: string;
 };
 
@@ -58,14 +57,14 @@ export class AgentSession {
     this.setStatus("running");
 
     const existingSession = this.options.sessionStore.load(
-      this.options.runtime.kind, this.options.channelId, this.options.conversationId, this.id,
+      this.options.runtime.kind, this.options.conversationId, this.id,
     );
 
     return this.executeRun(runId, prompt, runIndex, existingSession?.sessionId ?? undefined)
       .catch((error: unknown) => {
         if (this.isResumeFailure(error, existingSession)) {
           this.options.sessionStore.clear(
-            this.options.runtime.kind, this.options.channelId, this.options.conversationId, this.id,
+            this.options.runtime.kind, this.options.conversationId, this.id,
           );
           return this.executeRun(runId, prompt, runIndex, undefined);
         }
@@ -165,11 +164,10 @@ export class AgentSession {
 
   private persistSession(sessionId: string): void {
     const prev = this.options.sessionStore.load(
-      this.options.runtime.kind, this.options.channelId, this.options.conversationId, this.id,
+      this.options.runtime.kind, this.options.conversationId, this.id,
     );
-    this.options.sessionStore.save(this.options.runtime.kind, this.options.channelId, this.options.conversationId, this.id, {
+    this.options.sessionStore.save(this.options.runtime.kind, this.options.conversationId, this.id, {
       agentId: this.id,
-      channelId: this.options.channelId,
       runtime: this.options.runtime.kind,
       sessionId,
       lastRunAt: new Date().toISOString(),

--- a/src/core/conversation-store.ts
+++ b/src/core/conversation-store.ts
@@ -65,6 +65,9 @@ export class ConversationStore {
     }
     data.conversations.splice(index, 1);
     this.saveData(workspaceId, data);
+
+    // Clean up data directories for this conversation
+    this.cleanupConversationData(workspaceId, conversationId);
   }
 
   touchLastOpened(workspaceId: string, conversationId: string): void {
@@ -97,6 +100,36 @@ export class ConversationStore {
 
   private filePath(workspaceId: string): string {
     return path.join(this.baseDir, "channels", workspaceId, "default", "conversations.json");
+  }
+
+  private cleanupConversationData(workspaceId: string, conversationId: string): void {
+    // Remove channels data (messages)
+    const channelsDir = path.join(this.baseDir, "channels", workspaceId, "default", conversationId);
+    this.rmDir(channelsDir);
+
+    // Remove transcripts
+    const transcriptsDir = path.join(this.baseDir, "transcripts", workspaceId, "default", conversationId);
+    this.rmDir(transcriptsDir);
+
+    // Remove sessions for all runtimes under this workspace/channel/conversation
+    const sessionsBase = path.join(this.baseDir, "sessions", workspaceId);
+    try {
+      const runtimeDirs = fs.readdirSync(sessionsBase);
+      for (const runtime of runtimeDirs) {
+        const convSessionsDir = path.join(sessionsBase, runtime, "default", conversationId);
+        this.rmDir(convSessionsDir);
+      }
+    } catch {
+      // sessions dir may not exist
+    }
+  }
+
+  private rmDir(dirPath: string): void {
+    try {
+      fs.rmSync(dirPath, { recursive: true, force: true });
+    } catch {
+      // best effort — directory may not exist
+    }
   }
 
   private loadData(workspaceId: string): ConversationData {

--- a/src/core/conversation-store.ts
+++ b/src/core/conversation-store.ts
@@ -79,24 +79,24 @@ export class ConversationStore {
   }
 
   private filePath(workspaceId: string): string {
-    return path.join(this.baseDir, "channels", workspaceId, "default", "conversations.json");
+    return path.join(this.baseDir, "conversations", workspaceId, "conversations.json");
   }
 
   private cleanupConversationData(workspaceId: string, conversationId: string): void {
     // Remove channels data (messages)
-    const channelsDir = path.join(this.baseDir, "channels", workspaceId, "default", conversationId);
+    const channelsDir = path.join(this.baseDir, "conversations", workspaceId, conversationId);
     this.rmDir(channelsDir);
 
     // Remove transcripts
-    const transcriptsDir = path.join(this.baseDir, "transcripts", workspaceId, "default", conversationId);
+    const transcriptsDir = path.join(this.baseDir, "transcripts", workspaceId, conversationId);
     this.rmDir(transcriptsDir);
 
-    // Remove sessions for all runtimes under this workspace/channel/conversation
+    // Remove sessions for all runtimes under this workspace/conversation
     const sessionsBase = path.join(this.baseDir, "sessions", workspaceId);
     try {
       const runtimeDirs = fs.readdirSync(sessionsBase);
       for (const runtime of runtimeDirs) {
-        const convSessionsDir = path.join(sessionsBase, runtime, "default", conversationId);
+        const convSessionsDir = path.join(sessionsBase, runtime, conversationId);
         this.rmDir(convSessionsDir);
       }
     } catch {

--- a/src/core/conversation-store.ts
+++ b/src/core/conversation-store.ts
@@ -78,25 +78,6 @@ export class ConversationStore {
     this.saveData(workspaceId, data);
   }
 
-  ensureDefault(workspaceId: string): Conversation {
-    const data = this.loadData(workspaceId);
-    // If a "default" conversation already exists, return it
-    const existing = data.conversations.find((c) => c.id === "default");
-    if (existing) return existing;
-
-    const now = new Date().toISOString();
-    const defaultConv: Conversation = {
-      id: "default",
-      workspaceId,
-      name: "Default",
-      createdAt: now,
-      lastOpenedAt: now,
-    };
-    data.conversations.push(defaultConv);
-    this.saveData(workspaceId, data);
-    return defaultConv;
-  }
-
   private filePath(workspaceId: string): string {
     return path.join(this.baseDir, "channels", workspaceId, "default", "conversations.json");
   }

--- a/src/core/conversation-store.ts
+++ b/src/core/conversation-store.ts
@@ -80,11 +80,10 @@ export class ConversationStore {
 
   ensureDefault(workspaceId: string): Conversation {
     const data = this.loadData(workspaceId);
-    if (data.conversations.length > 0) {
-      return data.conversations.reduce((a, b) =>
-        a.lastOpenedAt > b.lastOpenedAt ? a : b,
-      );
-    }
+    // If a "default" conversation already exists, return it
+    const existing = data.conversations.find((c) => c.id === "default");
+    if (existing) return existing;
+
     const now = new Date().toISOString();
     const defaultConv: Conversation = {
       id: "default",

--- a/src/core/conversation-store.ts
+++ b/src/core/conversation-store.ts
@@ -1,0 +1,119 @@
+import fs from "node:fs";
+import crypto from "node:crypto";
+import os from "node:os";
+import path from "node:path";
+
+import type { Conversation } from "../shared/types.ts";
+
+type ConversationData = {
+  conversations: Conversation[];
+};
+
+export class ConversationStore {
+  private readonly baseDir: string;
+
+  constructor(baseDir?: string) {
+    this.baseDir = baseDir ?? path.join(os.homedir(), ".orbit");
+  }
+
+  list(workspaceId: string): Conversation[] {
+    const data = this.loadData(workspaceId);
+    const sorted = [...data.conversations];
+    sorted.sort((a, b) => b.lastOpenedAt.localeCompare(a.lastOpenedAt));
+    return sorted;
+  }
+
+  get(workspaceId: string, conversationId: string): Conversation | null {
+    const data = this.loadData(workspaceId);
+    return data.conversations.find((c) => c.id === conversationId) ?? null;
+  }
+
+  create(workspaceId: string, name: string): Conversation {
+    const data = this.loadData(workspaceId);
+    const now = new Date().toISOString();
+    const conversation: Conversation = {
+      id: `conv_${Date.now().toString(36)}_${crypto.randomBytes(2).toString("hex")}`,
+      workspaceId,
+      name,
+      createdAt: now,
+      lastOpenedAt: now,
+    };
+    data.conversations.push(conversation);
+    this.saveData(workspaceId, data);
+    return conversation;
+  }
+
+  update(workspaceId: string, conversationId: string, patch: { name?: string }): Conversation {
+    const data = this.loadData(workspaceId);
+    const index = data.conversations.findIndex((c) => c.id === conversationId);
+    if (index === -1) {
+      throw new Error(`Conversation not found: ${conversationId}`);
+    }
+    data.conversations[index] = {
+      ...data.conversations[index]!,
+      ...(patch.name !== undefined ? { name: patch.name } : {}),
+    };
+    this.saveData(workspaceId, data);
+    return data.conversations[index]!;
+  }
+
+  delete(workspaceId: string, conversationId: string): void {
+    const data = this.loadData(workspaceId);
+    const index = data.conversations.findIndex((c) => c.id === conversationId);
+    if (index === -1) {
+      throw new Error(`Conversation not found: ${conversationId}`);
+    }
+    data.conversations.splice(index, 1);
+    this.saveData(workspaceId, data);
+  }
+
+  touchLastOpened(workspaceId: string, conversationId: string): void {
+    const data = this.loadData(workspaceId);
+    const conv = data.conversations.find((c) => c.id === conversationId);
+    if (!conv) return;
+    conv.lastOpenedAt = new Date().toISOString();
+    this.saveData(workspaceId, data);
+  }
+
+  ensureDefault(workspaceId: string): Conversation {
+    const data = this.loadData(workspaceId);
+    if (data.conversations.length > 0) {
+      return data.conversations.reduce((a, b) =>
+        a.lastOpenedAt > b.lastOpenedAt ? a : b,
+      );
+    }
+    const now = new Date().toISOString();
+    const defaultConv: Conversation = {
+      id: "default",
+      workspaceId,
+      name: "Default",
+      createdAt: now,
+      lastOpenedAt: now,
+    };
+    data.conversations.push(defaultConv);
+    this.saveData(workspaceId, data);
+    return defaultConv;
+  }
+
+  private filePath(workspaceId: string): string {
+    return path.join(this.baseDir, "channels", workspaceId, "default", "conversations.json");
+  }
+
+  private loadData(workspaceId: string): ConversationData {
+    try {
+      const content = fs.readFileSync(this.filePath(workspaceId), "utf8");
+      return JSON.parse(content) as ConversationData;
+    } catch {
+      return { conversations: [] };
+    }
+  }
+
+  private saveData(workspaceId: string, data: ConversationData): void {
+    const filePath = this.filePath(workspaceId);
+    const dir = path.dirname(filePath);
+    fs.mkdirSync(dir, { recursive: true });
+    const tmpFile = filePath + ".tmp";
+    fs.writeFileSync(tmpFile, JSON.stringify(data, null, 2) + os.EOL);
+    fs.renameSync(tmpFile, filePath);
+  }
+}

--- a/src/core/message-router.ts
+++ b/src/core/message-router.ts
@@ -1,7 +1,7 @@
 import type { AgentId, ChatMessage, MessageRouteState } from "../shared/types.ts";
 import { routeMention } from "./mention-router.ts";
 
-export type ChannelRouterOptions = {
+export type MessageRouterOptions = {
   availableAgents: readonly AgentId[];
   maxRouteDepth: number;
   createSystemMessage: (content: string, parentMessageId?: string) => ChatMessage;
@@ -9,10 +9,10 @@ export type ChannelRouterOptions = {
   markMessageRouted: (messageId: string, routeState: MessageRouteState) => void;
 };
 
-export class ChannelRouter {
+export class MessageRouter {
   private processedIds = new Set<string>();
 
-  constructor(private options: ChannelRouterOptions) {}
+  constructor(private options: MessageRouterOptions) {}
 
   process(message: ChatMessage): void {
     if (this.processedIds.has(message.id)) {

--- a/src/core/migrate-channel-layer.ts
+++ b/src/core/migrate-channel-layer.ts
@@ -1,0 +1,101 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const BASE_DIR = path.join(os.homedir(), ".orbit");
+
+/**
+ * One-time migration: flatten the hardcoded "default/" directory layer
+ * and rename "channels/" to "conversations/".
+ */
+export function migrateChannelLayer(): void {
+  // 1. Flatten "default/" in sessions
+  flattenDefaultDirs(path.join(BASE_DIR, "sessions"));
+
+  // 2. Flatten "default/" in transcripts
+  flattenDefaultDirs(path.join(BASE_DIR, "transcripts"));
+
+  // 3. Flatten "default/" in channels, then rename channels → conversations
+  flattenDefaultDirs(path.join(BASE_DIR, "channels"));
+  renameDir(path.join(BASE_DIR, "channels"), path.join(BASE_DIR, "conversations"));
+}
+
+function flattenDefaultDirs(parentDir: string): void {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(parentDir);
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const entryPath = path.join(parentDir, entry);
+    if (!fs.statSync(entryPath).isDirectory()) continue;
+
+    // For sessions, there's a runtime subdirectory (e.g., "claude-code")
+    const subEntries = fs.readdirSync(entryPath);
+    for (const sub of subEntries) {
+      const subPath = path.join(entryPath, sub);
+      if (!fs.statSync(subPath).isDirectory()) continue;
+
+      const defaultDir = path.join(subPath, "default");
+      if (isDir(defaultDir)) {
+        moveChildrenUp(defaultDir, subPath);
+        rmDir(defaultDir);
+      }
+    }
+
+    // Also check for a direct "default" child (e.g., channels/{wsId}/default/)
+    const directDefault = path.join(entryPath, "default");
+    if (isDir(directDefault)) {
+      moveChildrenUp(directDefault, entryPath);
+      rmDir(directDefault);
+    }
+  }
+}
+
+function moveChildrenUp(srcDir: string, destDir: string): void {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(srcDir);
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const src = path.join(srcDir, entry);
+    const dest = path.join(destDir, entry);
+    if (fs.existsSync(dest)) continue;
+    try {
+      fs.renameSync(src, dest);
+    } catch {
+      // cross-device or other issue, skip
+    }
+  }
+}
+
+function renameDir(oldPath: string, newPath: string): void {
+  if (!isDir(oldPath)) return;
+  if (isDir(newPath)) return; // already migrated
+  try {
+    fs.renameSync(oldPath, newPath);
+  } catch {
+    // skip on failure
+  }
+}
+
+function isDir(p: string): boolean {
+  try {
+    return fs.statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function rmDir(p: string): void {
+  try {
+    fs.rmSync(p, { recursive: true, force: true });
+  } catch {
+    // best effort
+  }
+}

--- a/src/core/run-manager.ts
+++ b/src/core/run-manager.ts
@@ -31,6 +31,7 @@ export type ManagedRun = {
 };
 
 export type RunManagerOptions = {
+  conversationId: string;
   agents: AgentRunner;
   messages: MessageStore;
   eventBus: EventBus;
@@ -74,7 +75,7 @@ export class RunManager {
       routeDepth,
       activity,
     } satisfies NewChatMessage);
-    this.options.eventBus.publish({ type: "message.created", message: agentMessage });
+    this.options.eventBus.publish({ type: "message.created", conversationId: this.options.conversationId, message: agentMessage });
 
     const run: ManagedRun = {
       id: runId,
@@ -136,9 +137,10 @@ export class RunManager {
       sessionId: runResult.sessionId,
       runIndex: runResult.runIndex,
     });
-    this.options.eventBus.publish({ type: "message.updated", message: updated });
+    this.options.eventBus.publish({ type: "message.updated", conversationId: this.options.conversationId, message: updated });
     this.options.eventBus.publish({
       type: "run.completed",
+      conversationId: this.options.conversationId,
       agentId: run.agentId,
       runId: run.id,
       resultMessageId: updated.id,
@@ -163,8 +165,8 @@ export class RunManager {
       completedAt: run.completedAt,
       startedAt: run.startedAt,
     });
-    this.options.eventBus.publish({ type: "message.updated", message: updated });
-    this.options.eventBus.publish({ type: "run.failed", agentId: run.agentId, runId: run.id, error: errorSummary });
+    this.options.eventBus.publish({ type: "message.updated", conversationId: this.options.conversationId, message: updated });
+    this.options.eventBus.publish({ type: "run.failed", conversationId: this.options.conversationId, agentId: run.agentId, runId: run.id, error: errorSummary });
     this.startNext(run.agentId);
   }
 
@@ -181,7 +183,7 @@ export class RunManager {
       activity: next.activity,
       startedAt,
     });
-    this.options.eventBus.publish({ type: "message.updated", message: updated });
+    this.options.eventBus.publish({ type: "message.updated", conversationId: this.options.conversationId, message: updated });
     this.start(next);
   }
 
@@ -195,17 +197,20 @@ export class RunManager {
     this.options.messages.update(run.resultMessageId, {
       activity: run.activity,
     });
-    this.options.eventBus.publish({ type: "run.activity", agentId: run.agentId, runId: run.id, activity: run.activity[run.activity.length - 1]! });
+    this.options.eventBus.publish({ type: "run.activity", conversationId: this.options.conversationId, agentId: run.agentId, runId: run.id, activity: run.activity[run.activity.length - 1]! });
   }
 
   private handleRuntimeEvent(event: RuntimeEvent): void {
+    // Only process events for our own conversation
+    if ("conversationId" in event && event.conversationId !== this.options.conversationId) return;
+
     if (event.type === "run.sessionId" && event.runId) {
       const run = this.runs.get(event.runId);
       if (run && run.status === "running") {
         const updated = this.options.messages.update(run.resultMessageId, {
           sessionId: event.sessionId,
         });
-        this.options.eventBus.publish({ type: "message.updated", message: updated });
+        this.options.eventBus.publish({ type: "message.updated", conversationId: this.options.conversationId, message: updated });
       }
       return;
     }

--- a/src/core/run-manager.ts
+++ b/src/core/run-manager.ts
@@ -6,6 +6,7 @@ import type {
   RunResult,
   RuntimeEvent,
 } from "../shared/types.ts";
+import { randomBytes } from "node:crypto";
 import type { EventBus } from "./event-bus.ts";
 import type { MessageStore } from "./message-store.ts";
 
@@ -318,7 +319,7 @@ export class RunManager {
 }
 
 function createRunId(agentId: AgentId): string {
-  return `run_${agentId}_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+  return `run_${agentId}_${Date.now()}_${randomBytes(8).toString("hex")}`;
 }
 
 function createActivity(text: string): AgentActivityEvent {

--- a/src/core/session-store.ts
+++ b/src/core/session-store.ts
@@ -6,7 +6,6 @@ import type { AgentRuntimeKind } from "../shared/types.ts";
 
 export type SessionRecord = {
   agentId: string;
-  channelId: string;
   runtime: AgentRuntimeKind;
   sessionId: string;
   lastRunAt: string;
@@ -20,8 +19,8 @@ export class SessionStore {
     this.baseDir = baseDir ?? path.join(process.cwd(), ".orbit", "sessions");
   }
 
-  load(runtime: AgentRuntimeKind, channelId: string, conversationId: string, agentId: string): SessionRecord | null {
-    const filePath = this.filePath(runtime, channelId, conversationId, agentId);
+  load(runtime: AgentRuntimeKind, conversationId: string, agentId: string): SessionRecord | null {
+    const filePath = this.filePath(runtime, conversationId, agentId);
     try {
       const data = fs.readFileSync(filePath, "utf8");
       return JSON.parse(data) as SessionRecord;
@@ -30,8 +29,8 @@ export class SessionStore {
     }
   }
 
-  save(runtime: AgentRuntimeKind, channelId: string, conversationId: string, agentId: string, record: SessionRecord): void {
-    const filePath = this.filePath(runtime, channelId, conversationId, agentId);
+  save(runtime: AgentRuntimeKind, conversationId: string, agentId: string, record: SessionRecord): void {
+    const filePath = this.filePath(runtime, conversationId, agentId);
     const dir = path.dirname(filePath);
     fs.mkdirSync(dir, { recursive: true });
 
@@ -40,8 +39,8 @@ export class SessionStore {
     fs.renameSync(tmpFile, filePath);
   }
 
-  clear(runtime: AgentRuntimeKind, channelId: string, conversationId: string, agentId: string): void {
-    const filePath = this.filePath(runtime, channelId, conversationId, agentId);
+  clear(runtime: AgentRuntimeKind, conversationId: string, agentId: string): void {
+    const filePath = this.filePath(runtime, conversationId, agentId);
     try {
       fs.unlinkSync(filePath);
     } catch {
@@ -49,7 +48,7 @@ export class SessionStore {
     }
   }
 
-  private filePath(runtime: AgentRuntimeKind, channelId: string, conversationId: string, agentId: string): string {
-    return path.join(this.baseDir, runtime, channelId, conversationId, `${agentId}.json`);
+  private filePath(runtime: AgentRuntimeKind, conversationId: string, agentId: string): string {
+    return path.join(this.baseDir, runtime, conversationId, `${agentId}.json`);
   }
 }

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -26,7 +26,13 @@ export class WorkspaceStore {
   static deriveId(cwd: string): string {
     const resolved = path.resolve(cwd);
     const normalized = process.platform === "win32" ? resolved.toLowerCase() : resolved;
-    return crypto.createHash("sha256").update(normalized).digest("hex").slice(0, 12);
+    const hash = crypto.createHash("sha256").update(normalized).digest("hex").slice(0, 6);
+    const sanitized = normalized
+      .replace(/[^a-zA-Z0-9]/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-+/, "")
+      .replace(/-+$/, "");
+    return `${sanitized}_${hash}`;
   }
 
   resolve(cwd: string): WorkspaceInfo {

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -109,7 +109,7 @@ export class WorkspaceStore {
     const dirs = [
       path.join(this.baseDir, "workspaces", id),
       path.join(this.baseDir, "sessions", id),
-      path.join(this.baseDir, "channels", id),
+      path.join(this.baseDir, "conversations", id),
       path.join(this.baseDir, "transcripts", id),
     ];
     for (const dir of dirs) {
@@ -136,12 +136,12 @@ export class WorkspaceStore {
     return path.join(this.baseDir, "data", workspaceId);
   }
 
-  channelsDir(workspaceId: string, channelId = "default", conversationId = "default"): string {
-    return path.join(this.baseDir, "channels", workspaceId, channelId, conversationId);
+  channelsDir(workspaceId: string, conversationId: string): string {
+    return path.join(this.baseDir, "conversations", workspaceId, conversationId);
   }
 
-  transcriptsDir(workspaceId: string, channelId = "default", conversationId = "default"): string {
-    return path.join(this.baseDir, "transcripts", workspaceId, channelId, conversationId);
+  transcriptsDir(workspaceId: string, conversationId: string): string {
+    return path.join(this.baseDir, "transcripts", workspaceId, conversationId);
   }
 
   private metadataPath(id: string): string {

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -81,7 +81,9 @@ export class WorkspaceStore {
       throw new Error(`Workspace already exists for path "${dirPath}": ${existing.name} (${existing.id})`);
     }
     const now = new Date().toISOString();
-    const metadata: WorkspaceMetadata = { id, name, path: path.resolve(dirPath), createdAt: now, lastOpenedAt: now };
+    const resolvedPath = path.resolve(dirPath);
+    const workspaceName = name.trim() || path.basename(resolvedPath) || resolvedPath;
+    const metadata: WorkspaceMetadata = { id, name: workspaceName, path: resolvedPath, createdAt: now, lastOpenedAt: now };
     this.writeMetadata(id, metadata);
     return metadata;
   }

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -3,6 +3,8 @@ import crypto from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 
+import type { Workspace } from "../shared/types.ts";
+
 export type WorkspaceInfo = {
   id: string;
   name: string;
@@ -29,27 +31,99 @@ export class WorkspaceStore {
 
   resolve(cwd: string): WorkspaceInfo {
     const id = WorkspaceStore.deriveId(cwd);
-    const metadataPath = path.join(this.baseDir, "workspaces", id, "workspace.json");
+    const metadataPath = this.metadataPath(id);
 
     try {
-      const data = fs.readFileSync(metadataPath, "utf8");
-      const metadata = JSON.parse(data) as WorkspaceMetadata;
+      const metadata = this.readMetadata(id);
       const updated = { ...metadata, lastOpenedAt: new Date().toISOString() };
-      const tmpFile = metadataPath + ".tmp";
-      fs.writeFileSync(tmpFile, JSON.stringify(updated, null, 2) + os.EOL);
-      fs.renameSync(tmpFile, metadataPath);
+      this.writeMetadata(id, updated);
       return { id: metadata.id, name: metadata.name, path: metadata.path };
     } catch {
       const now = new Date().toISOString();
       const name = path.basename(cwd);
       const workspace: WorkspaceMetadata = { id, name, path: cwd, createdAt: now, lastOpenedAt: now };
-      const dir = path.dirname(metadataPath);
-      fs.mkdirSync(dir, { recursive: true });
-      const tmpFile = metadataPath + ".tmp";
-      fs.writeFileSync(tmpFile, JSON.stringify(workspace, null, 2) + os.EOL);
-      fs.renameSync(tmpFile, metadataPath);
+      this.writeMetadata(id, workspace);
       return { id, name, path: cwd };
     }
+  }
+
+  list(): Workspace[] {
+    const workspacesDir = path.join(this.baseDir, "workspaces");
+    try {
+      const entries = fs.readdirSync(workspacesDir);
+      const workspaces: Workspace[] = [];
+      for (const entry of entries) {
+        try {
+          workspaces.push(this.readMetadata(entry));
+        } catch {
+          // skip malformed workspace directories
+        }
+      }
+      workspaces.sort((a, b) => b.lastOpenedAt.localeCompare(a.lastOpenedAt));
+      return workspaces;
+    } catch {
+      return [];
+    }
+  }
+
+  get(id: string): Workspace | null {
+    try {
+      return this.readMetadata(id);
+    } catch {
+      return null;
+    }
+  }
+
+  create(name: string, dirPath: string): Workspace {
+    const id = WorkspaceStore.deriveId(dirPath);
+    const existing = this.get(id);
+    if (existing) {
+      throw new Error(`Workspace already exists for path "${dirPath}": ${existing.name} (${existing.id})`);
+    }
+    const now = new Date().toISOString();
+    const metadata: WorkspaceMetadata = { id, name, path: dirPath, createdAt: now, lastOpenedAt: now };
+    this.writeMetadata(id, metadata);
+    return metadata;
+  }
+
+  update(id: string, patch: { name?: string }): Workspace {
+    const existing = this.get(id);
+    if (!existing) {
+      throw new Error(`Workspace not found: ${id}`);
+    }
+    const updated: WorkspaceMetadata = {
+      ...existing,
+      ...(patch.name !== undefined ? { name: patch.name } : {}),
+    };
+    this.writeMetadata(id, updated);
+    return updated;
+  }
+
+  delete(id: string): void {
+    const existing = this.get(id);
+    if (!existing) {
+      throw new Error(`Workspace not found: ${id}`);
+    }
+    const dirs = [
+      path.join(this.baseDir, "workspaces", id),
+      path.join(this.baseDir, "sessions", id),
+      path.join(this.baseDir, "channels", id),
+      path.join(this.baseDir, "transcripts", id),
+    ];
+    for (const dir of dirs) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // best effort
+      }
+    }
+  }
+
+  touchLastOpened(id: string): void {
+    const existing = this.get(id);
+    if (!existing) return;
+    const updated: WorkspaceMetadata = { ...existing, lastOpenedAt: new Date().toISOString() };
+    this.writeMetadata(id, updated);
   }
 
   sessionsDir(workspaceId: string): string {
@@ -66,5 +140,22 @@ export class WorkspaceStore {
 
   transcriptsDir(workspaceId: string, channelId = "default", conversationId = "default"): string {
     return path.join(this.baseDir, "transcripts", workspaceId, channelId, conversationId);
+  }
+
+  private metadataPath(id: string): string {
+    return path.join(this.baseDir, "workspaces", id, "workspace.json");
+  }
+
+  private readMetadata(id: string): WorkspaceMetadata {
+    return JSON.parse(fs.readFileSync(this.metadataPath(id), "utf8")) as WorkspaceMetadata;
+  }
+
+  private writeMetadata(id: string, metadata: WorkspaceMetadata): void {
+    const filePath = this.metadataPath(id);
+    const dir = path.dirname(filePath);
+    fs.mkdirSync(dir, { recursive: true });
+    const tmpFile = filePath + ".tmp";
+    fs.writeFileSync(tmpFile, JSON.stringify(metadata, null, 2) + os.EOL);
+    fs.renameSync(tmpFile, filePath);
   }
 }

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -59,7 +59,7 @@ export class WorkspaceStore {
           // skip malformed workspace directories
         }
       }
-      workspaces.sort((a, b) => b.lastOpenedAt.localeCompare(a.lastOpenedAt));
+      workspaces.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
       return workspaces;
     } catch {
       return [];

--- a/src/core/workspace-store.ts
+++ b/src/core/workspace-store.ts
@@ -41,9 +41,9 @@ export class WorkspaceStore {
     } catch {
       const now = new Date().toISOString();
       const name = path.basename(cwd);
-      const workspace: WorkspaceMetadata = { id, name, path: cwd, createdAt: now, lastOpenedAt: now };
+      const workspace: WorkspaceMetadata = { id, name, path: path.resolve(cwd), createdAt: now, lastOpenedAt: now };
       this.writeMetadata(id, workspace);
-      return { id, name, path: cwd };
+      return { id, name, path: path.resolve(cwd) };
     }
   }
 
@@ -81,7 +81,7 @@ export class WorkspaceStore {
       throw new Error(`Workspace already exists for path "${dirPath}": ${existing.name} (${existing.id})`);
     }
     const now = new Date().toISOString();
-    const metadata: WorkspaceMetadata = { id, name, path: dirPath, createdAt: now, lastOpenedAt: now };
+    const metadata: WorkspaceMetadata = { id, name, path: path.resolve(dirPath), createdAt: now, lastOpenedAt: now };
     this.writeMetadata(id, metadata);
     return metadata;
   }

--- a/src/server/conversation-context.ts
+++ b/src/server/conversation-context.ts
@@ -10,7 +10,7 @@ import { SessionStore } from "../core/session-store.ts";
 import { TerminalTranscriptStore } from "../core/terminal-transcript-store.ts";
 import { WorkspaceStore } from "../core/workspace-store.ts";
 import { ChannelRouter } from "../core/channel-router.ts";
-import type { AgentId, AgentProfile, RuntimeEvent } from "../shared/types.ts";
+import type { AgentId, AgentProfile } from "../shared/types.ts";
 
 const MAX_ROUTE_DEPTH = 5;
 const CHANNEL_ID = "default";
@@ -22,7 +22,6 @@ export type ConversationContextOptions = {
   eventBus: EventBus;
   sessionStore: SessionStore;
   workspaceStore: WorkspaceStore;
-  sseHub: { publish: (event: RuntimeEvent) => void };
 };
 
 export class ConversationContext {
@@ -34,14 +33,12 @@ export class ConversationContext {
 
   private _profiles: readonly AgentProfile[];
   private readonly eventBus: EventBus;
-  private readonly sseHub: { publish: (event: RuntimeEvent) => void };
   private readonly unsubscribe: () => void;
 
   constructor(private readonly options: ConversationContextOptions) {
-    const { workspaceId, conversationId, profiles, eventBus, sessionStore, workspaceStore, sseHub } = options;
+    const { workspaceId, conversationId, profiles, eventBus, sessionStore, workspaceStore } = options;
     this._profiles = profiles;
     this.eventBus = eventBus;
-    this.sseHub = sseHub;
 
     const messagesPath = path.join(
       workspaceStore.channelsDir(workspaceId, CHANNEL_ID, conversationId),
@@ -53,11 +50,12 @@ export class ConversationContext {
     this.transcripts = new TerminalTranscriptStore(transcriptsDir);
 
     this.unsubscribe = eventBus.subscribe((event) => {
+      // Only process events belonging to this conversation
+      if ("conversationId" in event && event.conversationId !== conversationId) return;
       if ((event as { type: string }).type === "terminal.chunk") {
         const e = event as { agentId: string; text: string };
         this.transcripts.append(e.agentId, e.text);
       }
-      sseHub.publish(event);
     });
 
     this.agents = new AgentRegistry(profiles, eventBus, sessionStore, CHANNEL_ID, conversationId);
@@ -66,6 +64,7 @@ export class ConversationContext {
     const agentIds = this.agents.ids();
 
     this.runManager = new RunManager({
+      conversationId,
       agents: this.agents,
       messages: this.messages,
       eventBus,
@@ -83,7 +82,7 @@ export class ConversationContext {
       maxRouteDepth: MAX_ROUTE_DEPTH,
       createSystemMessage: (content, parentMessageId) => {
         const msg = this.messages.add({ kind: "system", content, status: "done", parentMessageId });
-        eventBus.publish({ type: "message.created", message: msg });
+        eventBus.publish({ type: "message.created", conversationId, message: msg });
         return msg;
       },
       startAgentRun: (agentId, prompt, sourceMessage) => {
@@ -114,6 +113,7 @@ export class ConversationContext {
     const self = this;
 
     const newRunManager = new RunManager({
+      conversationId,
       agents: newAgents,
       messages: this.messages,
       eventBus,
@@ -131,7 +131,7 @@ export class ConversationContext {
       maxRouteDepth: MAX_ROUTE_DEPTH,
       createSystemMessage: (content, parentMessageId) => {
         const msg = self.messages.add({ kind: "system", content, status: "done", parentMessageId });
-        eventBus.publish({ type: "message.created", message: msg });
+        eventBus.publish({ type: "message.created", conversationId, message: msg });
         return msg;
       },
       startAgentRun: (agentId, prompt, sourceMessage) => {

--- a/src/server/conversation-context.ts
+++ b/src/server/conversation-context.ts
@@ -1,0 +1,155 @@
+import path from "node:path";
+
+import { AgentRegistry } from "../core/agent-registry.ts";
+import { buildChannelContext } from "../core/channel-context-builder.ts";
+import { buildHistoryForAgent } from "../core/channel-history.ts";
+import { EventBus } from "../core/event-bus.ts";
+import { MessageStore } from "../core/message-store.ts";
+import { RunManager } from "../core/run-manager.ts";
+import { SessionStore } from "../core/session-store.ts";
+import { TerminalTranscriptStore } from "../core/terminal-transcript-store.ts";
+import { WorkspaceStore } from "../core/workspace-store.ts";
+import { ChannelRouter } from "../core/channel-router.ts";
+import type { AgentId, AgentProfile, RuntimeEvent } from "../shared/types.ts";
+
+const MAX_ROUTE_DEPTH = 5;
+const CHANNEL_ID = "default";
+
+export type ConversationContextOptions = {
+  workspaceId: string;
+  conversationId: string;
+  profiles: readonly AgentProfile[];
+  eventBus: EventBus;
+  sessionStore: SessionStore;
+  workspaceStore: WorkspaceStore;
+  sseHub: { publish: (event: RuntimeEvent) => void };
+};
+
+export class ConversationContext {
+  readonly messages: MessageStore;
+  readonly transcripts: TerminalTranscriptStore;
+  readonly agents: AgentRegistry;
+  readonly runManager: RunManager;
+  readonly channelRouter: ChannelRouter;
+
+  private _profiles: readonly AgentProfile[];
+  private readonly eventBus: EventBus;
+  private readonly sseHub: { publish: (event: RuntimeEvent) => void };
+  private readonly unsubscribe: () => void;
+
+  constructor(private readonly options: ConversationContextOptions) {
+    const { workspaceId, conversationId, profiles, eventBus, sessionStore, workspaceStore, sseHub } = options;
+    this._profiles = profiles;
+    this.eventBus = eventBus;
+    this.sseHub = sseHub;
+
+    const messagesPath = path.join(
+      workspaceStore.channelsDir(workspaceId, CHANNEL_ID, conversationId),
+      "messages.json",
+    );
+    const transcriptsDir = workspaceStore.transcriptsDir(workspaceId, CHANNEL_ID, conversationId);
+
+    this.messages = new MessageStore(messagesPath);
+    this.transcripts = new TerminalTranscriptStore(transcriptsDir);
+
+    this.unsubscribe = eventBus.subscribe((event) => {
+      if ((event as { type: string }).type === "terminal.chunk") {
+        const e = event as { agentId: string; text: string };
+        this.transcripts.append(e.agentId, e.text);
+      }
+      sseHub.publish(event);
+    });
+
+    this.agents = new AgentRegistry(profiles, eventBus, sessionStore, CHANNEL_ID, conversationId);
+    this.agents.startAll();
+
+    const agentIds = this.agents.ids();
+
+    this.runManager = new RunManager({
+      agents: this.agents,
+      messages: this.messages,
+      eventBus,
+      buildPrompt: (agentId: AgentId, prompt: string) => {
+        const history = buildHistoryForAgent(agentId, this.messages.list());
+        return buildChannelContext({ agentId, profiles, channelMessage: prompt, history });
+      },
+      onRunCompleted: (message) => {
+        this.channelRouter.process(message);
+      },
+    });
+
+    this.channelRouter = new ChannelRouter({
+      availableAgents: agentIds,
+      maxRouteDepth: MAX_ROUTE_DEPTH,
+      createSystemMessage: (content, parentMessageId) => {
+        const msg = this.messages.add({ kind: "system", content, status: "done", parentMessageId });
+        eventBus.publish({ type: "message.created", message: msg });
+        return msg;
+      },
+      startAgentRun: (agentId, prompt, sourceMessage) => {
+        this.runManager.enqueue(agentId, prompt, sourceMessage);
+      },
+      markMessageRouted: (messageId, routeState) => {
+        this.messages.markRouteState(messageId, routeState);
+      },
+    });
+  }
+
+  hasRunningAgent(): boolean {
+    return this.agents.states().some((s) => s.status === "running");
+  }
+
+  refreshProfiles(profiles: readonly AgentProfile[]): void {
+    this.agents.stopAll();
+    this.runManager.dispose();
+
+    const { workspaceId, conversationId, eventBus, sessionStore } = this.options;
+    const newAgents = new AgentRegistry(profiles, eventBus, sessionStore, CHANNEL_ID, conversationId);
+    newAgents.startAll();
+
+    this._profiles = profiles;
+
+    const agentIds = newAgents.ids();
+
+    const self = this;
+
+    const newRunManager = new RunManager({
+      agents: newAgents,
+      messages: this.messages,
+      eventBus,
+      buildPrompt: (agentId: AgentId, prompt: string) => {
+        const history = buildHistoryForAgent(agentId, self.messages.list());
+        return buildChannelContext({ agentId, profiles, channelMessage: prompt, history });
+      },
+      onRunCompleted: (message) => {
+        self.channelRouter.process(message);
+      },
+    });
+
+    const newChannelRouter = new ChannelRouter({
+      availableAgents: agentIds,
+      maxRouteDepth: MAX_ROUTE_DEPTH,
+      createSystemMessage: (content, parentMessageId) => {
+        const msg = self.messages.add({ kind: "system", content, status: "done", parentMessageId });
+        eventBus.publish({ type: "message.created", message: msg });
+        return msg;
+      },
+      startAgentRun: (agentId, prompt, sourceMessage) => {
+        newRunManager.enqueue(agentId, prompt, sourceMessage);
+      },
+      markMessageRouted: (messageId, routeState) => {
+        self.messages.markRouteState(messageId, routeState);
+      },
+    });
+
+    // Replace readonly fields via Object.assign (intentional hot-swap)
+    Object.assign(this, { agents: newAgents, runManager: newRunManager, channelRouter: newChannelRouter });
+  }
+
+  dispose(): void {
+    this.agents.stopAll();
+    this.runManager.dispose();
+    this.transcripts.dispose();
+    this.unsubscribe();
+  }
+}

--- a/src/server/conversation-context.ts
+++ b/src/server/conversation-context.ts
@@ -26,9 +26,9 @@ export type ConversationContextOptions = {
 export class ConversationContext {
   readonly messages: MessageStore;
   readonly transcripts: TerminalTranscriptStore;
-  readonly agents: AgentRegistry;
-  readonly runManager: RunManager;
-  readonly messageRouter: MessageRouter;
+  agents: AgentRegistry;
+  runManager: RunManager;
+  messageRouter: MessageRouter;
 
   private _profiles: readonly AgentProfile[];
   private readonly eventBus: EventBus;

--- a/src/server/conversation-context.ts
+++ b/src/server/conversation-context.ts
@@ -1,19 +1,18 @@
 import path from "node:path";
 
 import { AgentRegistry } from "../core/agent-registry.ts";
-import { buildChannelContext } from "../core/channel-context-builder.ts";
-import { buildHistoryForAgent } from "../core/channel-history.ts";
+import { buildAgentContext } from "../core/agent-context-builder.ts";
+import { buildHistoryForAgent } from "../core/agent-history-builder.ts";
 import { EventBus } from "../core/event-bus.ts";
 import { MessageStore } from "../core/message-store.ts";
 import { RunManager } from "../core/run-manager.ts";
 import { SessionStore } from "../core/session-store.ts";
 import { TerminalTranscriptStore } from "../core/terminal-transcript-store.ts";
 import { WorkspaceStore } from "../core/workspace-store.ts";
-import { ChannelRouter } from "../core/channel-router.ts";
+import { MessageRouter } from "../core/message-router.ts";
 import type { AgentId, AgentProfile } from "../shared/types.ts";
 
 const MAX_ROUTE_DEPTH = 5;
-const CHANNEL_ID = "default";
 
 export type ConversationContextOptions = {
   workspaceId: string;
@@ -29,7 +28,7 @@ export class ConversationContext {
   readonly transcripts: TerminalTranscriptStore;
   readonly agents: AgentRegistry;
   readonly runManager: RunManager;
-  readonly channelRouter: ChannelRouter;
+  readonly messageRouter: MessageRouter;
 
   private _profiles: readonly AgentProfile[];
   private readonly eventBus: EventBus;
@@ -41,10 +40,10 @@ export class ConversationContext {
     this.eventBus = eventBus;
 
     const messagesPath = path.join(
-      workspaceStore.channelsDir(workspaceId, CHANNEL_ID, conversationId),
+      workspaceStore.channelsDir(workspaceId, conversationId),
       "messages.json",
     );
-    const transcriptsDir = workspaceStore.transcriptsDir(workspaceId, CHANNEL_ID, conversationId);
+    const transcriptsDir = workspaceStore.transcriptsDir(workspaceId, conversationId);
 
     this.messages = new MessageStore(messagesPath);
     this.transcripts = new TerminalTranscriptStore(transcriptsDir);
@@ -58,7 +57,7 @@ export class ConversationContext {
       }
     });
 
-    this.agents = new AgentRegistry(profiles, eventBus, sessionStore, CHANNEL_ID, conversationId);
+    this.agents = new AgentRegistry(profiles, eventBus, sessionStore, conversationId);
     this.agents.startAll();
 
     const agentIds = this.agents.ids();
@@ -70,14 +69,14 @@ export class ConversationContext {
       eventBus,
       buildPrompt: (agentId: AgentId, prompt: string) => {
         const history = buildHistoryForAgent(agentId, this.messages.list());
-        return buildChannelContext({ agentId, profiles, channelMessage: prompt, history });
+        return buildAgentContext({ agentId, profiles, agentMessage: prompt, history });
       },
       onRunCompleted: (message) => {
-        this.channelRouter.process(message);
+        this.messageRouter.process(message);
       },
     });
 
-    this.channelRouter = new ChannelRouter({
+    this.messageRouter = new MessageRouter({
       availableAgents: agentIds,
       maxRouteDepth: MAX_ROUTE_DEPTH,
       createSystemMessage: (content, parentMessageId) => {
@@ -103,7 +102,7 @@ export class ConversationContext {
     this.runManager.dispose();
 
     const { workspaceId, conversationId, eventBus, sessionStore } = this.options;
-    const newAgents = new AgentRegistry(profiles, eventBus, sessionStore, CHANNEL_ID, conversationId);
+    const newAgents = new AgentRegistry(profiles, eventBus, sessionStore, conversationId);
     newAgents.startAll();
 
     this._profiles = profiles;
@@ -119,14 +118,14 @@ export class ConversationContext {
       eventBus,
       buildPrompt: (agentId: AgentId, prompt: string) => {
         const history = buildHistoryForAgent(agentId, self.messages.list());
-        return buildChannelContext({ agentId, profiles, channelMessage: prompt, history });
+        return buildAgentContext({ agentId, profiles, agentMessage: prompt, history });
       },
       onRunCompleted: (message) => {
-        self.channelRouter.process(message);
+        self.messageRouter.process(message);
       },
     });
 
-    const newChannelRouter = new ChannelRouter({
+    const newMessageRouter = new MessageRouter({
       availableAgents: agentIds,
       maxRouteDepth: MAX_ROUTE_DEPTH,
       createSystemMessage: (content, parentMessageId) => {
@@ -143,7 +142,7 @@ export class ConversationContext {
     });
 
     // Replace readonly fields via Object.assign (intentional hot-swap)
-    Object.assign(this, { agents: newAgents, runManager: newRunManager, channelRouter: newChannelRouter });
+    Object.assign(this, { agents: newAgents, runManager: newRunManager, messageRouter: newMessageRouter });
   }
 
   dispose(): void {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -543,6 +543,10 @@ const server = http.createServer(async (req, res) => {
       try {
         const store = wsId === activeWorkspaceId ? conversationStore : new ConversationStore();
         const conv = store.update(wsId, convId, { name });
+        if (convId === activeConversationId && wsId === activeWorkspaceId) {
+          activeConversation = { id: conv.id, name: conv.name };
+          publishContextSwitched();
+        }
         sendJson(res, 200, conv);
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -10,10 +10,9 @@ import { AgentConfigStore, validateAgentConfigs } from "../core/agent-config-sto
 import type { AgentConfig } from "../core/agent-config-store.ts";
 import { ConversationStore } from "../core/conversation-store.ts";
 import { EventBus } from "../core/event-bus.ts";
-import { MessageStore } from "../core/message-store.ts";
 import { SessionStore } from "../core/session-store.ts";
 import { WorkspaceStore } from "../core/workspace-store.ts";
-import type { Conversation, ConversationInfo, WorkspaceInfo } from "../shared/types.ts";
+import type { ConversationInfo, RunningSummary, WorkspaceInfo } from "../shared/types.ts";
 import { ConversationContext } from "./conversation-context.ts";
 import { serveStatic } from "./static-server.ts";
 import { SseHub } from "./sse-hub.ts";
@@ -29,6 +28,26 @@ const eventBus = new EventBus();
 const sseHub = new SseHub();
 const workspaceStore = new WorkspaceStore();
 const configStore = new AgentConfigStore();
+
+// Forward all events to SSE clients (single global subscriber)
+eventBus.subscribe((event) => {
+  sseHub.publish(event);
+  // After agent.status events, push running.updated if summaries changed
+  if (event.type === "agent.status") {
+    pushRunningSummaries();
+  }
+});
+
+let lastRunningSummariesJson = "";
+
+function pushRunningSummaries(): void {
+  const summaries = buildRunningSummaries();
+  const json = JSON.stringify(summaries);
+  if (json !== lastRunningSummariesJson) {
+    lastRunningSummariesJson = json;
+    sseHub.publish({ type: "running.updated", summaries });
+  }
+}
 
 // --- Last-active persistence ---
 type LastActive = { workspaceId: string; conversationId: string };
@@ -63,10 +82,121 @@ let activeWorkspaceId = "";
 let activeConversationId = "";
 let activeWorkspace: WorkspaceInfo = EMPTY_WORKSPACE;
 let activeConversation: ConversationInfo = EMPTY_CONVERSATION;
-let activeContext: ConversationContext | null = null;
 let allConfigs: AgentConfig[] = [];
 let conversationStore: ConversationStore;
 let sessionStore: SessionStore | null = null;
+
+// --- Context map (multi-conversation parallel support) ---
+const MAX_ACTIVE_CONTEXTS = 10;
+const contextMap = new Map<string, ConversationContext>();
+const contextLru: string[] = [];
+
+function contextKey(workspaceId: string, conversationId: string): string {
+  return `${workspaceId}:${conversationId}`;
+}
+
+function getOrCreateContext(workspaceId: string, conversationId: string): ConversationContext {
+  const key = contextKey(workspaceId, conversationId);
+  const existing = contextMap.get(key);
+  if (existing) {
+    touchLru(key);
+    return existing;
+  }
+  evictIfNeeded();
+  const ctx = createContext(workspaceId, conversationId);
+  contextMap.set(key, ctx);
+  touchLru(key);
+  return ctx;
+}
+
+function touchLru(key: string): void {
+  const idx = contextLru.indexOf(key);
+  if (idx !== -1) contextLru.splice(idx, 1);
+  contextLru.push(key);
+}
+
+function evictIfNeeded(): void {
+  while (contextMap.size >= MAX_ACTIVE_CONTEXTS) {
+    let evicted = false;
+    for (const key of contextLru) {
+      const ctx = contextMap.get(key);
+      if (ctx && !ctx.hasRunningAgent()) {
+        ctx.dispose();
+        contextMap.delete(key);
+        const idx = contextLru.indexOf(key);
+        if (idx !== -1) contextLru.splice(idx, 1);
+        evicted = true;
+        break;
+      }
+    }
+    if (!evicted) break; // all contexts have running agents
+  }
+}
+
+function disposeContext(workspaceId: string, conversationId: string): void {
+  const key = contextKey(workspaceId, conversationId);
+  const ctx = contextMap.get(key);
+  if (ctx) {
+    ctx.dispose();
+    contextMap.delete(key);
+    const idx = contextLru.indexOf(key);
+    if (idx !== -1) contextLru.splice(idx, 1);
+  }
+}
+
+function disposeWorkspaceContexts(workspaceId: string): void {
+  const keysToRemove: string[] = [];
+  for (const key of contextMap.keys()) {
+    if (key.startsWith(`${workspaceId}:`)) {
+      keysToRemove.push(key);
+    }
+  }
+  for (const key of keysToRemove) {
+    contextMap.get(key)?.dispose();
+    contextMap.delete(key);
+    const idx = contextLru.indexOf(key);
+    if (idx !== -1) contextLru.splice(idx, 1);
+  }
+}
+
+function createContext(workspaceId: string, conversationId: string): ConversationContext {
+  const configs = workspaceId === activeWorkspaceId
+    ? allConfigs
+    : configStore.load(workspaceId);
+  const enabledConfigs = configs.filter((c) => c.enabled);
+  const ws = workspaceStore.get(workspaceId);
+  const profiles = configsToProfiles(enabledConfigs, ws!.path);
+  const sessStore = new SessionStore(workspaceStore.sessionsDir(workspaceId));
+  return new ConversationContext({
+    workspaceId,
+    conversationId,
+    profiles,
+    eventBus,
+    sessionStore: sessStore,
+    workspaceStore,
+  });
+}
+
+function getActiveContext(): ConversationContext | null {
+  if (!activeWorkspaceId || !activeConversationId) return null;
+  return contextMap.get(contextKey(activeWorkspaceId, activeConversationId)) ?? null;
+}
+
+function buildRunningSummaries(): RunningSummary[] {
+  const summaries: RunningSummary[] = [];
+  for (const [key, ctx] of contextMap) {
+    const running = ctx.agents.states().filter((s) => s.status === "running").map((s) => s.id);
+    if (running.length > 0) {
+      const separatorIdx = key.indexOf(":");
+      const wsId = key.slice(0, separatorIdx);
+      const convId = key.slice(separatorIdx + 1);
+      summaries.push({ workspaceId: wsId, conversationId: convId, runningAgentIds: running });
+    }
+  }
+  return summaries;
+}
+
+// --- Context lifecycle ---
 
 function initActiveContext(): void {
   conversationStore = new ConversationStore();
@@ -98,39 +228,22 @@ function initActiveContext(): void {
   }
 }
 
-function activateConversation(conversation: Conversation): void {
-  activeContext?.dispose();
-  if (!sessionStore) {
-    sessionStore = new SessionStore(workspaceStore.sessionsDir(activeWorkspaceId));
-  }
+function activateConversation(conversation: { id: string; name: string }): void {
+  // No dispose of old context — it stays alive in the map for parallel execution
   activeConversationId = conversation.id;
   activeConversation = { id: conversation.id, name: conversation.name };
   conversationStore.touchLastOpened(activeWorkspaceId, activeConversationId);
-  const enabledConfigs = allConfigs.filter((c) => c.enabled);
-  const profiles = configsToProfiles(enabledConfigs, activeWorkspace.path);
-  activeContext = new ConversationContext({
-    workspaceId: activeWorkspaceId,
-    conversationId: activeConversationId,
-    profiles,
-    eventBus,
-    sessionStore,
-    workspaceStore,
-    sseHub,
-  });
   saveLastActive(activeWorkspaceId, activeConversationId);
+  // Ensure context exists in map (creates lazily if needed)
+  getOrCreateContext(activeWorkspaceId, activeConversationId);
 }
 
 function switchWorkspace(workspaceId: string): void {
   if (workspaceId === activeWorkspaceId) return;
-  if (activeContext?.hasRunningAgent()) {
-    throw new Error("Cannot switch workspace while an agent is running.");
-  }
+  // No running-agent check — agents continue in background
 
   const ws = workspaceStore.get(workspaceId);
   if (!ws) throw new Error(`Workspace not found: ${workspaceId}`);
-
-  activeContext?.dispose();
-  activeContext = null;
 
   activeWorkspaceId = workspaceId;
   activeWorkspace = { id: ws.id, name: ws.name, path: ws.path };
@@ -150,9 +263,7 @@ function switchWorkspace(workspaceId: string): void {
 function switchConversation(conversationId: string): void {
   if (conversationId === activeConversationId) return;
   if (!activeWorkspaceId) throw new Error("No active workspace.");
-  if (activeContext?.hasRunningAgent()) {
-    throw new Error("Cannot switch conversation while an agent is running.");
-  }
+  // No running-agent check
 
   const conv = conversationStore.get(activeWorkspaceId, conversationId);
   if (!conv) throw new Error(`Conversation not found: ${conversationId}`);
@@ -162,10 +273,12 @@ function switchConversation(conversationId: string): void {
 }
 
 function refreshEnabledAgents(): void {
-  if (!activeContext || !activeWorkspaceId) return;
+  if (!activeWorkspaceId || !activeConversationId) return;
+  const ctx = getActiveContext();
+  if (!ctx) return;
   const enabledConfigs = allConfigs.filter((c) => c.enabled);
   const profiles = configsToProfiles(enabledConfigs, activeWorkspace.path);
-  activeContext.refreshProfiles(profiles);
+  ctx.refreshProfiles(profiles);
 }
 
 function publishContextSwitched(): void {
@@ -177,8 +290,7 @@ function publishContextSwitched(): void {
 }
 
 function clearActiveContext(): void {
-  activeContext?.dispose();
-  activeContext = null;
+  disposeWorkspaceContexts(activeWorkspaceId);
   activeWorkspaceId = "";
   activeConversationId = "";
   activeWorkspace = EMPTY_WORKSPACE;
@@ -190,8 +302,7 @@ function clearActiveContext(): void {
 }
 
 function clearActiveConversation(): void {
-  activeContext?.dispose();
-  activeContext = null;
+  // Don't dispose — just clear the active pointer
   activeConversationId = "";
   activeConversation = EMPTY_CONVERSATION;
   saveLastActive(activeWorkspaceId, activeConversationId);
@@ -199,8 +310,9 @@ function clearActiveConversation(): void {
 }
 
 function currentAgentStates() {
-  if (activeContext) {
-    return activeContext.agents.states();
+  const ctx = getActiveContext();
+  if (ctx) {
+    return ctx.agents.states();
   }
   return allConfigs
     .filter((config) => config.enabled)
@@ -229,12 +341,14 @@ const server = http.createServer(async (req, res) => {
 
     // State
     if (req.method === "GET" && url.pathname === "/api/state") {
+      const ctx = getActiveContext();
       sendJson(res, 200, {
         workspace: activeWorkspace,
         conversation: activeConversation,
         agents: currentAgentStates(),
-        messages: activeContext?.messages.list() ?? [],
-        terminal: activeContext?.transcripts.all() ?? {},
+        messages: ctx?.messages.list() ?? [],
+        terminal: ctx?.transcripts.all() ?? {},
+        runningSummaries: buildRunningSummaries(),
       });
       return;
     }
@@ -261,7 +375,8 @@ const server = http.createServer(async (req, res) => {
         sendJson(res, 409, { ok: false, message: "Create or select a workspace before resetting agents." });
         return;
       }
-      if (activeContext?.hasRunningAgent()) {
+      const ctx = getActiveContext();
+      if (ctx?.hasRunningAgent()) {
         sendJson(res, 409, { ok: false, message: "Cannot reset while an agent is running. Wait for it to finish." });
         return;
       }
@@ -322,16 +437,21 @@ const server = http.createServer(async (req, res) => {
       const parts = url.pathname.split("/");
       const wsId = parts[3];
       if (!wsId) { sendJson(res, 400, { ok: false, message: "Missing workspace id." }); return; }
-      if (wsId === activeWorkspaceId && activeContext?.hasRunningAgent()) {
-        sendJson(res, 409, { ok: false, message: "Cannot delete the active workspace while an agent is running." });
+      // Check if ANY context for this workspace has running agents
+      let hasRunning = false;
+      for (const [key, ctx] of contextMap) {
+        if (key.startsWith(`${wsId}:`) && ctx.hasRunningAgent()) {
+          hasRunning = true;
+          break;
+        }
+      }
+      if (hasRunning) {
+        sendJson(res, 409, { ok: false, message: "Cannot delete workspace with running agents." });
         return;
       }
       try {
         const wasActiveWorkspace = wsId === activeWorkspaceId;
-        if (wasActiveWorkspace) {
-          activeContext?.dispose();
-          activeContext = null;
-        }
+        disposeWorkspaceContexts(wsId);
         workspaceStore.delete(wsId);
         if (wasActiveWorkspace) {
           const nextWorkspace = workspaceStore.list()[0];
@@ -413,16 +533,14 @@ const server = http.createServer(async (req, res) => {
         sendJson(res, 409, { ok: false, message: "No active workspace." });
         return;
       }
-      if (convId === activeConversationId && activeContext?.hasRunningAgent()) {
-        sendJson(res, 409, { ok: false, message: "Cannot delete the active conversation while an agent is running." });
+      const targetCtx = contextMap.get(contextKey(activeWorkspaceId, convId));
+      if (targetCtx?.hasRunningAgent()) {
+        sendJson(res, 409, { ok: false, message: "Cannot delete a conversation with running agents." });
         return;
       }
       try {
         const wasActiveConversation = convId === activeConversationId;
-        if (wasActiveConversation) {
-          activeContext?.dispose();
-          activeContext = null;
-        }
+        disposeContext(activeWorkspaceId, convId);
         conversationStore.delete(activeWorkspaceId, convId);
         if (wasActiveConversation) {
           const nextConversation = conversationStore.list(activeWorkspaceId)[0];
@@ -487,9 +605,15 @@ async function handlePostMessage(req: http.IncomingMessage, res: http.ServerResp
     return;
   }
 
-  if (!activeContext) {
+  let context = getActiveContext();
+
+  if (!context) {
     const conversation = conversationStore.create(activeWorkspaceId, conversationTitle(content));
-    activateConversation(conversation);
+    activeConversationId = conversation.id;
+    activeConversation = { id: conversation.id, name: conversation.name };
+    conversationStore.touchLastOpened(activeWorkspaceId, activeConversationId);
+    context = getOrCreateContext(activeWorkspaceId, activeConversationId);
+    saveLastActive(activeWorkspaceId, activeConversationId);
     publishContextSwitched();
   } else if (activeConversation.name === UNTITLED_CONVERSATION_NAME) {
     const renamed = conversationStore.update(activeWorkspaceId, activeConversationId, { name: conversationTitle(content) });
@@ -497,14 +621,13 @@ async function handlePostMessage(req: http.IncomingMessage, res: http.ServerResp
     publishContextSwitched();
   }
 
-  const context = activeContext;
   if (!context) {
     sendJson(res, 500, { ok: false, message: "Conversation context was not initialized." });
     return;
   }
 
   const userMessage = context.messages.add({ kind: "user", content, status: "sent" });
-  eventBus.publish({ type: "message.created", message: userMessage });
+  eventBus.publish({ type: "message.created", conversationId: activeConversationId, message: userMessage });
   context.channelRouter.process(userMessage);
 
   sendJson(res, 200, { ok: true, messageId: userMessage.id });
@@ -581,7 +704,8 @@ async function handlePutAgents(req: http.IncomingMessage, res: http.ServerRespon
     sendJson(res, 409, { ok: false, message: "Create or select a workspace before saving agents." });
     return;
   }
-  if (activeContext?.hasRunningAgent()) {
+  const ctx = getActiveContext();
+  if (ctx?.hasRunningAgent()) {
     sendJson(res, 409, { ok: false, message: "Cannot save while an agent is running. Wait for it to finish." });
     return;
   }
@@ -605,7 +729,11 @@ async function handlePutAgents(req: http.IncomingMessage, res: http.ServerRespon
 }
 
 function shutdown(): void {
-  activeContext?.dispose();
+  for (const ctx of contextMap.values()) {
+    ctx.dispose();
+  }
+  contextMap.clear();
+  contextLru.length = 0;
   server.close(() => {
     process.exit(0);
   });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -458,7 +458,6 @@ const server = http.createServer(async (req, res) => {
         if (wasActiveWorkspace) {
           const nextWorkspace = workspaceStore.list()[0];
           if (nextWorkspace) {
-            activeWorkspaceId = "";
             switchWorkspace(nextWorkspace.id);
           } else {
             clearActiveContext();

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -510,12 +510,17 @@ const server = http.createServer(async (req, res) => {
     }
 
     if (req.method === "POST" && url.pathname === "/api/conversations") {
-      if (!activeWorkspaceId) {
+      const wsId = url.searchParams.get("workspaceId") || activeWorkspaceId;
+      if (!wsId) {
         sendJson(res, 409, { ok: false, message: "Create or select a workspace before creating a conversation." });
         return;
       }
       const input = (await readJson(req)) as { name?: unknown };
       const name = conversationTitle(typeof input.name === "string" ? input.name : "");
+      // Switch workspace if creating in a different one
+      if (wsId !== activeWorkspaceId) {
+        switchWorkspace(wsId);
+      }
       const conv = conversationStore.create(activeWorkspaceId, name);
       activateConversation(conv);
       publishContextSwitched();
@@ -527,10 +532,13 @@ const server = http.createServer(async (req, res) => {
       const parts = url.pathname.split("/");
       const convId = parts[3];
       if (!convId) { sendJson(res, 400, { ok: false, message: "Missing conversation id." }); return; }
+      const wsId = url.searchParams.get("workspaceId") || activeWorkspaceId;
+      if (!wsId) { sendJson(res, 409, { ok: false, message: "No active workspace." }); return; }
       const input = (await readJson(req)) as { name?: unknown };
       const name = typeof input.name === "string" ? input.name.trim() : undefined;
       try {
-        const conv = conversationStore.update(activeWorkspaceId, convId, { name });
+        const store = wsId === activeWorkspaceId ? conversationStore : new ConversationStore();
+        const conv = store.update(wsId, convId, { name });
         sendJson(res, 200, conv);
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
@@ -580,6 +588,10 @@ const server = http.createServer(async (req, res) => {
       const convId = parts[3];
       if (!convId) { sendJson(res, 400, { ok: false, message: "Missing conversation id." }); return; }
       try {
+        const wsId = url.searchParams.get("workspaceId");
+        if (wsId && wsId !== activeWorkspaceId) {
+          switchWorkspace(wsId);
+        }
         switchConversation(convId);
         sendJson(res, 200, { ok: true, workspace: activeWorkspace, conversation: activeConversation });
       } catch (error) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -543,19 +543,21 @@ const server = http.createServer(async (req, res) => {
       const parts = url.pathname.split("/");
       const convId = parts[3];
       if (!convId) { sendJson(res, 400, { ok: false, message: "Missing conversation id." }); return; }
-      if (!activeWorkspaceId) {
+      const wsId = url.searchParams.get("workspaceId") || activeWorkspaceId;
+      if (!wsId) {
         sendJson(res, 409, { ok: false, message: "No active workspace." });
         return;
       }
-      const targetCtx = contextMap.get(contextKey(activeWorkspaceId, convId));
+      const targetCtx = contextMap.get(contextKey(wsId, convId));
       if (targetCtx?.hasRunningAgent()) {
         sendJson(res, 409, { ok: false, message: "Cannot delete a conversation with running agents." });
         return;
       }
       try {
-        const wasActiveConversation = convId === activeConversationId;
-        disposeContext(activeWorkspaceId, convId);
-        conversationStore.delete(activeWorkspaceId, convId);
+        const wasActiveConversation = wsId === activeWorkspaceId && convId === activeConversationId;
+        disposeContext(wsId, convId);
+        const store = wsId === activeWorkspaceId ? conversationStore : new ConversationStore();
+        store.delete(wsId, convId);
         if (wasActiveConversation) {
           const nextConversation = conversationStore.list(activeWorkspaceId)[0];
           if (nextConversation) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -176,6 +176,28 @@ function publishContextSwitched(): void {
   });
 }
 
+function clearActiveContext(): void {
+  activeContext?.dispose();
+  activeContext = null;
+  activeWorkspaceId = "";
+  activeConversationId = "";
+  activeWorkspace = EMPTY_WORKSPACE;
+  activeConversation = EMPTY_CONVERSATION;
+  allConfigs = [];
+  sessionStore = null;
+  clearLastActive();
+  publishContextSwitched();
+}
+
+function clearActiveConversation(): void {
+  activeContext?.dispose();
+  activeContext = null;
+  activeConversationId = "";
+  activeConversation = EMPTY_CONVERSATION;
+  saveLastActive(activeWorkspaceId, activeConversationId);
+  publishContextSwitched();
+}
+
 function currentAgentStates() {
   if (activeContext) {
     return activeContext.agents.states();
@@ -300,12 +322,26 @@ const server = http.createServer(async (req, res) => {
       const parts = url.pathname.split("/");
       const wsId = parts[3];
       if (!wsId) { sendJson(res, 400, { ok: false, message: "Missing workspace id." }); return; }
-      if (wsId === activeWorkspaceId) {
-        sendJson(res, 400, { ok: false, message: "Cannot delete the active workspace. Switch to another first." });
+      if (wsId === activeWorkspaceId && activeContext?.hasRunningAgent()) {
+        sendJson(res, 409, { ok: false, message: "Cannot delete the active workspace while an agent is running." });
         return;
       }
       try {
+        const wasActiveWorkspace = wsId === activeWorkspaceId;
+        if (wasActiveWorkspace) {
+          activeContext?.dispose();
+          activeContext = null;
+        }
         workspaceStore.delete(wsId);
+        if (wasActiveWorkspace) {
+          const nextWorkspace = workspaceStore.list()[0];
+          if (nextWorkspace) {
+            activeWorkspaceId = "";
+            switchWorkspace(nextWorkspace.id);
+          } else {
+            clearActiveContext();
+          }
+        }
         sendJson(res, 200, { ok: true });
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
@@ -373,12 +409,30 @@ const server = http.createServer(async (req, res) => {
       const parts = url.pathname.split("/");
       const convId = parts[3];
       if (!convId) { sendJson(res, 400, { ok: false, message: "Missing conversation id." }); return; }
-      if (convId === activeConversationId) {
-        sendJson(res, 400, { ok: false, message: "Cannot delete the active conversation. Switch to another first." });
+      if (!activeWorkspaceId) {
+        sendJson(res, 409, { ok: false, message: "No active workspace." });
+        return;
+      }
+      if (convId === activeConversationId && activeContext?.hasRunningAgent()) {
+        sendJson(res, 409, { ok: false, message: "Cannot delete the active conversation while an agent is running." });
         return;
       }
       try {
+        const wasActiveConversation = convId === activeConversationId;
+        if (wasActiveConversation) {
+          activeContext?.dispose();
+          activeContext = null;
+        }
         conversationStore.delete(activeWorkspaceId, convId);
+        if (wasActiveConversation) {
+          const nextConversation = conversationStore.list(activeWorkspaceId)[0];
+          if (nextConversation) {
+            activateConversation(nextConversation);
+            publishContextSwitched();
+          } else {
+            clearActiveConversation();
+          }
+        }
         sendJson(res, 200, { ok: true });
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
@@ -499,13 +553,22 @@ async function pickWindowsDirectory(): Promise<string> {
 
   const script = [
     "Add-Type -AssemblyName System.Windows.Forms",
+    "Add-Type -AssemblyName System.Drawing",
+    "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8",
+    "$owner = New-Object System.Windows.Forms.Form",
+    "$owner.TopMost = $true",
+    "$owner.ShowInTaskbar = $false",
+    "$owner.StartPosition = 'CenterScreen'",
+    "$owner.Width = 1",
+    "$owner.Height = 1",
     "$dialog = New-Object System.Windows.Forms.FolderBrowserDialog",
-    "$dialog.Description = '选择工作区目录'",
+    "$dialog.Description = 'Select workspace folder'",
     "$dialog.ShowNewFolderButton = $true",
-    "if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {",
-    "  [Console]::OutputEncoding = [System.Text.Encoding]::UTF8",
+    "$owner.Add_Shown({ $owner.Activate() })",
+    "if ($dialog.ShowDialog($owner) -eq [System.Windows.Forms.DialogResult]::OK) {",
     "  Write-Output $dialog.SelectedPath",
     "}",
+    "$owner.Dispose()",
   ].join("; ");
   const { stdout } = await execFileAsync("powershell.exe", ["-NoProfile", "-STA", "-Command", script], {
     windowsHide: false,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,6 +2,8 @@ import fs from "node:fs";
 import http from "node:http";
 import os from "node:os";
 import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 
 import { configsToProfiles } from "../core/agent-profiles.ts";
 import { AgentConfigStore, validateAgentConfigs } from "../core/agent-config-store.ts";
@@ -17,6 +19,10 @@ import { serveStatic } from "./static-server.ts";
 import { SseHub } from "./sse-hub.ts";
 
 const port = Number(process.env.ORBIT_PORT ?? 4317);
+const UNTITLED_CONVERSATION_NAME = "新会话";
+const EMPTY_WORKSPACE: WorkspaceInfo = { id: "", name: "", path: "" };
+const EMPTY_CONVERSATION: ConversationInfo = { id: "", name: "" };
+const execFileAsync = promisify(execFile);
 
 // --- Shared singletons ---
 const eventBus = new EventBus();
@@ -44,57 +50,64 @@ function saveLastActive(workspaceId: string, conversationId: string): void {
   fs.renameSync(tmp, lastActivePath);
 }
 
+function clearLastActive(): void {
+  try {
+    fs.rmSync(lastActivePath, { force: true });
+  } catch {
+    // best effort
+  }
+}
+
 // --- Active context state ---
-let activeWorkspaceId: string;
-let activeConversationId: string;
-let activeWorkspace: WorkspaceInfo;
-let activeConversation: ConversationInfo;
-let activeContext: ConversationContext;
-let allConfigs: AgentConfig[];
+let activeWorkspaceId = "";
+let activeConversationId = "";
+let activeWorkspace: WorkspaceInfo = EMPTY_WORKSPACE;
+let activeConversation: ConversationInfo = EMPTY_CONVERSATION;
+let activeContext: ConversationContext | null = null;
+let allConfigs: AgentConfig[] = [];
 let conversationStore: ConversationStore;
-let sessionStore: SessionStore;
+let sessionStore: SessionStore | null = null;
 
 function initActiveContext(): void {
-  // Try to restore from last-active.json
-  const last = loadLastActive();
-  if (last && workspaceStore.get(last.workspaceId)) {
-    activeWorkspaceId = last.workspaceId;
-    const ws = workspaceStore.get(activeWorkspaceId)!;
-    activeWorkspace = { id: ws.id, name: ws.name, path: ws.path };
-    workspaceStore.touchLastOpened(activeWorkspaceId);
-  } else {
-    // Fall back to cwd-derived workspace
-    const ws = workspaceStore.resolve(process.cwd());
-    activeWorkspaceId = ws.id;
-    activeWorkspace = ws;
-  }
-
-  // SessionStore scoped to active workspace
-  sessionStore = new SessionStore(workspaceStore.sessionsDir(activeWorkspaceId));
-
-  // ConversationStore scoped to active workspace
   conversationStore = new ConversationStore();
 
-  // Ensure default conversation exists (migration)
-  const defaultConv = conversationStore.ensureDefault(activeWorkspaceId);
-
-  // Restore last conversation or use default
-  if (last && last.conversationId && conversationStore.get(activeWorkspaceId, last.conversationId)) {
-    activeConversationId = last.conversationId;
-  } else {
-    activeConversationId = defaultConv.id;
+  const last = loadLastActive();
+  if (!last) {
+    return;
   }
 
-  const conv = conversationStore.get(activeWorkspaceId, activeConversationId)!;
-  activeConversation = { id: conv.id, name: conv.name };
-  conversationStore.touchLastOpened(activeWorkspaceId, activeConversationId);
+  const ws = workspaceStore.get(last.workspaceId);
+  if (!ws) {
+    clearLastActive();
+    return;
+  }
 
-  // Load agent configs
+  activeWorkspaceId = ws.id;
+  activeWorkspace = { id: ws.id, name: ws.name, path: ws.path };
+  workspaceStore.touchLastOpened(activeWorkspaceId);
+  sessionStore = new SessionStore(workspaceStore.sessionsDir(activeWorkspaceId));
   allConfigs = configStore.load(activeWorkspaceId);
+
+  const conversation = last.conversationId ? conversationStore.get(activeWorkspaceId, last.conversationId) : null;
+  if (conversation) {
+    activateConversation(conversation);
+  } else {
+    activeConversationId = "";
+    activeConversation = EMPTY_CONVERSATION;
+    saveLastActive(activeWorkspaceId, activeConversationId);
+  }
+}
+
+function activateConversation(conversation: Conversation): void {
+  activeContext?.dispose();
+  if (!sessionStore) {
+    sessionStore = new SessionStore(workspaceStore.sessionsDir(activeWorkspaceId));
+  }
+  activeConversationId = conversation.id;
+  activeConversation = { id: conversation.id, name: conversation.name };
+  conversationStore.touchLastOpened(activeWorkspaceId, activeConversationId);
   const enabledConfigs = allConfigs.filter((c) => c.enabled);
   const profiles = configsToProfiles(enabledConfigs, activeWorkspace.path);
-
-  // Create context
   activeContext = new ConversationContext({
     workspaceId: activeWorkspaceId,
     conversationId: activeConversationId,
@@ -104,86 +117,52 @@ function initActiveContext(): void {
     workspaceStore,
     sseHub,
   });
-
   saveLastActive(activeWorkspaceId, activeConversationId);
 }
 
 function switchWorkspace(workspaceId: string): void {
   if (workspaceId === activeWorkspaceId) return;
-  if (activeContext.hasRunningAgent()) {
+  if (activeContext?.hasRunningAgent()) {
     throw new Error("Cannot switch workspace while an agent is running.");
   }
 
   const ws = workspaceStore.get(workspaceId);
   if (!ws) throw new Error(`Workspace not found: ${workspaceId}`);
 
-  activeContext.dispose();
+  activeContext?.dispose();
+  activeContext = null;
 
   activeWorkspaceId = workspaceId;
   activeWorkspace = { id: ws.id, name: ws.name, path: ws.path };
   workspaceStore.touchLastOpened(workspaceId);
 
-  // Rebuild session store and conversation store for new workspace
   sessionStore = new SessionStore(workspaceStore.sessionsDir(activeWorkspaceId));
   conversationStore = new ConversationStore();
-
-  const defaultConv = conversationStore.ensureDefault(activeWorkspaceId);
-  activeConversationId = defaultConv.id;
-  const conv = conversationStore.get(activeWorkspaceId, activeConversationId)!;
-  activeConversation = { id: conv.id, name: conv.name };
-  conversationStore.touchLastOpened(activeWorkspaceId, activeConversationId);
-
   allConfigs = configStore.load(activeWorkspaceId);
-  const enabledConfigs = allConfigs.filter((c) => c.enabled);
-  const profiles = configsToProfiles(enabledConfigs, activeWorkspace.path);
 
-  activeContext = new ConversationContext({
-    workspaceId: activeWorkspaceId,
-    conversationId: activeConversationId,
-    profiles,
-    eventBus,
-    sessionStore,
-    workspaceStore,
-    sseHub,
-  });
-
+  activeConversationId = "";
+  activeConversation = EMPTY_CONVERSATION;
   saveLastActive(activeWorkspaceId, activeConversationId);
+
   publishContextSwitched();
 }
 
 function switchConversation(conversationId: string): void {
   if (conversationId === activeConversationId) return;
-  if (activeContext.hasRunningAgent()) {
+  if (!activeWorkspaceId) throw new Error("No active workspace.");
+  if (activeContext?.hasRunningAgent()) {
     throw new Error("Cannot switch conversation while an agent is running.");
   }
 
   const conv = conversationStore.get(activeWorkspaceId, conversationId);
   if (!conv) throw new Error(`Conversation not found: ${conversationId}`);
 
-  activeContext.dispose();
-
-  activeConversationId = conversationId;
-  activeConversation = { id: conv.id, name: conv.name };
-  conversationStore.touchLastOpened(activeWorkspaceId, conversationId);
-
-  const enabledConfigs = allConfigs.filter((c) => c.enabled);
-  const profiles = configsToProfiles(enabledConfigs, activeWorkspace.path);
-
-  activeContext = new ConversationContext({
-    workspaceId: activeWorkspaceId,
-    conversationId: activeConversationId,
-    profiles,
-    eventBus,
-    sessionStore,
-    workspaceStore,
-    sseHub,
-  });
-
-  saveLastActive(activeWorkspaceId, activeConversationId);
+  activateConversation(conv);
   publishContextSwitched();
 }
 
 function refreshEnabledAgents(): void {
+  if (!activeContext || !activeWorkspaceId) return;
   const enabledConfigs = allConfigs.filter((c) => c.enabled);
   const profiles = configsToProfiles(enabledConfigs, activeWorkspace.path);
   activeContext.refreshProfiles(profiles);
@@ -195,6 +174,21 @@ function publishContextSwitched(): void {
     workspace: activeWorkspace,
     conversation: activeConversation,
   });
+}
+
+function currentAgentStates() {
+  if (activeContext) {
+    return activeContext.agents.states();
+  }
+  return allConfigs
+    .filter((config) => config.enabled)
+    .map((config, index) => ({
+      id: config.id,
+      label: config.name,
+      runtime: config.runtime,
+      status: "idle" as const,
+      selected: index === 0,
+    }));
 }
 
 // --- Initialize ---
@@ -216,9 +210,9 @@ const server = http.createServer(async (req, res) => {
       sendJson(res, 200, {
         workspace: activeWorkspace,
         conversation: activeConversation,
-        agents: activeContext.agents.states(),
-        messages: activeContext.messages.list(),
-        terminal: activeContext.transcripts.all(),
+        agents: currentAgentStates(),
+        messages: activeContext?.messages.list() ?? [],
+        terminal: activeContext?.transcripts.all() ?? {},
       });
       return;
     }
@@ -241,7 +235,11 @@ const server = http.createServer(async (req, res) => {
     }
 
     if (req.method === "POST" && url.pathname === "/api/agents/reset") {
-      if (activeContext.hasRunningAgent()) {
+      if (!activeWorkspaceId) {
+        sendJson(res, 409, { ok: false, message: "Create or select a workspace before resetting agents." });
+        return;
+      }
+      if (activeContext?.hasRunningAgent()) {
         sendJson(res, 409, { ok: false, message: "Cannot reset while an agent is running. Wait for it to finish." });
         return;
       }
@@ -253,6 +251,12 @@ const server = http.createServer(async (req, res) => {
 
     // --- Workspace endpoints ---
 
+    if (req.method === "POST" && url.pathname === "/api/workspaces/pick-directory") {
+      const directory = await pickWindowsDirectory();
+      sendJson(res, 200, { path: directory });
+      return;
+    }
+
     if (req.method === "GET" && url.pathname === "/api/workspaces") {
       sendJson(res, 200, workspaceStore.list());
       return;
@@ -262,8 +266,8 @@ const server = http.createServer(async (req, res) => {
       const input = (await readJson(req)) as { name?: unknown; path?: unknown };
       const name = typeof input.name === "string" ? input.name.trim() : "";
       const wsPath = typeof input.path === "string" ? input.path.trim() : "";
-      if (!name || !wsPath) {
-        sendJson(res, 400, { ok: false, message: "name and path are required." });
+      if (!wsPath) {
+        sendJson(res, 400, { ok: false, message: "path is required." });
         return;
       }
       try {
@@ -327,18 +331,24 @@ const server = http.createServer(async (req, res) => {
     // --- Conversation endpoints ---
 
     if (req.method === "GET" && url.pathname === "/api/conversations") {
+      if (!activeWorkspaceId) {
+        sendJson(res, 200, []);
+        return;
+      }
       sendJson(res, 200, conversationStore.list(activeWorkspaceId));
       return;
     }
 
     if (req.method === "POST" && url.pathname === "/api/conversations") {
-      const input = (await readJson(req)) as { name?: unknown };
-      const name = typeof input.name === "string" ? input.name.trim() : "";
-      if (!name) {
-        sendJson(res, 400, { ok: false, message: "name is required." });
+      if (!activeWorkspaceId) {
+        sendJson(res, 409, { ok: false, message: "Create or select a workspace before creating a conversation." });
         return;
       }
+      const input = (await readJson(req)) as { name?: unknown };
+      const name = conversationTitle(typeof input.name === "string" ? input.name : "");
       const conv = conversationStore.create(activeWorkspaceId, name);
+      activateConversation(conv);
+      publishContextSwitched();
       sendJson(res, 200, conv);
       return;
     }
@@ -418,9 +428,30 @@ async function handlePostMessage(req: http.IncomingMessage, res: http.ServerResp
     return;
   }
 
-  const userMessage = activeContext.messages.add({ kind: "user", content, status: "sent" });
+  if (!activeWorkspaceId) {
+    sendJson(res, 409, { ok: false, message: "Create or select a workspace before sending a message." });
+    return;
+  }
+
+  if (!activeContext) {
+    const conversation = conversationStore.create(activeWorkspaceId, conversationTitle(content));
+    activateConversation(conversation);
+    publishContextSwitched();
+  } else if (activeConversation.name === UNTITLED_CONVERSATION_NAME) {
+    const renamed = conversationStore.update(activeWorkspaceId, activeConversationId, { name: conversationTitle(content) });
+    activeConversation = { id: renamed.id, name: renamed.name };
+    publishContextSwitched();
+  }
+
+  const context = activeContext;
+  if (!context) {
+    sendJson(res, 500, { ok: false, message: "Conversation context was not initialized." });
+    return;
+  }
+
+  const userMessage = context.messages.add({ kind: "user", content, status: "sent" });
   eventBus.publish({ type: "message.created", message: userMessage });
-  activeContext.channelRouter.process(userMessage);
+  context.channelRouter.process(userMessage);
 
   sendJson(res, 200, { ok: true, messageId: userMessage.id });
 }
@@ -453,8 +484,41 @@ function sendJson(res: http.ServerResponse, status: number, value: unknown): voi
   res.end(JSON.stringify(value));
 }
 
+function conversationTitle(content: string): string {
+  const title = content.replace(/\s+/g, " ").trim();
+  if (!title) {
+    return UNTITLED_CONVERSATION_NAME;
+  }
+  return title.length > 24 ? `${title.slice(0, 24)}...` : title;
+}
+
+async function pickWindowsDirectory(): Promise<string> {
+  if (process.platform !== "win32") {
+    throw new Error("Directory picker is currently only supported on Windows.");
+  }
+
+  const script = [
+    "Add-Type -AssemblyName System.Windows.Forms",
+    "$dialog = New-Object System.Windows.Forms.FolderBrowserDialog",
+    "$dialog.Description = '选择工作区目录'",
+    "$dialog.ShowNewFolderButton = $true",
+    "if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {",
+    "  [Console]::OutputEncoding = [System.Text.Encoding]::UTF8",
+    "  Write-Output $dialog.SelectedPath",
+    "}",
+  ].join("; ");
+  const { stdout } = await execFileAsync("powershell.exe", ["-NoProfile", "-STA", "-Command", script], {
+    windowsHide: false,
+  });
+  return stdout.trim();
+}
+
 async function handlePutAgents(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
-  if (activeContext.hasRunningAgent()) {
+  if (!activeWorkspaceId) {
+    sendJson(res, 409, { ok: false, message: "Create or select a workspace before saving agents." });
+    return;
+  }
+  if (activeContext?.hasRunningAgent()) {
     sendJson(res, 409, { ok: false, message: "Cannot save while an agent is running. Wait for it to finish." });
     return;
   }
@@ -478,7 +542,7 @@ async function handlePutAgents(req: http.IncomingMessage, res: http.ServerRespon
 }
 
 function shutdown(): void {
-  activeContext.dispose();
+  activeContext?.dispose();
   server.close(() => {
     process.exit(0);
   });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -12,6 +12,7 @@ import { ConversationStore } from "../core/conversation-store.ts";
 import { EventBus } from "../core/event-bus.ts";
 import { SessionStore } from "../core/session-store.ts";
 import { WorkspaceStore } from "../core/workspace-store.ts";
+import { migrateChannelLayer } from "../core/migrate-channel-layer.ts";
 import type { ConversationInfo, RunningSummary, WorkspaceInfo } from "../shared/types.ts";
 import { ConversationContext } from "./conversation-context.ts";
 import { serveStatic } from "./static-server.ts";
@@ -326,6 +327,7 @@ function currentAgentStates() {
 }
 
 // --- Initialize ---
+migrateChannelLayer();
 initActiveContext();
 
 // --- HTTP Server ---
@@ -656,7 +658,7 @@ async function handlePostMessage(req: http.IncomingMessage, res: http.ServerResp
 
   const userMessage = context.messages.add({ kind: "user", content, status: "sent" });
   eventBus.publish({ type: "message.created", conversationId: activeConversationId, message: userMessage });
-  context.channelRouter.process(userMessage);
+  context.messageRouter.process(userMessage);
 
   sendJson(res, 200, { ok: true, messageId: userMessage.id });
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -495,6 +495,20 @@ const server = http.createServer(async (req, res) => {
       return;
     }
 
+    if (req.method === "GET" && url.pathname.match(/^\/api\/workspaces\/[^/]+\/conversations$/)) {
+      const parts = url.pathname.split("/");
+      const wsId = parts[3];
+      if (!wsId) { sendJson(res, 400, { ok: false, message: "Missing workspace id." }); return; }
+      try {
+        const store = wsId === activeWorkspaceId ? conversationStore : new ConversationStore();
+        sendJson(res, 200, store.list(wsId));
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        sendJson(res, 404, { ok: false, message: msg });
+      }
+      return;
+    }
+
     if (req.method === "POST" && url.pathname === "/api/conversations") {
       if (!activeWorkspaceId) {
         sendJson(res, 409, { ok: false, message: "Create or select a workspace before creating a conversation." });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -130,7 +130,10 @@ function evictIfNeeded(): void {
         break;
       }
     }
-    if (!evicted) break; // all contexts have running agents
+    if (!evicted) {
+      console.warn("[orbit] LRU eviction skipped: all active contexts have running agents");
+      break;
+    }
   }
 }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,111 +1,235 @@
+import fs from "node:fs";
 import http from "node:http";
+import os from "node:os";
 import path from "node:path";
 
 import { configsToProfiles } from "../core/agent-profiles.ts";
 import { AgentConfigStore, validateAgentConfigs } from "../core/agent-config-store.ts";
 import type { AgentConfig } from "../core/agent-config-store.ts";
-import { AgentRegistry } from "../core/agent-registry.ts";
-import { ChannelRouter } from "../core/channel-router.ts";
-import { buildChannelContext } from "../core/channel-context-builder.ts";
-import { buildHistoryForAgent } from "../core/channel-history.ts";
+import { ConversationStore } from "../core/conversation-store.ts";
 import { EventBus } from "../core/event-bus.ts";
 import { MessageStore } from "../core/message-store.ts";
-import { RunManager } from "../core/run-manager.ts";
 import { SessionStore } from "../core/session-store.ts";
-import { TerminalTranscriptStore } from "../core/terminal-transcript-store.ts";
 import { WorkspaceStore } from "../core/workspace-store.ts";
-import type { AgentId, AgentProfile } from "../shared/types.ts";
+import type { Conversation, ConversationInfo, WorkspaceInfo } from "../shared/types.ts";
+import { ConversationContext } from "./conversation-context.ts";
 import { serveStatic } from "./static-server.ts";
 import { SseHub } from "./sse-hub.ts";
 
-const MAX_ROUTE_DEPTH = 5;
-const CHANNEL_ID = "default";
-const CONVERSATION_ID = "default";
 const port = Number(process.env.ORBIT_PORT ?? 4317);
 
+// --- Shared singletons ---
 const eventBus = new EventBus();
 const sseHub = new SseHub();
 const workspaceStore = new WorkspaceStore();
-const workspace = workspaceStore.resolve(process.cwd());
-const messagesPath = path.join(
-  workspaceStore.channelsDir(workspace.id, CHANNEL_ID, CONVERSATION_ID),
-  "messages.json",
-);
-const transcriptsDir = workspaceStore.transcriptsDir(workspace.id, CHANNEL_ID, CONVERSATION_ID);
-const messages = new MessageStore(messagesPath);
-const transcripts = new TerminalTranscriptStore(transcriptsDir);
-const sessionStore = new SessionStore(workspaceStore.sessionsDir(workspace.id));
 const configStore = new AgentConfigStore();
-let allConfigs = configStore.load(workspace.id);
-let enabledConfigs = allConfigs.filter((c) => c.enabled);
-let profiles = configsToProfiles(enabledConfigs, process.cwd());
-let agents = new AgentRegistry(profiles, eventBus, sessionStore, CHANNEL_ID, CONVERSATION_ID);
-let agentIds = agents.ids();
 
-eventBus.subscribe((event) => {
-  if (event.type === "terminal.chunk") {
-    transcripts.append(event.agentId, event.text);
+// --- Last-active persistence ---
+type LastActive = { workspaceId: string; conversationId: string };
+const lastActivePath = path.join(os.homedir(), ".orbit", "last-active.json");
+
+function loadLastActive(): LastActive | null {
+  try {
+    return JSON.parse(fs.readFileSync(lastActivePath, "utf8")) as LastActive;
+  } catch {
+    return null;
   }
-  sseHub.publish(event);
-});
+}
 
-agents.startAll();
+function saveLastActive(workspaceId: string, conversationId: string): void {
+  const dir = path.dirname(lastActivePath);
+  fs.mkdirSync(dir, { recursive: true });
+  const tmp = lastActivePath + ".tmp";
+  fs.writeFileSync(tmp, JSON.stringify({ workspaceId, conversationId }, null, 2) + os.EOL);
+  fs.renameSync(tmp, lastActivePath);
+}
 
-let channelRouter: ChannelRouter;
+// --- Active context state ---
+let activeWorkspaceId: string;
+let activeConversationId: string;
+let activeWorkspace: WorkspaceInfo;
+let activeConversation: ConversationInfo;
+let activeContext: ConversationContext;
+let allConfigs: AgentConfig[];
+let conversationStore: ConversationStore;
+let sessionStore: SessionStore;
 
-let runManager = new RunManager({
-  agents,
-  messages,
-  eventBus,
-  buildPrompt(agentId: AgentId, prompt: string) {
-    const history = buildHistoryForAgent(agentId, messages.list());
-    return buildChannelContext({ agentId, profiles, channelMessage: prompt, history });
-  },
-  onRunCompleted(message) {
-    channelRouter.process(message);
-  },
-});
+function initActiveContext(): void {
+  // Try to restore from last-active.json
+  const last = loadLastActive();
+  if (last && workspaceStore.get(last.workspaceId)) {
+    activeWorkspaceId = last.workspaceId;
+    const ws = workspaceStore.get(activeWorkspaceId)!;
+    activeWorkspace = { id: ws.id, name: ws.name, path: ws.path };
+    workspaceStore.touchLastOpened(activeWorkspaceId);
+  } else {
+    // Fall back to cwd-derived workspace
+    const ws = workspaceStore.resolve(process.cwd());
+    activeWorkspaceId = ws.id;
+    activeWorkspace = ws;
+  }
 
-channelRouter = new ChannelRouter({
-  availableAgents: agentIds,
-  maxRouteDepth: MAX_ROUTE_DEPTH,
-  createSystemMessage(content: string, parentMessageId?: string) {
-    const msg = messages.add({ kind: "system", content, status: "done", parentMessageId });
-    eventBus.publish({ type: "message.created", message: msg });
-    return msg;
-  },
-  startAgentRun(agentId: AgentId, prompt: string, sourceMessage) {
-    runManager.enqueue(agentId, prompt, sourceMessage);
-  },
-  markMessageRouted(messageId: string, routeState) {
-    messages.markRouteState(messageId, routeState);
-  },
-});
+  // SessionStore scoped to active workspace
+  sessionStore = new SessionStore(workspaceStore.sessionsDir(activeWorkspaceId));
 
+  // ConversationStore scoped to active workspace
+  conversationStore = new ConversationStore();
+
+  // Ensure default conversation exists (migration)
+  const defaultConv = conversationStore.ensureDefault(activeWorkspaceId);
+
+  // Restore last conversation or use default
+  if (last && last.conversationId && conversationStore.get(activeWorkspaceId, last.conversationId)) {
+    activeConversationId = last.conversationId;
+  } else {
+    activeConversationId = defaultConv.id;
+  }
+
+  const conv = conversationStore.get(activeWorkspaceId, activeConversationId)!;
+  activeConversation = { id: conv.id, name: conv.name };
+  conversationStore.touchLastOpened(activeWorkspaceId, activeConversationId);
+
+  // Load agent configs
+  allConfigs = configStore.load(activeWorkspaceId);
+  const enabledConfigs = allConfigs.filter((c) => c.enabled);
+  const profiles = configsToProfiles(enabledConfigs, activeWorkspace.path);
+
+  // Create context
+  activeContext = new ConversationContext({
+    workspaceId: activeWorkspaceId,
+    conversationId: activeConversationId,
+    profiles,
+    eventBus,
+    sessionStore,
+    workspaceStore,
+    sseHub,
+  });
+
+  saveLastActive(activeWorkspaceId, activeConversationId);
+}
+
+function switchWorkspace(workspaceId: string): void {
+  if (workspaceId === activeWorkspaceId) return;
+  if (activeContext.hasRunningAgent()) {
+    throw new Error("Cannot switch workspace while an agent is running.");
+  }
+
+  const ws = workspaceStore.get(workspaceId);
+  if (!ws) throw new Error(`Workspace not found: ${workspaceId}`);
+
+  activeContext.dispose();
+
+  activeWorkspaceId = workspaceId;
+  activeWorkspace = { id: ws.id, name: ws.name, path: ws.path };
+  workspaceStore.touchLastOpened(workspaceId);
+
+  // Rebuild session store and conversation store for new workspace
+  sessionStore = new SessionStore(workspaceStore.sessionsDir(activeWorkspaceId));
+  conversationStore = new ConversationStore();
+
+  const defaultConv = conversationStore.ensureDefault(activeWorkspaceId);
+  activeConversationId = defaultConv.id;
+  const conv = conversationStore.get(activeWorkspaceId, activeConversationId)!;
+  activeConversation = { id: conv.id, name: conv.name };
+  conversationStore.touchLastOpened(activeWorkspaceId, activeConversationId);
+
+  allConfigs = configStore.load(activeWorkspaceId);
+  const enabledConfigs = allConfigs.filter((c) => c.enabled);
+  const profiles = configsToProfiles(enabledConfigs, activeWorkspace.path);
+
+  activeContext = new ConversationContext({
+    workspaceId: activeWorkspaceId,
+    conversationId: activeConversationId,
+    profiles,
+    eventBus,
+    sessionStore,
+    workspaceStore,
+    sseHub,
+  });
+
+  saveLastActive(activeWorkspaceId, activeConversationId);
+  publishContextSwitched();
+}
+
+function switchConversation(conversationId: string): void {
+  if (conversationId === activeConversationId) return;
+  if (activeContext.hasRunningAgent()) {
+    throw new Error("Cannot switch conversation while an agent is running.");
+  }
+
+  const conv = conversationStore.get(activeWorkspaceId, conversationId);
+  if (!conv) throw new Error(`Conversation not found: ${conversationId}`);
+
+  activeContext.dispose();
+
+  activeConversationId = conversationId;
+  activeConversation = { id: conv.id, name: conv.name };
+  conversationStore.touchLastOpened(activeWorkspaceId, conversationId);
+
+  const enabledConfigs = allConfigs.filter((c) => c.enabled);
+  const profiles = configsToProfiles(enabledConfigs, activeWorkspace.path);
+
+  activeContext = new ConversationContext({
+    workspaceId: activeWorkspaceId,
+    conversationId: activeConversationId,
+    profiles,
+    eventBus,
+    sessionStore,
+    workspaceStore,
+    sseHub,
+  });
+
+  saveLastActive(activeWorkspaceId, activeConversationId);
+  publishContextSwitched();
+}
+
+function refreshEnabledAgents(): void {
+  const enabledConfigs = allConfigs.filter((c) => c.enabled);
+  const profiles = configsToProfiles(enabledConfigs, activeWorkspace.path);
+  activeContext.refreshProfiles(profiles);
+}
+
+function publishContextSwitched(): void {
+  sseHub.publish({
+    type: "context.switched",
+    workspace: activeWorkspace,
+    conversation: activeConversation,
+  });
+}
+
+// --- Initialize ---
+initActiveContext();
+
+// --- HTTP Server ---
 const server = http.createServer(async (req, res) => {
   try {
     const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
 
+    // SSE
     if (req.method === "GET" && url.pathname === "/events") {
       sseHub.add(res);
       return;
     }
 
+    // State
     if (req.method === "GET" && url.pathname === "/api/state") {
       sendJson(res, 200, {
-        workspace,
-        agents: agents.states(),
-        messages: messages.list(),
-        terminal: transcripts.all(),
+        workspace: activeWorkspace,
+        conversation: activeConversation,
+        agents: activeContext.agents.states(),
+        messages: activeContext.messages.list(),
+        terminal: activeContext.transcripts.all(),
       });
       return;
     }
 
+    // Messages
     if (req.method === "POST" && url.pathname === "/api/messages") {
       await handlePostMessage(req, res);
       return;
     }
 
+    // Agents
     if (req.method === "GET" && url.pathname === "/api/agents") {
       sendJson(res, 200, allConfigs);
       return;
@@ -117,16 +241,157 @@ const server = http.createServer(async (req, res) => {
     }
 
     if (req.method === "POST" && url.pathname === "/api/agents/reset") {
-      if (hasRunningAgent()) {
+      if (activeContext.hasRunningAgent()) {
         sendJson(res, 409, { ok: false, message: "Cannot reset while an agent is running. Wait for it to finish." });
         return;
       }
-      allConfigs = configStore.reset(workspace.id);
+      allConfigs = configStore.reset(activeWorkspaceId);
       refreshEnabledAgents();
       sendJson(res, 200, allConfigs);
       return;
     }
 
+    // --- Workspace endpoints ---
+
+    if (req.method === "GET" && url.pathname === "/api/workspaces") {
+      sendJson(res, 200, workspaceStore.list());
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/api/workspaces") {
+      const input = (await readJson(req)) as { name?: unknown; path?: unknown };
+      const name = typeof input.name === "string" ? input.name.trim() : "";
+      const wsPath = typeof input.path === "string" ? input.path.trim() : "";
+      if (!name || !wsPath) {
+        sendJson(res, 400, { ok: false, message: "name and path are required." });
+        return;
+      }
+      try {
+        const ws = workspaceStore.create(name, wsPath);
+        sendJson(res, 200, ws);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        sendJson(res, 409, { ok: false, message: msg });
+      }
+      return;
+    }
+
+    if (req.method === "PUT" && url.pathname.startsWith("/api/workspaces/")) {
+      const parts = url.pathname.split("/");
+      const wsId = parts[3];
+      if (!wsId) { sendJson(res, 400, { ok: false, message: "Missing workspace id." }); return; }
+      const input = (await readJson(req)) as { name?: unknown };
+      const name = typeof input.name === "string" ? input.name.trim() : undefined;
+      try {
+        const ws = workspaceStore.update(wsId, { name });
+        sendJson(res, 200, ws);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        sendJson(res, 404, { ok: false, message: msg });
+      }
+      return;
+    }
+
+    if (req.method === "DELETE" && url.pathname.startsWith("/api/workspaces/")) {
+      const parts = url.pathname.split("/");
+      const wsId = parts[3];
+      if (!wsId) { sendJson(res, 400, { ok: false, message: "Missing workspace id." }); return; }
+      if (wsId === activeWorkspaceId) {
+        sendJson(res, 400, { ok: false, message: "Cannot delete the active workspace. Switch to another first." });
+        return;
+      }
+      try {
+        workspaceStore.delete(wsId);
+        sendJson(res, 200, { ok: true });
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        sendJson(res, 404, { ok: false, message: msg });
+      }
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname.startsWith("/api/workspaces/") && url.pathname.endsWith("/switch")) {
+      const parts = url.pathname.split("/");
+      const wsId = parts[3];
+      if (!wsId) { sendJson(res, 400, { ok: false, message: "Missing workspace id." }); return; }
+      try {
+        switchWorkspace(wsId);
+        sendJson(res, 200, { ok: true, workspace: activeWorkspace, conversation: activeConversation });
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        sendJson(res, 409, { ok: false, message: msg });
+      }
+      return;
+    }
+
+    // --- Conversation endpoints ---
+
+    if (req.method === "GET" && url.pathname === "/api/conversations") {
+      sendJson(res, 200, conversationStore.list(activeWorkspaceId));
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/api/conversations") {
+      const input = (await readJson(req)) as { name?: unknown };
+      const name = typeof input.name === "string" ? input.name.trim() : "";
+      if (!name) {
+        sendJson(res, 400, { ok: false, message: "name is required." });
+        return;
+      }
+      const conv = conversationStore.create(activeWorkspaceId, name);
+      sendJson(res, 200, conv);
+      return;
+    }
+
+    if (req.method === "PUT" && url.pathname.startsWith("/api/conversations/")) {
+      const parts = url.pathname.split("/");
+      const convId = parts[3];
+      if (!convId) { sendJson(res, 400, { ok: false, message: "Missing conversation id." }); return; }
+      const input = (await readJson(req)) as { name?: unknown };
+      const name = typeof input.name === "string" ? input.name.trim() : undefined;
+      try {
+        const conv = conversationStore.update(activeWorkspaceId, convId, { name });
+        sendJson(res, 200, conv);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        sendJson(res, 404, { ok: false, message: msg });
+      }
+      return;
+    }
+
+    if (req.method === "DELETE" && url.pathname.startsWith("/api/conversations/")) {
+      const parts = url.pathname.split("/");
+      const convId = parts[3];
+      if (!convId) { sendJson(res, 400, { ok: false, message: "Missing conversation id." }); return; }
+      if (convId === activeConversationId) {
+        sendJson(res, 400, { ok: false, message: "Cannot delete the active conversation. Switch to another first." });
+        return;
+      }
+      try {
+        conversationStore.delete(activeWorkspaceId, convId);
+        sendJson(res, 200, { ok: true });
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        sendJson(res, 404, { ok: false, message: msg });
+      }
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname.startsWith("/api/conversations/") && url.pathname.endsWith("/switch")) {
+      const parts = url.pathname.split("/");
+      const convId = parts[3];
+      if (!convId) { sendJson(res, 400, { ok: false, message: "Missing conversation id." }); return; }
+      try {
+        switchConversation(convId);
+        sendJson(res, 200, { ok: true, workspace: activeWorkspace, conversation: activeConversation });
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        sendJson(res, 409, { ok: false, message: msg });
+      }
+      return;
+    }
+
+    // Static files
     if (req.method === "GET" && serveStatic(url.pathname, res)) {
       return;
     }
@@ -142,6 +407,8 @@ server.listen(port, () => {
   console.log(`[orbit] listening on http://localhost:${port}`);
 });
 
+// --- Helpers ---
+
 async function handlePostMessage(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
   const input = (await readJson(req)) as { content?: unknown };
   const content = typeof input.content === "string" ? input.content.trim() : "";
@@ -151,10 +418,9 @@ async function handlePostMessage(req: http.IncomingMessage, res: http.ServerResp
     return;
   }
 
-  const userMessage = messages.add({ kind: "user", content, status: "sent" });
+  const userMessage = activeContext.messages.add({ kind: "user", content, status: "sent" });
   eventBus.publish({ type: "message.created", message: userMessage });
-
-  channelRouter.process(userMessage);
+  activeContext.channelRouter.process(userMessage);
 
   sendJson(res, 200, { ok: true, messageId: userMessage.id });
 }
@@ -187,51 +453,8 @@ function sendJson(res: http.ServerResponse, status: number, value: unknown): voi
   res.end(JSON.stringify(value));
 }
 
-function refreshEnabledAgents(): void {
-  enabledConfigs = allConfigs.filter((c) => c.enabled);
-  profiles = configsToProfiles(enabledConfigs, process.cwd());
-  agents.stopAll();
-  agents = new AgentRegistry(profiles, eventBus, sessionStore, CHANNEL_ID, CONVERSATION_ID);
-  agentIds = agents.ids();
-  agents.startAll();
-
-  runManager.dispose();
-  runManager = new RunManager({
-    agents,
-    messages,
-    eventBus,
-    buildPrompt(agentId: AgentId, prompt: string) {
-      const history = buildHistoryForAgent(agentId, messages.list());
-      return buildChannelContext({ agentId, profiles, channelMessage: prompt, history });
-    },
-    onRunCompleted(message) {
-      channelRouter.process(message);
-    },
-  });
-
-  channelRouter = new ChannelRouter({
-    availableAgents: agentIds,
-    maxRouteDepth: MAX_ROUTE_DEPTH,
-    createSystemMessage(content: string, parentMessageId?: string) {
-      const msg = messages.add({ kind: "system", content, status: "done", parentMessageId });
-      eventBus.publish({ type: "message.created", message: msg });
-      return msg;
-    },
-    startAgentRun(agentId: AgentId, prompt: string, sourceMessage) {
-      runManager.enqueue(agentId, prompt, sourceMessage);
-    },
-    markMessageRouted(messageId: string, routeState) {
-      messages.markRouteState(messageId, routeState);
-    },
-  });
-}
-
-function hasRunningAgent(): boolean {
-  return agents.states().some((s) => s.status === "running");
-}
-
 async function handlePutAgents(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
-  if (hasRunningAgent()) {
+  if (activeContext.hasRunningAgent()) {
     sendJson(res, 409, { ok: false, message: "Cannot save while an agent is running. Wait for it to finish." });
     return;
   }
@@ -249,13 +472,13 @@ async function handlePutAgents(req: http.IncomingMessage, res: http.ServerRespon
   }
 
   allConfigs = input;
-  configStore.save(workspace.id, allConfigs);
+  configStore.save(activeWorkspaceId, allConfigs);
   refreshEnabledAgents();
   sendJson(res, 200, allConfigs);
 }
 
 function shutdown(): void {
-  agents.stopAll();
+  activeContext.dispose();
   server.close(() => {
     process.exit(0);
   });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -100,7 +100,8 @@ export type RuntimeEvent =
   | { type: "terminal.chunk"; agentId: AgentId; runId?: string; text: string }
   | { type: "run.completed"; agentId: AgentId; runId: string; resultMessageId: string }
   | { type: "run.failed"; agentId: AgentId; runId: string; error: string }
-  | { type: "run.sessionId"; agentId: AgentId; runId: string; sessionId: string };
+  | { type: "run.sessionId"; agentId: AgentId; runId: string; sessionId: string }
+  | { type: "context.switched"; workspace: WorkspaceInfo; conversation: ConversationInfo };
 
 export type TerminalState = Record<string, string>;
 
@@ -110,8 +111,25 @@ export type WorkspaceInfo = {
   path: string;
 };
 
+export type Workspace = WorkspaceInfo & {
+  createdAt: string;
+  lastOpenedAt: string;
+};
+
+export type ConversationInfo = {
+  id: string;
+  name: string;
+};
+
+export type Conversation = ConversationInfo & {
+  workspaceId: string;
+  createdAt: string;
+  lastOpenedAt: string;
+};
+
 export type AppState = {
   workspace: WorkspaceInfo;
+  conversation: ConversationInfo;
   messages: ChatMessage[];
   agents: AgentState[];
   terminal: TerminalState;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -92,15 +92,22 @@ export type NewChatMessage = Omit<ChatMessage, "id" | "createdAt"> & {
   createdAt?: never;
 };
 
+export type RunningSummary = {
+  workspaceId: string;
+  conversationId: string;
+  runningAgentIds: AgentId[];
+};
+
 export type RuntimeEvent =
-  | { type: "message.created"; message: ChatMessage }
-  | { type: "message.updated"; message: ChatMessage }
-  | { type: "agent.status"; agentId: AgentId; status: AgentStatus }
-  | { type: "run.activity"; agentId: AgentId; runId: string; activity: AgentActivityEvent }
-  | { type: "terminal.chunk"; agentId: AgentId; runId?: string; text: string }
-  | { type: "run.completed"; agentId: AgentId; runId: string; resultMessageId: string }
-  | { type: "run.failed"; agentId: AgentId; runId: string; error: string }
-  | { type: "run.sessionId"; agentId: AgentId; runId: string; sessionId: string }
+  | { type: "message.created"; conversationId: string; message: ChatMessage }
+  | { type: "message.updated"; conversationId: string; message: ChatMessage }
+  | { type: "agent.status"; conversationId: string; agentId: AgentId; status: AgentStatus }
+  | { type: "run.activity"; conversationId: string; agentId: AgentId; runId: string; activity: AgentActivityEvent }
+  | { type: "terminal.chunk"; conversationId: string; agentId: AgentId; runId?: string; text: string }
+  | { type: "run.completed"; conversationId: string; agentId: AgentId; runId: string; resultMessageId: string }
+  | { type: "run.failed"; conversationId: string; agentId: AgentId; runId: string; error: string }
+  | { type: "run.sessionId"; conversationId: string; agentId: AgentId; runId: string; sessionId: string }
+  | { type: "running.updated"; summaries: RunningSummary[] }
   | { type: "context.switched"; workspace: WorkspaceInfo; conversation: ConversationInfo };
 
 export type TerminalState = Record<string, string>;
@@ -133,4 +140,5 @@ export type AppState = {
   messages: ChatMessage[];
   agents: AgentState[];
   terminal: TerminalState;
+  runningSummaries: RunningSummary[];
 };

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -498,7 +498,7 @@ export function App() {
             ) : (
               workspaces.map((ws) => {
                 const isActiveWorkspace = ws.id === state.workspace.id;
-                const isWorkspaceConversationOpen = isActiveWorkspace && !collapsedWorkspaceIds.has(ws.id);
+                const isWorkspaceConversationOpen = !collapsedWorkspaceIds.has(ws.id);
                 return (
                   <div className="workspaceGroup" key={ws.id}>
                     <div className={`workspaceTreeRow ${isActiveWorkspace ? "active" : ""}`}>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,7 +1,7 @@
 import { CSSProperties, FormEvent, KeyboardEvent, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { renderMarkdown } from "./markdown-renderer.ts";
 import { permissionProfile } from "../core/agent-profiles.ts";
-import type { AgentActivityEvent, AgentConfig, AgentId, AgentRole, AgentRuntimeKind, AgentState, AppState, ChatMessage, Conversation, ConversationInfo, PermissionProfile, RuntimeEvent, Workspace } from "../shared/types.ts";
+import type { AgentActivityEvent, AgentConfig, AgentId, AgentRole, AgentRuntimeKind, AgentState, AppState, ChatMessage, Conversation, ConversationInfo, PermissionProfile, RunningSummary, RuntimeEvent, Workspace } from "../shared/types.ts";
 
 const initialState: AppState = {
   workspace: { id: "", name: "", path: "" },
@@ -9,6 +9,7 @@ const initialState: AppState = {
   agents: [],
   messages: [],
   terminal: {},
+  runningSummaries: [],
 };
 
 export function App() {
@@ -278,7 +279,7 @@ export function App() {
   }
 
   async function switchWorkspace(workspaceId: string) {
-    if (workspaceId === state.workspace.id || isAnyAgentRunning) return;
+    if (workspaceId === state.workspace.id) return;
     const response = await fetch(`/api/workspaces/${workspaceId}/switch`, { method: "POST" });
     if (!response.ok) return;
     refreshWorkspaces();
@@ -364,7 +365,7 @@ export function App() {
     }
 
   async function switchConversation(conversationId: string) {
-    if (conversationId === state.conversation.id || isAnyAgentRunning) return;
+    if (conversationId === state.conversation.id) return;
     const response = await fetch(`/api/conversations/${conversationId}/switch`, { method: "POST" });
     if (!response.ok) return;
     refreshConversations();
@@ -524,7 +525,7 @@ export function App() {
                           />
                         </form>
                       ) : (
-                        <button className="workspaceNameButton" type="button" onClick={() => handleWorkspaceClick(ws.id)} disabled={isAnyAgentRunning && !isActiveWorkspace} title={ws.path}>
+                        <button className="workspaceNameButton" type="button" onClick={() => handleWorkspaceClick(ws.id)} title={ws.path}>
                           <NavIcon kind="workspace" />
                           <span>{ws.name}</span>
                         </button>
@@ -589,9 +590,14 @@ export function App() {
                                 />
                               </form>
                             ) : (
-                              <button type="button" onClick={() => switchConversation(conv.id)} disabled={isAnyAgentRunning} title={conv.name}>
-                                <span>{conv.name}</span>
-                              </button>
+                              <>
+                                <button type="button" onClick={() => switchConversation(conv.id)} title={conv.name}>
+                                  <span>{conv.name}</span>
+                                </button>
+                                {isConversationRunning(state.runningSummaries, ws.id, conv.id) && (
+                                  <span className="conversationRunningDot" title="Agent running" />
+                                )}
+                              </>
                             )}
                             <div className="rowMenuWrap">
                               <button
@@ -1311,6 +1317,15 @@ function PlainText({ content }: { content: string }) {
 }
 
 function applyEvent(state: AppState, event: RuntimeEvent): AppState {
+  if (event.type === "running.updated") {
+    return { ...state, runningSummaries: event.summaries };
+  }
+
+  // For conversation-scoped events, only process if they match the active conversation
+  if ("conversationId" in event && event.conversationId !== state.conversation.id) {
+    return state;
+  }
+
   if (event.type === "message.created") {
     return upsertMessage(state, event.message);
   }
@@ -1368,6 +1383,7 @@ function normalizeState(nextState: AppState): AppState {
     terminal: {
       ...(nextState.terminal ?? {}),
     },
+    runningSummaries: nextState.runningSummaries ?? [],
   };
 }
 
@@ -1414,6 +1430,16 @@ function connectionLabel(state: "connecting" | "live" | "offline"): string {
 const SIDEBAR_MIN_WIDTH = 280;
 const SIDEBAR_MAX_WIDTH = 460;
 const SIDEBAR_DEFAULT_WIDTH = 336;
+
+function isConversationRunning(
+  summaries: RunningSummary[],
+  workspaceId: string,
+  conversationId: string,
+): boolean {
+  return summaries.some(
+    (r) => r.workspaceId === workspaceId && r.conversationId === conversationId,
+  );
+}
 
 function loadSidebarWidth(): number {
   if (typeof window === "undefined") {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -688,12 +688,13 @@ export function App() {
                 <span>点击右上角 +，启用默认模板或添加自定义智能体。</span>
               </div>
             ) : (
-              agentIds.map((agentId) => (
+              agentIds.map((agentId, index) => (
                 <AgentButton
                   key={agentId}
                   agent={agentsById.get(agentId) ?? { id: agentId, label: agentId, runtime: "claude-code", status: "idle" }}
                   selected={selectedAgent === agentId}
                   onClick={() => chooseAgent(agentId)}
+                  isFirst={index === 0}
                 />
               ))
             )}
@@ -945,11 +946,11 @@ function NavIcon({ kind }: { kind: "workspace" | "conversation" | "agents" | "se
   );
 }
 
-function AgentButton(props: { agent: AgentState; selected: boolean; onClick: () => void }) {
+function AgentButton(props: { agent: AgentState; selected: boolean; onClick: () => void; isFirst?: boolean }) {
   const isRunning = props.agent.status === "running" || props.agent.status === "starting";
+  const showRunning = !props.isFirst && isRunning;
   return (
-    <button className={`agentButton ${props.selected ? "selected" : ""} ${isRunning ? "agentRunning" : ""}`} onClick={props.onClick} type="button">
-      {isRunning ? <span className="agentProgressBar" aria-hidden="true" /> : null}
+    <button className={`agentButton ${props.selected ? "selected" : ""} ${showRunning ? "agentRunning" : ""}`} onClick={props.onClick} type="button">
       <span className={`statusDot ${props.agent.status}`} aria-hidden="true" />
       <span className="agentText">
         <strong>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -401,38 +401,40 @@ export function App() {
 
   async function switchConversation(conversationId: string, targetWorkspaceId?: string) {
     if (conversationId === state.conversation.id) return;
-    // If the conversation belongs to a different workspace, switch workspace first
-    if (targetWorkspaceId && targetWorkspaceId !== state.workspace.id) {
-      const wsResponse = await fetch(`/api/workspaces/${targetWorkspaceId}/switch`, { method: "POST" });
-      if (!wsResponse.ok) return;
-    }
-    const response = await fetch(`/api/conversations/${conversationId}/switch`, { method: "POST" });
+    const wsParam = targetWorkspaceId && targetWorkspaceId !== state.workspace.id ? `?workspaceId=${targetWorkspaceId}` : "";
+    const response = await fetch(`/api/conversations/${conversationId}/switch${wsParam}`, { method: "POST" });
     if (!response.ok) return;
     refreshConversations();
     refreshState();
   }
 
-  async function createConversation() {
-    if (!state.workspace.id) return;
-    // Active workspace is always expanded, no need to track in expandedWorkspaceIds
-    const response = await fetch("/api/conversations", {
+  async function createConversation(workspaceId: string) {
+    const wsParam = workspaceId !== state.workspace.id ? `?workspaceId=${workspaceId}` : "";
+    const response = await fetch(`/api/conversations${wsParam}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({}),
     });
     if (!response.ok) return;
+    // Expand the workspace so user sees the new conversation
+    setExpandedWorkspaceIds((ids) => {
+      const next = new Set(ids);
+      next.add(workspaceId);
+      return next;
+    });
     refreshConversations();
     refreshState();
   }
 
-  async function renameConversation(conversationId: string, name: string) {
+  async function renameConversation(conversationId: string, name: string, workspaceId?: string) {
     const trimmed = name.trim();
     if (!trimmed) {
       setEditingConversationId(null);
       setEditingConversationName("");
       return;
     }
-    const response = await fetch(`/api/conversations/${conversationId}`, {
+    const wsParam = workspaceId && workspaceId !== state.workspace.id ? `?workspaceId=${workspaceId}` : "";
+    const response = await fetch(`/api/conversations/${conversationId}${wsParam}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: trimmed }),
@@ -594,8 +596,8 @@ export function App() {
                           </div>
                         ) : null}
                       </div>
-                      {isActiveWorkspace ? (
-                        <button className="rowIconButton persistent" type="button" onClick={createConversation} title="新建会话">
+                      {isWorkspaceConversationOpen ? (
+                        <button className="rowIconButton persistent" type="button" onClick={() => createConversation(ws.id)} title="新建会话">
                           <NavIcon kind="edit" />
                         </button>
                       ) : null}
@@ -609,13 +611,13 @@ export function App() {
                                 className="rowRenameForm"
                                 onSubmit={(event) => {
                                   event.preventDefault();
-                                  renameConversation(conv.id, editingConversationName);
+                                  renameConversation(conv.id, editingConversationName, ws.id);
                                 }}
                               >
                                 <input
                                   value={editingConversationName}
                                   onChange={(event) => setEditingConversationName(event.target.value)}
-                                  onBlur={() => renameConversation(conv.id, editingConversationName)}
+                                  onBlur={() => renameConversation(conv.id, editingConversationName, ws.id)}
                                   onKeyDown={(event) => {
                                     if (event.key === "Escape") {
                                       setEditingConversationId(null);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -628,14 +628,14 @@ export function App() {
                                 />
                               </form>
                             ) : (
-                              <>
+                              <div className="conversationRowName">
                                 <button type="button" onClick={() => switchConversation(conv.id, ws.id)} title={conv.name}>
                                   <span>{conv.name}</span>
                                 </button>
                                 {isConversationRunning(state.runningSummaries, ws.id, conv.id) && (
                                   <span className="conversationRunningDot" title="Agent running" />
                                 )}
-                              </>
+                              </div>
                             )}
                             <div className="rowMenuWrap">
                               <button

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -399,8 +399,13 @@ export function App() {
       }
     }
 
-  async function switchConversation(conversationId: string) {
+  async function switchConversation(conversationId: string, targetWorkspaceId?: string) {
     if (conversationId === state.conversation.id) return;
+    // If the conversation belongs to a different workspace, switch workspace first
+    if (targetWorkspaceId && targetWorkspaceId !== state.workspace.id) {
+      const wsResponse = await fetch(`/api/workspaces/${targetWorkspaceId}/switch`, { method: "POST" });
+      if (!wsResponse.ok) return;
+    }
     const response = await fetch(`/api/conversations/${conversationId}/switch`, { method: "POST" });
     if (!response.ok) return;
     refreshConversations();
@@ -622,7 +627,7 @@ export function App() {
                               </form>
                             ) : (
                               <>
-                                <button type="button" onClick={() => switchConversation(conv.id)} title={conv.name}>
+                                <button type="button" onClick={() => switchConversation(conv.id, ws.id)} title={conv.name}>
                                   <span>{conv.name}</span>
                                 </button>
                                 {isConversationRunning(state.runningSummaries, ws.id, conv.id) && (

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -446,7 +446,7 @@ export function App() {
 
   async function deleteConversation(conversation: Conversation) {
     if (!confirm(`Delete conversation "${conversation.name}"?`)) return;
-    const response = await fetch(`/api/conversations/${conversation.id}`, { method: "DELETE" });
+    const response = await fetch(`/api/conversations/${conversation.id}?workspaceId=${conversation.workspaceId}`, { method: "DELETE" });
     if (response.ok) {
       setOpenConversationMenuId(null);
       refreshConversations();

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -28,14 +28,14 @@ export function App() {
   const [showSettings, setShowSettings] = useState(false);
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [conversations, setConversations] = useState<Conversation[]>([]);
-  const [showNewWorkspace, setShowNewWorkspace] = useState(false);
-  const [showWorkspaceConversations, setShowWorkspaceConversations] = useState(true);
   const [showAgentManager, setShowAgentManager] = useState(false);
-  const [newWorkspacePath, setNewWorkspacePath] = useState("");
   const [editingWorkspaceId, setEditingWorkspaceId] = useState<string | null>(null);
   const [editingWorkspaceName, setEditingWorkspaceName] = useState("");
   const [editingConversationId, setEditingConversationId] = useState<string | null>(null);
   const [editingConversationName, setEditingConversationName] = useState("");
+  const [openWorkspaceMenuId, setOpenWorkspaceMenuId] = useState<string | null>(null);
+  const [openConversationMenuId, setOpenConversationMenuId] = useState<string | null>(null);
+  const [collapsedWorkspaceIds, setCollapsedWorkspaceIds] = useState<Set<string>>(() => new Set());
   const [isPickingDirectory, setIsPickingDirectory] = useState(false);
   const [sidebarWidth, setSidebarWidth] = useState(() => loadSidebarWidth());
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
@@ -178,6 +178,32 @@ export function App() {
     setSelectedMentionIndex(0);
   }, [mentionDraft?.query]);
 
+  useEffect(() => {
+    if (!openWorkspaceMenuId && !openConversationMenuId) return;
+
+    function closeMenusOnOutsideClick(event: PointerEvent) {
+      const target = event.target;
+      if (target instanceof Element && target.closest(".rowMenuWrap")) {
+        return;
+      }
+      setOpenWorkspaceMenuId(null);
+      setOpenConversationMenuId(null);
+    }
+
+    function closeMenusOnEscape(event: globalThis.KeyboardEvent) {
+      if (event.key !== "Escape") return;
+      setOpenWorkspaceMenuId(null);
+      setOpenConversationMenuId(null);
+    }
+
+    document.addEventListener("pointerdown", closeMenusOnOutsideClick);
+    document.addEventListener("keydown", closeMenusOnEscape);
+    return () => {
+      document.removeEventListener("pointerdown", closeMenusOnOutsideClick);
+      document.removeEventListener("keydown", closeMenusOnEscape);
+    };
+  }, [openWorkspaceMenuId, openConversationMenuId]);
+
   function handleMessagesScroll() {
     const el = messagesRef.current;
     if (!el) return;
@@ -260,29 +286,43 @@ export function App() {
     refreshState();
   }
 
-  async function createWorkspace(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    if (!newWorkspacePath.trim()) return;
-    const response = await fetch("/api/workspaces", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ path: newWorkspacePath }),
-    });
-    if (!response.ok) return;
-    setShowNewWorkspace(false);
-    setNewWorkspacePath("");
-    refreshWorkspaces();
+  function handleWorkspaceClick(workspaceId: string) {
+    if (workspaceId === state.workspace.id) {
+      setCollapsedWorkspaceIds((ids) => {
+        const next = new Set(ids);
+        if (next.has(workspaceId)) {
+          next.delete(workspaceId);
+        } else {
+          next.add(workspaceId);
+        }
+        return next;
+      });
+      return;
+    }
+
+    switchWorkspace(workspaceId);
   }
 
-  async function pickWorkspaceDirectory() {
+  async function createWorkspaceFromDirectoryPicker() {
     setIsPickingDirectory(true);
     try {
-      const response = await fetch("/api/workspaces/pick-directory", { method: "POST" });
-      if (!response.ok) return;
-      const result = (await response.json()) as { path?: string };
-      if (result.path) {
-        setNewWorkspacePath(result.path);
+      const pickResponse = await fetch("/api/workspaces/pick-directory", { method: "POST" });
+      if (!pickResponse.ok) return;
+      const result = (await pickResponse.json()) as { path?: string };
+      const selectedPath = result.path?.trim();
+      if (!selectedPath) return;
+
+      const createResponse = await fetch("/api/workspaces", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path: selectedPath }),
+      });
+      if (!createResponse.ok) return;
+      const workspace = (await createResponse.json()) as Workspace;
+      if (workspace.id) {
+        await switchWorkspace(workspace.id);
       }
+      refreshWorkspaces();
     } finally {
       setIsPickingDirectory(false);
     }
@@ -290,7 +330,11 @@ export function App() {
 
   async function renameWorkspace(workspaceId: string, name: string) {
     const trimmed = name.trim();
-    if (!trimmed) return;
+    if (!trimmed) {
+      setEditingWorkspaceId(null);
+      setEditingWorkspaceName("");
+      return;
+    }
     const response = await fetch(`/api/workspaces/${workspaceId}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -304,11 +348,20 @@ export function App() {
   }
 
   async function deleteWorkspace(workspace: Workspace) {
-    if (workspace.id === state.workspace.id) return;
     if (!confirm(`Delete workspace "${workspace.name}"?`)) return;
     const response = await fetch(`/api/workspaces/${workspace.id}`, { method: "DELETE" });
-    if (response.ok) refreshWorkspaces();
-  }
+      if (response.ok) {
+        setOpenWorkspaceMenuId(null);
+        setCollapsedWorkspaceIds((ids) => {
+          const next = new Set(ids);
+          next.delete(workspace.id);
+          return next;
+        });
+        refreshWorkspaces();
+        refreshConversations();
+        refreshState();
+      }
+    }
 
   async function switchConversation(conversationId: string) {
     if (conversationId === state.conversation.id || isAnyAgentRunning) return;
@@ -320,6 +373,11 @@ export function App() {
 
   async function createConversation() {
     if (!state.workspace.id) return;
+    setCollapsedWorkspaceIds((ids) => {
+      const next = new Set(ids);
+      next.delete(state.workspace.id);
+      return next;
+    });
     const response = await fetch("/api/conversations", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -332,7 +390,11 @@ export function App() {
 
   async function renameConversation(conversationId: string, name: string) {
     const trimmed = name.trim();
-    if (!trimmed) return;
+    if (!trimmed) {
+      setEditingConversationId(null);
+      setEditingConversationName("");
+      return;
+    }
     const response = await fetch(`/api/conversations/${conversationId}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -346,10 +408,13 @@ export function App() {
   }
 
   async function deleteConversation(conversation: Conversation) {
-    if (conversation.id === state.conversation.id) return;
     if (!confirm(`Delete conversation "${conversation.name}"?`)) return;
     const response = await fetch(`/api/conversations/${conversation.id}`, { method: "DELETE" });
-    if (response.ok) refreshConversations();
+    if (response.ok) {
+      setOpenConversationMenuId(null);
+      refreshConversations();
+      refreshState();
+    }
   }
 
   function updateCursorFromInput() {
@@ -424,143 +489,146 @@ export function App() {
 
         <section className="navSection workspaceStack" aria-label="当前工作区和会话">
           <div className="navSectionHeader">
-            <span><NavIcon kind="workspace" />工作区</span>
-            <button type="button" onClick={() => setShowNewWorkspace((value) => !value)} title="新建工作区">+</button>
+            <span>工作区</span>
+            <button type="button" onClick={createWorkspaceFromDirectoryPicker} disabled={isPickingDirectory} title="新建工作区">+</button>
           </div>
-          <div className="workspaceCard">
-            <div className="navList workspaceList">
-              {workspaces.length === 0 ? (
-                <div className="emptyNavHint">还没有工作区</div>
-              ) : (
-                workspaces.map((ws) => (
-                  <div className={`navRow workspaceRow ${ws.id === state.workspace.id ? "active" : ""}`} key={ws.id}>
-                    {editingWorkspaceId === ws.id ? (
-                      <form
-                        className="rowRenameForm"
-                        onSubmit={(event) => {
-                          event.preventDefault();
-                          renameWorkspace(ws.id, editingWorkspaceName);
-                        }}
-                      >
-                        <input
-                          value={editingWorkspaceName}
-                          onChange={(event) => setEditingWorkspaceName(event.target.value)}
-                          onBlur={() => renameWorkspace(ws.id, editingWorkspaceName)}
-                          onKeyDown={(event) => {
-                            if (event.key === "Escape") {
-                              setEditingWorkspaceId(null);
-                              setEditingWorkspaceName("");
-                            }
+          <div className="workspaceTree">
+            {workspaces.length === 0 ? (
+              <div className="emptyNavHint">还没有工作区</div>
+            ) : (
+              workspaces.map((ws) => {
+                const isActiveWorkspace = ws.id === state.workspace.id;
+                const isWorkspaceConversationOpen = isActiveWorkspace && !collapsedWorkspaceIds.has(ws.id);
+                return (
+                  <div className="workspaceGroup" key={ws.id}>
+                    <div className={`workspaceTreeRow ${isActiveWorkspace ? "active" : ""}`}>
+                      {editingWorkspaceId === ws.id ? (
+                        <form
+                          className="rowRenameForm"
+                          onSubmit={(event) => {
+                            event.preventDefault();
+                            renameWorkspace(ws.id, editingWorkspaceName);
                           }}
-                          autoFocus
-                        />
-                        <small title={ws.path}>{ws.path}</small>
-                      </form>
-                    ) : (
-                      <button type="button" onClick={() => switchWorkspace(ws.id)} disabled={isAnyAgentRunning}>
-                        <span>{ws.name}</span>
-                        <small title={ws.path}>{ws.path}</small>
-                      </button>
-                    )}
-                    {editingWorkspaceId !== ws.id ? (
-                      <button
-                        className="rowIconButton"
-                        type="button"
-                        onClick={() => {
-                          setEditingWorkspaceId(ws.id);
-                          setEditingWorkspaceName(ws.name);
-                        }}
-                        title="重命名工作区"
-                      >
-                        <NavIcon kind="edit" />
-                      </button>
-                    ) : null}
-                    {ws.id !== state.workspace.id && editingWorkspaceId !== ws.id ? (
-                      <button className="rowIconButton" type="button" onClick={() => deleteWorkspace(ws)} title="删除工作区">x</button>
+                        >
+                          <input
+                            value={editingWorkspaceName}
+                            onChange={(event) => setEditingWorkspaceName(event.target.value)}
+                            onBlur={() => renameWorkspace(ws.id, editingWorkspaceName)}
+                            onKeyDown={(event) => {
+                              if (event.key === "Escape") {
+                                setEditingWorkspaceId(null);
+                                setEditingWorkspaceName("");
+                              }
+                            }}
+                            autoFocus
+                          />
+                        </form>
+                      ) : (
+                        <button className="workspaceNameButton" type="button" onClick={() => handleWorkspaceClick(ws.id)} disabled={isAnyAgentRunning && !isActiveWorkspace} title={ws.path}>
+                          <NavIcon kind="workspace" />
+                          <span>{ws.name}</span>
+                        </button>
+                      )}
+                      <div className="rowMenuWrap">
+                        <button
+                          className="rowIconButton persistent"
+                          type="button"
+                          onClick={() => {
+                            setOpenConversationMenuId(null);
+                            setOpenWorkspaceMenuId((id) => (id === ws.id ? null : ws.id));
+                          }}
+                          title="工作区操作"
+                        >
+                          ...
+                        </button>
+                        {openWorkspaceMenuId === ws.id ? (
+                          <div className="rowActionMenu">
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setOpenWorkspaceMenuId(null);
+                                setEditingWorkspaceId(ws.id);
+                                setEditingWorkspaceName(ws.name);
+                              }}
+                            >
+                              重命名工作区
+                            </button>
+                            <button type="button" onClick={() => deleteWorkspace(ws)}>删除工作区</button>
+                          </div>
+                        ) : null}
+                      </div>
+                      {isActiveWorkspace ? (
+                        <button className="rowIconButton persistent" type="button" onClick={createConversation} title="新建会话">
+                          <NavIcon kind="edit" />
+                        </button>
+                      ) : null}
+                    </div>
+                    {isWorkspaceConversationOpen ? (
+                      <div className="navList conversationList">
+                        {conversations.map((conv) => (
+                          <div className={`conversationRow ${conv.id === state.conversation.id ? "active" : ""}`} key={conv.id}>
+                            {editingConversationId === conv.id ? (
+                              <form
+                                className="rowRenameForm"
+                                onSubmit={(event) => {
+                                  event.preventDefault();
+                                  renameConversation(conv.id, editingConversationName);
+                                }}
+                              >
+                                <input
+                                  value={editingConversationName}
+                                  onChange={(event) => setEditingConversationName(event.target.value)}
+                                  onBlur={() => renameConversation(conv.id, editingConversationName)}
+                                  onKeyDown={(event) => {
+                                    if (event.key === "Escape") {
+                                      setEditingConversationId(null);
+                                      setEditingConversationName("");
+                                    }
+                                  }}
+                                  autoFocus
+                                />
+                              </form>
+                            ) : (
+                              <button type="button" onClick={() => switchConversation(conv.id)} disabled={isAnyAgentRunning} title={conv.name}>
+                                <span>{conv.name}</span>
+                              </button>
+                            )}
+                            <div className="rowMenuWrap">
+                              <button
+                                className="rowIconButton conversationMenuButton"
+                                type="button"
+                                onClick={() => {
+                                  setOpenWorkspaceMenuId(null);
+                                  setOpenConversationMenuId((id) => (id === conv.id ? null : conv.id));
+                                }}
+                                title="会话操作"
+                              >
+                                ...
+                              </button>
+                              {openConversationMenuId === conv.id ? (
+                                <div className="rowActionMenu">
+                                  <button
+                                    type="button"
+                                    onClick={() => {
+                                      setOpenConversationMenuId(null);
+                                      setEditingConversationId(conv.id);
+                                      setEditingConversationName(conv.name);
+                                    }}
+                                  >
+                                    重命名会话
+                                  </button>
+                                  <button type="button" onClick={() => deleteConversation(conv)}>删除会话</button>
+                                </div>
+                              ) : null}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
                     ) : null}
                   </div>
-                ))
-              )}
-            </div>
-          </div>
-          {showNewWorkspace ? (
-            <form className="inlineCreateForm" onSubmit={createWorkspace}>
-              <div className="pathPickerRow">
-                <input placeholder="选择本地目录" value={newWorkspacePath} onChange={(event) => setNewWorkspacePath(event.target.value)} />
-                <button type="button" onClick={pickWorkspaceDirectory} disabled={isPickingDirectory}>
-                  {isPickingDirectory ? "选择中" : "浏览"}
-                </button>
-              </div>
-              <div>
-                <button type="submit">创建</button>
-                <button type="button" onClick={() => setShowNewWorkspace(false)}>取消</button>
-              </div>
-            </form>
-          ) : null}
-
-          <div className="nestedConversations">
-            <div className="navSectionHeader nestedHeader">
-              <button
-                className="nestedToggle"
-                type="button"
-                onClick={() => setShowWorkspaceConversations((value) => !value)}
-                disabled={!state.workspace.id}
-                title={showWorkspaceConversations ? "收起会话" : "展开会话"}
-              >
-                <NavIcon kind={showWorkspaceConversations ? "collapse" : "expand"} />
-                <span><NavIcon kind="conversation" />{state.workspace.name ? `${state.workspace.name} 的会话` : "会话"}</span>
-              </button>
-              <button type="button" onClick={createConversation} disabled={!state.workspace.id} title="新建会话">+</button>
-            </div>
-            {showWorkspaceConversations ? (
-            <div className="navList conversationList">
-              {conversations.map((conv) => (
-                <div className={`navRow ${conv.id === state.conversation.id ? "active" : ""}`} key={conv.id}>
-                  {editingConversationId === conv.id ? (
-                    <form
-                      className="rowRenameForm"
-                      onSubmit={(event) => {
-                        event.preventDefault();
-                        renameConversation(conv.id, editingConversationName);
-                      }}
-                    >
-                      <input
-                        value={editingConversationName}
-                        onChange={(event) => setEditingConversationName(event.target.value)}
-                        onBlur={() => renameConversation(conv.id, editingConversationName)}
-                        onKeyDown={(event) => {
-                          if (event.key === "Escape") {
-                            setEditingConversationId(null);
-                            setEditingConversationName("");
-                          }
-                        }}
-                        autoFocus
-                      />
-                    </form>
-                  ) : (
-                    <button type="button" onClick={() => switchConversation(conv.id)} disabled={isAnyAgentRunning}>
-                      <span>{conv.name}</span>
-                    </button>
-                  )}
-                  {conv.id !== state.conversation.id ? (
-                    <button className="rowIconButton" type="button" onClick={() => deleteConversation(conv)} title="删除会话">x</button>
-                  ) : editingConversationId !== conv.id ? (
-                    <button
-                      className="rowIconButton"
-                      type="button"
-                      onClick={() => {
-                        setEditingConversationId(conv.id);
-                        setEditingConversationName(conv.name);
-                      }}
-                      title="重命名会话"
-                    >
-                      <NavIcon kind="edit" />
-                    </button>
-                  ) : null}
-                </div>
-              ))}
-            </div>
-            ) : null}
+                );
+              })
+            )}
           </div>
         </section>
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -689,13 +689,12 @@ export function App() {
                 <span>点击右上角 +，启用默认模板或添加自定义智能体。</span>
               </div>
             ) : (
-              agentIds.map((agentId, index) => (
+              agentIds.map((agentId) => (
                 <AgentButton
                   key={agentId}
                   agent={agentsById.get(agentId) ?? { id: agentId, label: agentId, runtime: "claude-code", status: "idle" }}
                   selected={selectedAgent === agentId}
                   onClick={() => chooseAgent(agentId)}
-                  isFirst={index === 0}
                 />
               ))
             )}
@@ -959,16 +958,15 @@ function NavIcon({ kind }: { kind: "workspace" | "conversation" | "agents" | "se
   );
 }
 
-function AgentButton(props: { agent: AgentState; selected: boolean; onClick: () => void; isFirst?: boolean }) {
+function AgentButton(props: { agent: AgentState; selected: boolean; onClick: () => void }) {
   const isRunning = props.agent.status === "running" || props.agent.status === "starting";
-  const showRunning = !props.isFirst && isRunning;
   return (
-    <button className={`agentButton ${props.selected ? "selected" : ""} ${showRunning ? "agentRunning" : ""}`} onClick={props.onClick} type="button">
+    <button className={`agentButton ${props.selected && !isRunning ? "selected" : ""} ${isRunning ? "agentRunning" : ""}`} onClick={props.onClick} type="button">
       <span className={`statusDot ${props.agent.status}`} aria-hidden="true" />
       <span className="agentText">
         <strong>
           {props.agent.label}
-          {showRunning && <span className="agentRunningLabel">Running</span>}
+          {isRunning && <span className="agentRunningLabel">Running</span>}
           <RuntimeBadge runtime={props.agent.runtime} />
         </strong>
         <small>{props.agent.id}</small>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,17 +1,12 @@
-import { FormEvent, KeyboardEvent, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { CSSProperties, FormEvent, KeyboardEvent, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { renderMarkdown } from "./markdown-renderer.ts";
 import { permissionProfile } from "../core/agent-profiles.ts";
 import type { AgentActivityEvent, AgentConfig, AgentId, AgentRole, AgentRuntimeKind, AgentState, AppState, ChatMessage, Conversation, ConversationInfo, PermissionProfile, RuntimeEvent, Workspace } from "../shared/types.ts";
 
 const initialState: AppState = {
-  workspace: { id: "", name: "orbit", path: "" },
-  conversation: { id: "default", name: "Default" },
-  agents: [
-    { id: "pm", label: "Product Manager", runtime: "codex", status: "starting", selected: true },
-    { id: "architect", label: "Architect", runtime: "codex", status: "starting", selected: false },
-    { id: "developer", label: "Developer", runtime: "claude-code", status: "starting", selected: false },
-    { id: "tester", label: "Tester", runtime: "codebuddy", status: "starting", selected: false },
-  ],
+  workspace: { id: "", name: "", path: "" },
+  conversation: { id: "", name: "" },
+  agents: [],
   messages: [],
   terminal: {},
 };
@@ -19,7 +14,7 @@ const initialState: AppState = {
 export function App() {
   const [state, setState] = useState<AppState>(initialState);
   const [content, setContent] = useState("");
-  const [selectedAgent, setSelectedAgent] = useState<AgentId>(initialState.agents[0].id);
+  const [selectedAgent, setSelectedAgent] = useState<AgentId>("pm");
   const [connectionState, setConnectionState] = useState<"connecting" | "live" | "offline">("connecting");
   const [isSending, setIsSending] = useState(false);
   const [inputFocused, setInputFocused] = useState(false);
@@ -33,22 +28,34 @@ export function App() {
   const [showSettings, setShowSettings] = useState(false);
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [conversations, setConversations] = useState<Conversation[]>([]);
-  const [showWorkspaceDropdown, setShowWorkspaceDropdown] = useState(false);
-  const [showConversationDropdown, setShowConversationDropdown] = useState(false);
   const [showNewWorkspace, setShowNewWorkspace] = useState(false);
-  const [showNewConversation, setShowNewConversation] = useState(false);
-  const [newWorkspaceName, setNewWorkspaceName] = useState("");
+  const [showWorkspaceConversations, setShowWorkspaceConversations] = useState(true);
+  const [showAgentManager, setShowAgentManager] = useState(false);
   const [newWorkspacePath, setNewWorkspacePath] = useState("");
-  const [newConversationName, setNewConversationName] = useState("");
+  const [editingWorkspaceId, setEditingWorkspaceId] = useState<string | null>(null);
+  const [editingWorkspaceName, setEditingWorkspaceName] = useState("");
+  const [editingConversationId, setEditingConversationId] = useState<string | null>(null);
+  const [editingConversationName, setEditingConversationName] = useState("");
+  const [isPickingDirectory, setIsPickingDirectory] = useState(false);
+  const [sidebarWidth, setSidebarWidth] = useState(() => loadSidebarWidth());
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [isResizingSidebar, setIsResizingSidebar] = useState(false);
   const isNearBottomRef = useRef(true);
 
   const isAnyAgentRunning = state.agents.some((a) => a.status === "running");
+  const hasWorkspace = Boolean(state.workspace.id);
 
   const refreshWorkspaces = () => {
     fetch("/api/workspaces").then((r) => r.json()).then(setWorkspaces).catch(() => {});
   };
   const refreshConversations = () => {
     fetch("/api/conversations").then((r) => r.json()).then(setConversations).catch(() => {});
+  };
+  const refreshState = () => {
+    fetch("/api/state")
+      .then((r) => r.json())
+      .then((nextState: AppState) => setState(normalizeState(nextState)))
+      .catch(() => setConnectionState("offline"));
   };
 
   useEffect(() => {
@@ -108,6 +115,7 @@ export function App() {
 
   const agentsById = useMemo(() => new Map(state.agents.map((agent) => [agent.id, agent])), [state.agents]);
   const agentIds = useMemo(() => state.agents.map((agent) => agent.id), [state.agents]);
+  const hasEnabledAgent = agentIds.length > 0;
   const scrollKey = useMemo(
     () =>
       state.messages
@@ -141,6 +149,30 @@ export function App() {
       setSelectedAgent(agentIds[0]);
     }
   }, [agentIds, agentsById, selectedAgent]);
+
+  useEffect(() => {
+    if (sidebarCollapsed) return;
+    window.localStorage.setItem("orbit.sidebarWidth", String(sidebarWidth));
+  }, [sidebarCollapsed, sidebarWidth]);
+
+  useEffect(() => {
+    if (!isResizingSidebar) return;
+    function handlePointerMove(event: PointerEvent) {
+      setSidebarWidth(clampSidebarWidth(event.clientX));
+    }
+    function handlePointerUp() {
+      setIsResizingSidebar(false);
+      document.body.classList.remove("sidebarResizing");
+    }
+    document.body.classList.add("sidebarResizing");
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
+    return () => {
+      document.body.classList.remove("sidebarResizing");
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+    };
+  }, [isResizingSidebar]);
 
   useEffect(() => {
     setSelectedMentionIndex(0);
@@ -194,7 +226,7 @@ export function App() {
     } catch {
       setState((current) => ({
         ...current,
-        messages: [...current.messages, createLocalSystemMessage("Send failed. Check that the local server is running.")],
+        messages: [...current.messages, createLocalSystemMessage("发送失败，请检查本地服务是否正在运行。")],
       }));
     } finally {
       setIsSending(false);
@@ -203,7 +235,121 @@ export function App() {
 
   function chooseAgent(agentId: AgentId) {
     setSelectedAgent(agentId);
-    window.setTimeout(() => inputRef.current?.focus(), 0);
+    setContent((current) => {
+      if (!current.trim() || /^@\w[\w-]*:\s*$/.test(current.trim())) {
+        return `@${agentId}: `;
+      }
+      return current;
+    });
+    const nextCursorIndex = agentId.length + 3;
+    setCursorIndex(nextCursorIndex);
+    window.setTimeout(() => {
+      inputRef.current?.focus();
+      if (!content.trim() || /^@\w[\w-]*:\s*$/.test(content.trim())) {
+        inputRef.current?.setSelectionRange(nextCursorIndex, nextCursorIndex);
+      }
+    }, 0);
+  }
+
+  async function switchWorkspace(workspaceId: string) {
+    if (workspaceId === state.workspace.id || isAnyAgentRunning) return;
+    const response = await fetch(`/api/workspaces/${workspaceId}/switch`, { method: "POST" });
+    if (!response.ok) return;
+    refreshWorkspaces();
+    refreshConversations();
+    refreshState();
+  }
+
+  async function createWorkspace(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!newWorkspacePath.trim()) return;
+    const response = await fetch("/api/workspaces", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: newWorkspacePath }),
+    });
+    if (!response.ok) return;
+    setShowNewWorkspace(false);
+    setNewWorkspacePath("");
+    refreshWorkspaces();
+  }
+
+  async function pickWorkspaceDirectory() {
+    setIsPickingDirectory(true);
+    try {
+      const response = await fetch("/api/workspaces/pick-directory", { method: "POST" });
+      if (!response.ok) return;
+      const result = (await response.json()) as { path?: string };
+      if (result.path) {
+        setNewWorkspacePath(result.path);
+      }
+    } finally {
+      setIsPickingDirectory(false);
+    }
+  }
+
+  async function renameWorkspace(workspaceId: string, name: string) {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    const response = await fetch(`/api/workspaces/${workspaceId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: trimmed }),
+    });
+    if (!response.ok) return;
+    setEditingWorkspaceId(null);
+    setEditingWorkspaceName("");
+    refreshWorkspaces();
+    refreshState();
+  }
+
+  async function deleteWorkspace(workspace: Workspace) {
+    if (workspace.id === state.workspace.id) return;
+    if (!confirm(`Delete workspace "${workspace.name}"?`)) return;
+    const response = await fetch(`/api/workspaces/${workspace.id}`, { method: "DELETE" });
+    if (response.ok) refreshWorkspaces();
+  }
+
+  async function switchConversation(conversationId: string) {
+    if (conversationId === state.conversation.id || isAnyAgentRunning) return;
+    const response = await fetch(`/api/conversations/${conversationId}/switch`, { method: "POST" });
+    if (!response.ok) return;
+    refreshConversations();
+    refreshState();
+  }
+
+  async function createConversation() {
+    if (!state.workspace.id) return;
+    const response = await fetch("/api/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    if (!response.ok) return;
+    refreshConversations();
+    refreshState();
+  }
+
+  async function renameConversation(conversationId: string, name: string) {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    const response = await fetch(`/api/conversations/${conversationId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: trimmed }),
+    });
+    if (!response.ok) return;
+    setEditingConversationId(null);
+    setEditingConversationName("");
+    refreshConversations();
+    refreshState();
+  }
+
+  async function deleteConversation(conversation: Conversation) {
+    if (conversation.id === state.conversation.id) return;
+    if (!confirm(`Delete conversation "${conversation.name}"?`)) return;
+    const response = await fetch(`/api/conversations/${conversation.id}`, { method: "DELETE" });
+    if (response.ok) refreshConversations();
   }
 
   function updateCursorFromInput() {
@@ -258,182 +404,231 @@ export function App() {
   }
 
   return (
-    <main className="shell">
-      <aside className="sidebar" aria-label="Agent status">
-        <div className="brandBlock">
-          <div className="brandMark">orbit</div>
-          <div className={`connection ${connectionState}`}>{connectionLabel(connectionState)}</div>
+    <main
+      className={`shell ${sidebarCollapsed ? "sidebarCollapsed" : ""}`}
+      style={{
+        gridTemplateColumns: sidebarCollapsed ? "0 minmax(0, 1fr)" : `${sidebarWidth}px minmax(0, 1fr)`,
+        "--sidebar-resize-left": `${sidebarWidth}px`,
+      } as CSSProperties}
+    >
+      <aside className="sidebar" aria-label="工作区导航" aria-hidden={sidebarCollapsed}>
+        <div className="sidebarTop">
+          <div className="brandBlock">
+            <div className="brandMark">orbit</div>
+            <div className={`connection ${connectionState}`}>{connectionLabel(connectionState)}</div>
+            <button className="sidebarCollapseBtn" type="button" onClick={() => setSidebarCollapsed(true)} title="隐藏侧边栏">
+              <NavIcon kind="collapse" />
+            </button>
+          </div>
         </div>
 
-        <nav className="agentList" aria-label="Choose agent">
-          {agentIds.map((agentId) => (
-            <AgentButton
-              key={agentId}
-              agent={agentsById.get(agentId) ?? initialState.agents[0]}
-              selected={selectedAgent === agentId}
-              onClick={() => chooseAgent(agentId)}
-            />
-          ))}
-        </nav>
+        <section className="navSection workspaceStack" aria-label="当前工作区和会话">
+          <div className="navSectionHeader">
+            <span><NavIcon kind="workspace" />工作区</span>
+            <button type="button" onClick={() => setShowNewWorkspace((value) => !value)} title="新建工作区">+</button>
+          </div>
+          <div className="workspaceCard">
+            <div className="navList workspaceList">
+              {workspaces.length === 0 ? (
+                <div className="emptyNavHint">还没有工作区</div>
+              ) : (
+                workspaces.map((ws) => (
+                  <div className={`navRow workspaceRow ${ws.id === state.workspace.id ? "active" : ""}`} key={ws.id}>
+                    {editingWorkspaceId === ws.id ? (
+                      <form
+                        className="rowRenameForm"
+                        onSubmit={(event) => {
+                          event.preventDefault();
+                          renameWorkspace(ws.id, editingWorkspaceName);
+                        }}
+                      >
+                        <input
+                          value={editingWorkspaceName}
+                          onChange={(event) => setEditingWorkspaceName(event.target.value)}
+                          onBlur={() => renameWorkspace(ws.id, editingWorkspaceName)}
+                          onKeyDown={(event) => {
+                            if (event.key === "Escape") {
+                              setEditingWorkspaceId(null);
+                              setEditingWorkspaceName("");
+                            }
+                          }}
+                          autoFocus
+                        />
+                        <small title={ws.path}>{ws.path}</small>
+                      </form>
+                    ) : (
+                      <button type="button" onClick={() => switchWorkspace(ws.id)} disabled={isAnyAgentRunning}>
+                        <span>{ws.name}</span>
+                        <small title={ws.path}>{ws.path}</small>
+                      </button>
+                    )}
+                    {editingWorkspaceId !== ws.id ? (
+                      <button
+                        className="rowIconButton"
+                        type="button"
+                        onClick={() => {
+                          setEditingWorkspaceId(ws.id);
+                          setEditingWorkspaceName(ws.name);
+                        }}
+                        title="重命名工作区"
+                      >
+                        <NavIcon kind="edit" />
+                      </button>
+                    ) : null}
+                    {ws.id !== state.workspace.id && editingWorkspaceId !== ws.id ? (
+                      <button className="rowIconButton" type="button" onClick={() => deleteWorkspace(ws)} title="删除工作区">x</button>
+                    ) : null}
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+          {showNewWorkspace ? (
+            <form className="inlineCreateForm" onSubmit={createWorkspace}>
+              <div className="pathPickerRow">
+                <input placeholder="选择本地目录" value={newWorkspacePath} onChange={(event) => setNewWorkspacePath(event.target.value)} />
+                <button type="button" onClick={pickWorkspaceDirectory} disabled={isPickingDirectory}>
+                  {isPickingDirectory ? "选择中" : "浏览"}
+                </button>
+              </div>
+              <div>
+                <button type="submit">创建</button>
+                <button type="button" onClick={() => setShowNewWorkspace(false)}>取消</button>
+              </div>
+            </form>
+          ) : null}
+
+          <div className="nestedConversations">
+            <div className="navSectionHeader nestedHeader">
+              <button
+                className="nestedToggle"
+                type="button"
+                onClick={() => setShowWorkspaceConversations((value) => !value)}
+                disabled={!state.workspace.id}
+                title={showWorkspaceConversations ? "收起会话" : "展开会话"}
+              >
+                <NavIcon kind={showWorkspaceConversations ? "collapse" : "expand"} />
+                <span><NavIcon kind="conversation" />{state.workspace.name ? `${state.workspace.name} 的会话` : "会话"}</span>
+              </button>
+              <button type="button" onClick={createConversation} disabled={!state.workspace.id} title="新建会话">+</button>
+            </div>
+            {showWorkspaceConversations ? (
+            <div className="navList conversationList">
+              {conversations.map((conv) => (
+                <div className={`navRow ${conv.id === state.conversation.id ? "active" : ""}`} key={conv.id}>
+                  {editingConversationId === conv.id ? (
+                    <form
+                      className="rowRenameForm"
+                      onSubmit={(event) => {
+                        event.preventDefault();
+                        renameConversation(conv.id, editingConversationName);
+                      }}
+                    >
+                      <input
+                        value={editingConversationName}
+                        onChange={(event) => setEditingConversationName(event.target.value)}
+                        onBlur={() => renameConversation(conv.id, editingConversationName)}
+                        onKeyDown={(event) => {
+                          if (event.key === "Escape") {
+                            setEditingConversationId(null);
+                            setEditingConversationName("");
+                          }
+                        }}
+                        autoFocus
+                      />
+                    </form>
+                  ) : (
+                    <button type="button" onClick={() => switchConversation(conv.id)} disabled={isAnyAgentRunning}>
+                      <span>{conv.name}</span>
+                    </button>
+                  )}
+                  {conv.id !== state.conversation.id ? (
+                    <button className="rowIconButton" type="button" onClick={() => deleteConversation(conv)} title="删除会话">x</button>
+                  ) : editingConversationId !== conv.id ? (
+                    <button
+                      className="rowIconButton"
+                      type="button"
+                      onClick={() => {
+                        setEditingConversationId(conv.id);
+                        setEditingConversationName(conv.name);
+                      }}
+                      title="重命名会话"
+                    >
+                      <NavIcon kind="edit" />
+                    </button>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+            ) : null}
+          </div>
+        </section>
+
+        <section className="navSection compactAgents" aria-label="智能体">
+          <div className="navSectionHeader">
+            <span><NavIcon kind="agents" />智能体</span>
+            <button type="button" onClick={() => setShowAgentManager(true)} disabled={!hasWorkspace} title="添加或启用智能体">+</button>
+          </div>
+          <nav className="agentList" aria-label="选择智能体">
+            {agentIds.length === 0 ? (
+              <div className="emptyAgentsHint">
+                <strong>还没有启用智能体</strong>
+                <span>点击右上角 +，启用默认模板或添加自定义智能体。</span>
+              </div>
+            ) : (
+              agentIds.map((agentId) => (
+                <AgentButton
+                  key={agentId}
+                  agent={agentsById.get(agentId) ?? { id: agentId, label: agentId, runtime: "claude-code", status: "idle" }}
+                  selected={selectedAgent === agentId}
+                  onClick={() => chooseAgent(agentId)}
+                />
+              ))
+            )}
+          </nav>
+        </section>
 
         <div className="sidebarFooter">
-          <button className="settingsBtn" type="button" onClick={() => setShowSettings(true)} title="智能体设置">&#9881;</button>
+          <button className="settingsBtn" type="button" onClick={() => setShowSettings(true)} title="智能体设置">
+            <NavIcon kind="settings" />
+            设置
+          </button>
         </div>
       </aside>
+      <button
+        className="sidebarRevealBtn"
+        type="button"
+        onClick={() => setSidebarCollapsed(false)}
+        title="显示侧边栏"
+        aria-label="显示侧边栏"
+      >
+        <NavIcon kind="expand" />
+      </button>
+      <div
+        className="sidebarResizeHandle"
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="调整侧边栏宽度"
+        onPointerDown={(event) => {
+          if (sidebarCollapsed) return;
+          event.preventDefault();
+          setIsResizingSidebar(true);
+        }}
+      />
 
       <section className="channel" aria-label="Chat channel">
         <header className="channelHeader">
           <div className="channelHeaderLeft">
-            <p className="eyebrow">workspace</p>
-            <h1 className="workspaceTitle" onClick={() => { setShowWorkspaceDropdown(!showWorkspaceDropdown); setShowConversationDropdown(false); }}>
-              <svg className="workspaceIcon" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M2 4.5A1.5 1.5 0 0 1 3.5 3h2.672a.5.5 0 0 1 .39.188l1.633 2.041a.5.5 0 0 0 .39.188H12.5A1.5 1.5 0 0 1 14 6.916V11.5a1.5 1.5 0 0 1-1.5 1.5h-9A1.5 1.5 0 0 1 2 11.5V4.5Z" />
-              </svg>
-              {state.workspace.name || "Orbit"}
-              <span className="dropdownCaret">&#9662;</span>
-            </h1>
-            {state.workspace.path ? <p className="workspacePath">{state.workspace.path}</p> : null}
+            <p className="eyebrow">{state.workspace.name || "工作区"}</p>
+            <h1>{state.conversation.name || (hasWorkspace ? "新会话" : "未选择工作区")}</h1>
+            {state.workspace.path ? <p className="workspacePath" title={state.workspace.path}>{state.workspace.path}</p> : null}
           </div>
           <div className="channelHeaderRight">
-            <button
-              className="conversationSelector"
-              onClick={() => { setShowConversationDropdown(!showConversationDropdown); setShowWorkspaceDropdown(false); }}
-              title="Switch conversation"
-            >
-              {state.conversation.name}
-              <span className="dropdownCaret">&#9662;</span>
-            </button>
+            <span className="headerMeta">{state.messages.length} 条消息</span>
           </div>
-
-          {showWorkspaceDropdown && (
-            <div className="contextDropdown workspaceDropdown">
-              {workspaces.map((ws) => (
-                <button
-                  key={ws.id}
-                  className={`contextItem ${ws.id === state.workspace.id ? "active" : ""}`}
-                  onClick={() => {
-                    if (ws.id !== state.workspace.id && !isAnyAgentRunning) {
-                      fetch(`/api/workspaces/${ws.id}/switch`, { method: "POST" }).then(() => {
-                        setShowWorkspaceDropdown(false);
-                        refreshWorkspaces();
-                      });
-                    }
-                  }}
-                  disabled={isAnyAgentRunning}
-                >
-                  <span className="contextItemName">{ws.name}</span>
-                  <span className="contextItemPath">{ws.path}</span>
-                  {ws.id !== state.workspace.id && (
-                    <span
-                      className="contextItemDelete"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        if (confirm(`Delete workspace "${ws.name}"?`)) {
-                          fetch(`/api/workspaces/${ws.id}`, { method: "DELETE" }).then(() => refreshWorkspaces());
-                        }
-                      }}
-                      title="Delete workspace"
-                    >&#10005;</span>
-                  )}
-                </button>
-              ))}
-              {!showNewWorkspace ? (
-                <button className="contextItem contextCreateBtn" onClick={() => setShowNewWorkspace(true)}>
-                  + New Workspace
-                </button>
-              ) : (
-                <form
-                  className="contextCreateForm"
-                  onSubmit={(e) => {
-                    e.preventDefault();
-                    if (!newWorkspaceName.trim() || !newWorkspacePath.trim()) return;
-                    fetch("/api/workspaces", {
-                      method: "POST",
-                      headers: { "Content-Type": "application/json" },
-                      body: JSON.stringify({ name: newWorkspaceName, path: newWorkspacePath }),
-                    }).then(() => {
-                      setShowNewWorkspace(false);
-                      setNewWorkspaceName("");
-                      setNewWorkspacePath("");
-                      refreshWorkspaces();
-                    });
-                  }}
-                >
-                  <input placeholder="Name" value={newWorkspaceName} onChange={(e) => setNewWorkspaceName(e.target.value)} />
-                  <input placeholder="Path" value={newWorkspacePath} onChange={(e) => setNewWorkspacePath(e.target.value)} />
-                  <div className="contextCreateFormActions">
-                    <button type="submit">Create</button>
-                    <button type="button" onClick={() => setShowNewWorkspace(false)}>Cancel</button>
-                  </div>
-                </form>
-              )}
-            </div>
-          )}
-
-          {showConversationDropdown && (
-            <div className="contextDropdown conversationDropdown">
-              {conversations.map((conv) => (
-                <button
-                  key={conv.id}
-                  className={`contextItem ${conv.id === state.conversation.id ? "active" : ""}`}
-                  onClick={() => {
-                    if (conv.id !== state.conversation.id && !isAnyAgentRunning) {
-                      fetch(`/api/conversations/${conv.id}/switch`, { method: "POST" }).then(() => {
-                        setShowConversationDropdown(false);
-                        refreshConversations();
-                      });
-                    }
-                  }}
-                  disabled={isAnyAgentRunning}
-                >
-                  <span className="contextItemName">{conv.name}</span>
-                  {conv.id !== state.conversation.id && (
-                    <span
-                      className="contextItemDelete"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        if (confirm(`Delete conversation "${conv.name}"?`)) {
-                          fetch(`/api/conversations/${conv.id}`, { method: "DELETE" }).then(() => refreshConversations());
-                        }
-                      }}
-                      title="Delete conversation"
-                    >&#10005;</span>
-                  )}
-                </button>
-              ))}
-              {!showNewConversation ? (
-                <button className="contextItem contextCreateBtn" onClick={() => setShowNewConversation(true)}>
-                  + New Conversation
-                </button>
-              ) : (
-                <form
-                  className="contextCreateForm"
-                  onSubmit={(e) => {
-                    e.preventDefault();
-                    if (!newConversationName.trim()) return;
-                    fetch("/api/conversations", {
-                      method: "POST",
-                      headers: { "Content-Type": "application/json" },
-                      body: JSON.stringify({ name: newConversationName }),
-                    }).then(() => {
-                      setShowNewConversation(false);
-                      setNewConversationName("");
-                      refreshConversations();
-                    });
-                  }}
-                >
-                  <input placeholder="Conversation name" value={newConversationName} onChange={(e) => setNewConversationName(e.target.value)} />
-                  <div className="contextCreateFormActions">
-                    <button type="submit">Create</button>
-                    <button type="button" onClick={() => setShowNewConversation(false)}>Cancel</button>
-                  </div>
-                </form>
-              )}
-            </div>
-          )}
         </header>
 
-        <div ref={messagesRef} className="messages" role="log" aria-live="polite" aria-label="Message list" onScroll={handleMessagesScroll}>
+        <div ref={messagesRef} className="messages" role="log" aria-live="polite" aria-label="消息列表" onScroll={handleMessagesScroll}>
           {state.messages.length === 0 ? (
             <div className="emptyState">
               <div className="emptyOrbital" aria-hidden="true">
@@ -446,11 +641,21 @@ export function App() {
                   <circle className="orbitDot orbitDot3" cx="60" cy="94" r="3.5" fill="var(--success)" />
                 </svg>
               </div>
-              <p className="emptyTitle">Ready to launch</p>
+              <p className="emptyTitle">{hasWorkspace ? "准备开始" : "先选择工作区"}</p>
               <ol className="emptySteps">
-                <li><strong>1</strong> Select an agent from the sidebar</li>
-                <li><strong>2</strong> Type your task with <code>@agent:</code></li>
-                <li><strong>3</strong> Watch agents collaborate</li>
+                {hasWorkspace ? (
+                  <>
+                    <li><strong>1</strong> 启用或添加智能体</li>
+                    <li><strong>2</strong> 使用 <code>@agent:</code> 输入任务</li>
+                    <li><strong>3</strong> 首句话会成为会话名称</li>
+                  </>
+                ) : (
+                  <>
+                    <li><strong>1</strong> 点击工作区旁边的 <code>+</code></li>
+                    <li><strong>2</strong> 选择本地项目目录</li>
+                    <li><strong>3</strong> 开始输入第一条任务</li>
+                  </>
+                )}
               </ol>
             </div>
           ) : (
@@ -506,8 +711,9 @@ export function App() {
                 handleComposerKeyDown(event as unknown as KeyboardEvent<HTMLInputElement>);
               }}
               onKeyUp={updateCursorFromInput}
-              placeholder={`@${selectedAgent}: Hello!`}
+              placeholder={!hasWorkspace ? "先选择或创建工作区" : hasEnabledAgent ? `@${selectedAgent}: 输入任务` : "先添加或启用智能体"}
               aria-label="Message to agent"
+              disabled={!hasWorkspace || !hasEnabledAgent}
               spellCheck={false}
             />
             {mentionCandidates.length > 0 ? (
@@ -519,15 +725,20 @@ export function App() {
               />
             ) : null}
           </div>
-          <button type="submit" disabled={!content.trim() || isSending}>
-            {isSending ? <span className="sendSpinner" aria-hidden="true" /> : "Send"}
+          <button type="submit" disabled={!hasWorkspace || !hasEnabledAgent || !content.trim() || isSending}>
+            {isSending ? <span className="sendSpinner" aria-hidden="true" /> : "发送"}
           </button>
         </form>
       </section>
       {showSettings ? (
-        <AgentSettingsPanel
+        <SystemSettingsPanel
           onClose={() => setShowSettings(false)}
-          onSaved={() => { setShowSettings(false); window.location.reload(); }}
+        />
+      ) : null}
+      {showAgentManager ? (
+        <AgentManagerPanel
+          onClose={() => setShowAgentManager(false)}
+          onSaved={() => { setShowAgentManager(false); window.location.reload(); }}
         />
       ) : null}
     </main>
@@ -566,6 +777,59 @@ function MentionMenu(props: {
       })}
       <div className="mentionHint">↑↓ select · Tab/Enter confirm · Esc close</div>
     </div>
+  );
+}
+
+function NavIcon({ kind }: { kind: "workspace" | "conversation" | "agents" | "settings" | "collapse" | "expand" | "edit" }) {
+  if (kind === "workspace") {
+    return (
+      <svg className="navIcon" viewBox="0 0 16 16" aria-hidden="true">
+        <path d="M2.5 4.5h3l1.1 1.4h6.9v5.6a1.5 1.5 0 0 1-1.5 1.5h-8A1.5 1.5 0 0 1 2.5 11.5v-7Z" />
+      </svg>
+    );
+  }
+  if (kind === "conversation") {
+    return (
+      <svg className="navIcon" viewBox="0 0 16 16" aria-hidden="true">
+        <path d="M3 4.5A2 2 0 0 1 5 2.5h6A2 2 0 0 1 13 4.5v4A2 2 0 0 1 11 10.5H7L4 13v-2.6A2 2 0 0 1 3 8.5v-4Z" />
+      </svg>
+    );
+  }
+  if (kind === "agents") {
+    return (
+      <svg className="navIcon" viewBox="0 0 16 16" aria-hidden="true">
+        <path d="M8 3.2a2.2 2.2 0 1 0 0 4.4 2.2 2.2 0 0 0 0-4.4Z" />
+        <path d="M3.8 13a4.2 4.2 0 0 1 8.4 0" />
+      </svg>
+    );
+  }
+  if (kind === "collapse") {
+    return (
+      <svg className="navIcon" viewBox="0 0 16 16" aria-hidden="true">
+        <path d="M10 3 5 8l5 5" />
+      </svg>
+    );
+  }
+  if (kind === "expand") {
+    return (
+      <svg className="navIcon" viewBox="0 0 16 16" aria-hidden="true">
+        <path d="M6 3l5 5-5 5" />
+      </svg>
+    );
+  }
+  if (kind === "edit") {
+    return (
+      <svg className="navIcon" viewBox="0 0 16 16" aria-hidden="true">
+        <path d="M3 11.5V13h1.5l7-7L10 4.5l-7 7Z" />
+        <path d="M9.5 5 11 3.5 12.5 5 11 6.5" />
+      </svg>
+    );
+  }
+  return (
+    <svg className="navIcon" viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5Z" />
+      <path d="M8 1.8v1.4M8 12.8v1.4M3.6 3.6l1 1M11.4 11.4l1 1M1.8 8h1.4M12.8 8h1.4M3.6 12.4l1-1M11.4 4.6l1-1" />
+    </svg>
   );
 }
 
@@ -763,7 +1027,29 @@ function PermissionEditor({ config, onChange }: { config: AgentConfig; onChange:
   );
 }
 
-function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved: () => void }) {
+function SystemSettingsPanel({ onClose }: { onClose: () => void }) {
+  return (
+    <div className="modalOverlay" onClick={onClose}>
+      <div className="modalPanel settingsPlaceholderPanel" onClick={(e) => e.stopPropagation()}>
+        <div className="modalHeader">
+          <h2>系统设置</h2>
+          <button type="button" onClick={onClose}>&times;</button>
+        </div>
+        <div className="settingsBody">
+          <div className="settingsPlaceholder">
+            <strong>暂时没有系统设置项</strong>
+            <span>智能体管理已经移动到左侧“智能体”标题右侧的 +。</span>
+          </div>
+        </div>
+        <div className="modalFooter">
+          <button type="button" onClick={onClose}>关闭</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AgentManagerPanel({ onClose, onSaved }: { onClose: () => void; onSaved: () => void }) {
   const [configs, setConfigs] = useState<AgentConfig[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -841,11 +1127,16 @@ function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved
     <div className="modalOverlay" onClick={onClose}>
       <div className="modalPanel" onClick={(e) => e.stopPropagation()}>
         <div className="modalHeader">
-          <h2>智能体设置</h2>
+          <h2>智能体</h2>
           <button type="button" onClick={onClose}>&times;</button>
         </div>
         {loading ? <p className="settingsLoading">加载中...</p> : (
           <div className="settingsBody">
+            <div className="agentManagerIntro">
+              <strong>默认智能体模板</strong>
+              <span>Product Manager、Architect、Developer、Tester 是内置模板，默认不启用。你可以按当前工作区需要开启，也可以创建自己的智能体。</span>
+            </div>
+            <button type="button" className="addBtn addBtnTop" onClick={addConfig}>+ 添加自定义智能体</button>
             {configs.map((config, i) => {
               const isExpanded = expandedIndex === i;
               return (
@@ -911,7 +1202,6 @@ function AgentSettingsPanel({ onClose, onSaved }: { onClose: () => void; onSaved
                 </div>
               );
             })}
-            <button type="button" className="addBtn" onClick={addConfig}>+ 添加智能体</button>
             {error ? <p className="settingsError">{error}</p> : null}
           </div>
         )}
@@ -1051,6 +1341,23 @@ function connectionLabel(state: "connecting" | "live" | "offline"): string {
     return "offline";
   }
   return "connecting";
+}
+
+const SIDEBAR_MIN_WIDTH = 280;
+const SIDEBAR_MAX_WIDTH = 460;
+const SIDEBAR_DEFAULT_WIDTH = 336;
+
+function loadSidebarWidth(): number {
+  if (typeof window === "undefined") {
+    return SIDEBAR_DEFAULT_WIDTH;
+  }
+  const stored = window.localStorage.getItem("orbit.sidebarWidth");
+  const parsed = stored ? Number(stored) : SIDEBAR_DEFAULT_WIDTH;
+  return clampSidebarWidth(Number.isFinite(parsed) ? parsed : SIDEBAR_DEFAULT_WIDTH);
+}
+
+function clampSidebarWidth(value: number): number {
+  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, Math.round(value)));
 }
 
 function formatTime(value: string): string {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -36,7 +36,7 @@ export function App() {
   const [editingConversationName, setEditingConversationName] = useState("");
   const [openWorkspaceMenuId, setOpenWorkspaceMenuId] = useState<string | null>(null);
   const [openConversationMenuId, setOpenConversationMenuId] = useState<string | null>(null);
-  const [collapsedWorkspaceIds, setCollapsedWorkspaceIds] = useState<Set<string>>(() => new Set());
+  const [expandedWorkspaceIds, setExpandedWorkspaceIds] = useState<Set<string>>(() => new Set());  // non-active workspaces only; active workspace is always expanded
   const [isPickingDirectory, setIsPickingDirectory] = useState(false);
   const [sidebarWidth, setSidebarWidth] = useState(() => loadSidebarWidth());
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
@@ -308,20 +308,25 @@ export function App() {
   }
 
   function handleWorkspaceClick(workspaceId: string) {
-    if (workspaceId === state.workspace.id) {
-      setCollapsedWorkspaceIds((ids) => {
-        const next = new Set(ids);
-        if (next.has(workspaceId)) {
-          next.delete(workspaceId);
-        } else {
-          next.add(workspaceId);
-        }
-        return next;
-      });
-      return;
+    if (workspaceId === state.workspace.id) return; // active workspace is always expanded
+    setExpandedWorkspaceIds((ids) => {
+      const next = new Set(ids);
+      if (next.has(workspaceId)) {
+        next.delete(workspaceId);
+      } else {
+        next.add(workspaceId);
+      }
+      return next;
+    });
+    // Eagerly load conversations for this workspace
+    if (!conversationsByWorkspace[workspaceId]) {
+      fetch(`/api/workspaces/${workspaceId}/conversations`)
+        .then((r) => r.json())
+        .then((convs: Conversation[]) => {
+          setConversationsByWorkspace((prev) => ({ ...prev, [workspaceId]: convs }));
+        })
+        .catch(() => {});
     }
-
-    switchWorkspace(workspaceId);
   }
 
   async function createWorkspaceFromDirectoryPicker() {
@@ -373,7 +378,7 @@ export function App() {
     const response = await fetch(`/api/workspaces/${workspace.id}`, { method: "DELETE" });
       if (response.ok) {
         setOpenWorkspaceMenuId(null);
-        setCollapsedWorkspaceIds((ids) => {
+        setExpandedWorkspaceIds((ids) => {
           const next = new Set(ids);
           next.delete(workspace.id);
           return next;
@@ -394,11 +399,7 @@ export function App() {
 
   async function createConversation() {
     if (!state.workspace.id) return;
-    setCollapsedWorkspaceIds((ids) => {
-      const next = new Set(ids);
-      next.delete(state.workspace.id);
-      return next;
-    });
+    // Active workspace is always expanded, no need to track in expandedWorkspaceIds
     const response = await fetch("/api/conversations", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -519,7 +520,7 @@ export function App() {
             ) : (
               workspaces.map((ws) => {
                 const isActiveWorkspace = ws.id === state.workspace.id;
-                const isWorkspaceConversationOpen = !collapsedWorkspaceIds.has(ws.id);
+                const isWorkspaceConversationOpen = isActiveWorkspace || expandedWorkspaceIds.has(ws.id);
                 return (
                   <div className="workspaceGroup" key={ws.id}>
                     <div className={`workspaceTreeRow ${isActiveWorkspace ? "active" : ""}`}>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,10 +1,11 @@
 import { FormEvent, KeyboardEvent, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { renderMarkdown } from "./markdown-renderer.ts";
 import { permissionProfile } from "../core/agent-profiles.ts";
-import type { AgentActivityEvent, AgentConfig, AgentId, AgentRole, AgentRuntimeKind, AgentState, AppState, ChatMessage, PermissionProfile, RuntimeEvent } from "../shared/types.ts";
+import type { AgentActivityEvent, AgentConfig, AgentId, AgentRole, AgentRuntimeKind, AgentState, AppState, ChatMessage, Conversation, ConversationInfo, PermissionProfile, RuntimeEvent, Workspace } from "../shared/types.ts";
 
 const initialState: AppState = {
   workspace: { id: "", name: "orbit", path: "" },
+  conversation: { id: "default", name: "Default" },
   agents: [
     { id: "pm", label: "Product Manager", runtime: "codex", status: "starting", selected: true },
     { id: "architect", label: "Architect", runtime: "codex", status: "starting", selected: false },
@@ -30,7 +31,25 @@ export function App() {
   const [isNearBottom, setIsNearBottom] = useState(true);
   const [showNewMessageHint, setShowNewMessageHint] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [showWorkspaceDropdown, setShowWorkspaceDropdown] = useState(false);
+  const [showConversationDropdown, setShowConversationDropdown] = useState(false);
+  const [showNewWorkspace, setShowNewWorkspace] = useState(false);
+  const [showNewConversation, setShowNewConversation] = useState(false);
+  const [newWorkspaceName, setNewWorkspaceName] = useState("");
+  const [newWorkspacePath, setNewWorkspacePath] = useState("");
+  const [newConversationName, setNewConversationName] = useState("");
   const isNearBottomRef = useRef(true);
+
+  const isAnyAgentRunning = state.agents.some((a) => a.status === "running");
+
+  const refreshWorkspaces = () => {
+    fetch("/api/workspaces").then((r) => r.json()).then(setWorkspaces).catch(() => {});
+  };
+  const refreshConversations = () => {
+    fetch("/api/conversations").then((r) => r.json()).then(setConversations).catch(() => {});
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -59,6 +78,16 @@ export function App() {
     events.onmessage = (message) => {
       try {
         const event = JSON.parse(message.data) as RuntimeEvent;
+        if (event.type === "context.switched") {
+          // Full state re-fetch on context switch
+          fetch("/api/state")
+            .then((r) => r.json())
+            .then((nextState: AppState) => {
+              if (!cancelled) setState(normalizeState(nextState));
+            })
+            .catch(() => {});
+          return;
+        }
         setState((current) => applyEvent(current, event));
       } catch {
         setConnectionState("offline");
@@ -70,6 +99,12 @@ export function App() {
       events.close();
     };
   }, []);
+
+  // Load workspace and conversation lists
+  useEffect(() => {
+    refreshWorkspaces();
+    refreshConversations();
+  }, [state.workspace.id, state.conversation.id]);
 
   const agentsById = useMemo(() => new Map(state.agents.map((agent) => [agent.id, agent])), [state.agents]);
   const agentIds = useMemo(() => state.agents.map((agent) => agent.id), [state.agents]);
@@ -248,16 +283,154 @@ export function App() {
 
       <section className="channel" aria-label="Chat channel">
         <header className="channelHeader">
-          <div>
+          <div className="channelHeaderLeft">
             <p className="eyebrow">workspace</p>
-            <h1>
+            <h1 className="workspaceTitle" onClick={() => { setShowWorkspaceDropdown(!showWorkspaceDropdown); setShowConversationDropdown(false); }}>
               <svg className="workspaceIcon" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M2 4.5A1.5 1.5 0 0 1 3.5 3h2.672a.5.5 0 0 1 .39.188l1.633 2.041a.5.5 0 0 0 .39.188H12.5A1.5 1.5 0 0 1 14 6.916V11.5a1.5 1.5 0 0 1-1.5 1.5h-9A1.5 1.5 0 0 1 2 11.5V4.5Z" />
               </svg>
               {state.workspace.name || "Orbit"}
+              <span className="dropdownCaret">&#9662;</span>
             </h1>
             {state.workspace.path ? <p className="workspacePath">{state.workspace.path}</p> : null}
           </div>
+          <div className="channelHeaderRight">
+            <button
+              className="conversationSelector"
+              onClick={() => { setShowConversationDropdown(!showConversationDropdown); setShowWorkspaceDropdown(false); }}
+              title="Switch conversation"
+            >
+              {state.conversation.name}
+              <span className="dropdownCaret">&#9662;</span>
+            </button>
+          </div>
+
+          {showWorkspaceDropdown && (
+            <div className="contextDropdown workspaceDropdown">
+              {workspaces.map((ws) => (
+                <button
+                  key={ws.id}
+                  className={`contextItem ${ws.id === state.workspace.id ? "active" : ""}`}
+                  onClick={() => {
+                    if (ws.id !== state.workspace.id && !isAnyAgentRunning) {
+                      fetch(`/api/workspaces/${ws.id}/switch`, { method: "POST" }).then(() => {
+                        setShowWorkspaceDropdown(false);
+                        refreshWorkspaces();
+                      });
+                    }
+                  }}
+                  disabled={isAnyAgentRunning}
+                >
+                  <span className="contextItemName">{ws.name}</span>
+                  <span className="contextItemPath">{ws.path}</span>
+                  {ws.id !== state.workspace.id && (
+                    <span
+                      className="contextItemDelete"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (confirm(`Delete workspace "${ws.name}"?`)) {
+                          fetch(`/api/workspaces/${ws.id}`, { method: "DELETE" }).then(() => refreshWorkspaces());
+                        }
+                      }}
+                      title="Delete workspace"
+                    >&#10005;</span>
+                  )}
+                </button>
+              ))}
+              {!showNewWorkspace ? (
+                <button className="contextItem contextCreateBtn" onClick={() => setShowNewWorkspace(true)}>
+                  + New Workspace
+                </button>
+              ) : (
+                <form
+                  className="contextCreateForm"
+                  onSubmit={(e) => {
+                    e.preventDefault();
+                    if (!newWorkspaceName.trim() || !newWorkspacePath.trim()) return;
+                    fetch("/api/workspaces", {
+                      method: "POST",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({ name: newWorkspaceName, path: newWorkspacePath }),
+                    }).then(() => {
+                      setShowNewWorkspace(false);
+                      setNewWorkspaceName("");
+                      setNewWorkspacePath("");
+                      refreshWorkspaces();
+                    });
+                  }}
+                >
+                  <input placeholder="Name" value={newWorkspaceName} onChange={(e) => setNewWorkspaceName(e.target.value)} />
+                  <input placeholder="Path" value={newWorkspacePath} onChange={(e) => setNewWorkspacePath(e.target.value)} />
+                  <div className="contextCreateFormActions">
+                    <button type="submit">Create</button>
+                    <button type="button" onClick={() => setShowNewWorkspace(false)}>Cancel</button>
+                  </div>
+                </form>
+              )}
+            </div>
+          )}
+
+          {showConversationDropdown && (
+            <div className="contextDropdown conversationDropdown">
+              {conversations.map((conv) => (
+                <button
+                  key={conv.id}
+                  className={`contextItem ${conv.id === state.conversation.id ? "active" : ""}`}
+                  onClick={() => {
+                    if (conv.id !== state.conversation.id && !isAnyAgentRunning) {
+                      fetch(`/api/conversations/${conv.id}/switch`, { method: "POST" }).then(() => {
+                        setShowConversationDropdown(false);
+                        refreshConversations();
+                      });
+                    }
+                  }}
+                  disabled={isAnyAgentRunning}
+                >
+                  <span className="contextItemName">{conv.name}</span>
+                  {conv.id !== state.conversation.id && (
+                    <span
+                      className="contextItemDelete"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (confirm(`Delete conversation "${conv.name}"?`)) {
+                          fetch(`/api/conversations/${conv.id}`, { method: "DELETE" }).then(() => refreshConversations());
+                        }
+                      }}
+                      title="Delete conversation"
+                    >&#10005;</span>
+                  )}
+                </button>
+              ))}
+              {!showNewConversation ? (
+                <button className="contextItem contextCreateBtn" onClick={() => setShowNewConversation(true)}>
+                  + New Conversation
+                </button>
+              ) : (
+                <form
+                  className="contextCreateForm"
+                  onSubmit={(e) => {
+                    e.preventDefault();
+                    if (!newConversationName.trim()) return;
+                    fetch("/api/conversations", {
+                      method: "POST",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({ name: newConversationName }),
+                    }).then(() => {
+                      setShowNewConversation(false);
+                      setNewConversationName("");
+                      refreshConversations();
+                    });
+                  }}
+                >
+                  <input placeholder="Conversation name" value={newConversationName} onChange={(e) => setNewConversationName(e.target.value)} />
+                  <div className="contextCreateFormActions">
+                    <button type="submit">Create</button>
+                    <button type="button" onClick={() => setShowNewConversation(false)}>Cancel</button>
+                  </div>
+                </form>
+              )}
+            </div>
+          )}
         </header>
 
         <div ref={messagesRef} className="messages" role="log" aria-live="polite" aria-label="Message list" onScroll={handleMessagesScroll}>
@@ -829,6 +1002,7 @@ function upsertMessage(state: AppState, nextMessage: ChatMessage): AppState {
 function normalizeState(nextState: AppState): AppState {
   return {
     workspace: nextState.workspace ?? initialState.workspace,
+    conversation: nextState.conversation ?? initialState.conversation,
     agents: nextState.agents?.length
       ? nextState.agents.map((agent) => ({ ...agent, runtime: agent.runtime ?? "claude-code" }))
       : initialState.agents,

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -28,7 +28,7 @@ export function App() {
   const [showNewMessageHint, setShowNewMessageHint] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
-  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [conversationsByWorkspace, setConversationsByWorkspace] = useState<Record<string, Conversation[]>>({});
   const [showAgentManager, setShowAgentManager] = useState(false);
   const [editingWorkspaceId, setEditingWorkspaceId] = useState<string | null>(null);
   const [editingWorkspaceName, setEditingWorkspaceName] = useState("");
@@ -50,7 +50,22 @@ export function App() {
     fetch("/api/workspaces").then((r) => r.json()).then(setWorkspaces).catch(() => {});
   };
   const refreshConversations = () => {
-    fetch("/api/conversations").then((r) => r.json()).then(setConversations).catch(() => {});
+    // Load conversations for all workspaces
+    const pending = workspaces.length > 0 ? workspaces : (state.workspace.id ? [{ id: state.workspace.id }] as Workspace[] : []);
+    Promise.all(
+      pending.map((ws) =>
+        fetch(`/api/workspaces/${ws.id}/conversations`)
+          .then((r) => r.json())
+          .then((convs: Conversation[]) => ({ wsId: ws.id, convs }))
+          .catch(() => ({ wsId: ws.id, convs: [] as Conversation[] })),
+      ),
+    ).then((results) => {
+      const byWs: Record<string, Conversation[]> = {};
+      for (const { wsId, convs } of results) {
+        byWs[wsId] = convs;
+      }
+      setConversationsByWorkspace((prev) => ({ ...prev, ...byWs }));
+    });
   };
   const refreshState = () => {
     fetch("/api/state")
@@ -111,8 +126,13 @@ export function App() {
   // Load workspace and conversation lists
   useEffect(() => {
     refreshWorkspaces();
-    refreshConversations();
   }, [state.workspace.id, state.conversation.id]);
+
+  // Refresh conversations when workspaces list changes
+  useEffect(() => {
+    if (workspaces.length === 0 && !state.workspace.id) return;
+    refreshConversations();
+  }, [workspaces, state.workspace.id]);
 
   const agentsById = useMemo(() => new Map(state.agents.map((agent) => [agent.id, agent])), [state.agents]);
   const agentIds = useMemo(() => state.agents.map((agent) => agent.id), [state.agents]);
@@ -566,7 +586,7 @@ export function App() {
                     </div>
                     {isWorkspaceConversationOpen ? (
                       <div className="navList conversationList">
-                        {conversations.map((conv) => (
+                        {(conversationsByWorkspace[ws.id] ?? []).map((conv) => (
                           <div className={`conversationRow ${conv.id === state.conversation.id ? "active" : ""}`} key={conv.id}>
                             {editingConversationId === conv.id ? (
                               <form

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -728,14 +728,14 @@ export function App() {
         }}
       />
 
-      <section className="channel" aria-label="Chat channel">
-        <header className="channelHeader">
-          <div className="channelHeaderLeft">
+      <section className="conversation" aria-label="Chat conversation">
+        <header className="conversationHeader">
+          <div className="conversationHeaderLeft">
             <p className="eyebrow">{state.workspace.name || "工作区"}</p>
             <h1>{state.conversation.name || (hasWorkspace ? "新会话" : "未选择工作区")}</h1>
             {state.workspace.path ? <p className="workspacePath" title={state.workspace.path}>{state.workspace.path}</p> : null}
           </div>
-          <div className="channelHeaderRight">
+          <div className="conversationHeaderRight">
             <span className="headerMeta">{state.messages.length} 条消息</span>
           </div>
         </header>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -968,6 +968,7 @@ function AgentButton(props: { agent: AgentState; selected: boolean; onClick: () 
       <span className="agentText">
         <strong>
           {props.agent.label}
+          {showRunning && <span className="agentRunningLabel">Running</span>}
           <RuntimeBadge runtime={props.agent.runtime} />
         </strong>
         <small>{props.agent.id}</small>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -41,6 +41,7 @@ export function App() {
   const [sidebarWidth, setSidebarWidth] = useState(() => loadSidebarWidth());
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [isResizingSidebar, setIsResizingSidebar] = useState(false);
+  const [headerCollapsed, setHeaderCollapsed] = useState(false);
   const isNearBottomRef = useRef(true);
 
   const isAnyAgentRunning = state.agents.some((a) => a.status === "running");
@@ -730,14 +731,26 @@ export function App() {
       />
 
       <section className="conversation" aria-label="Chat conversation">
-        <header className="conversationHeader">
-          <div className="conversationHeaderLeft">
-            <p className="eyebrow">{state.workspace.name || "工作区"}</p>
+        <header className={`conversationHeader ${headerCollapsed ? "collapsed" : ""}`}>
+          {headerCollapsed ? (
             <h1>{state.conversation.name || (hasWorkspace ? "新会话" : "未选择工作区")}</h1>
-            {state.workspace.path ? <p className="workspacePath" title={state.workspace.path}>{state.workspace.path}</p> : null}
-          </div>
+          ) : (
+            <div className="conversationHeaderLeft">
+              <p className="eyebrow">{state.workspace.name || "工作区"}</p>
+              <h1>{state.conversation.name || (hasWorkspace ? "新会话" : "未选择工作区")}</h1>
+              {state.workspace.path ? <p className="workspacePath" title={state.workspace.path}>{state.workspace.path}</p> : null}
+            </div>
+          )}
           <div className="conversationHeaderRight">
-            <span className="headerMeta">{state.messages.length} 条消息</span>
+            {!headerCollapsed && <span className="headerMeta">{state.messages.length} 条消息</span>}
+            <button
+              className="headerCollapseBtn"
+              type="button"
+              onClick={() => setHeaderCollapsed((c) => !c)}
+              title={headerCollapsed ? "展开头部" : "折叠头部"}
+            >
+              <NavIcon kind="collapse" />
+            </button>
           </div>
         </header>
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1194,12 +1194,11 @@ function AgentManagerPanel({ onClose, onSaved }: { onClose: () => void; onSaved:
   }
 
   function addConfig() {
-    const newIndex = configs.length;
     setConfigs((prev) => [
-      ...prev,
       { id: `agent-${Date.now()}`, name: "", role: "general", runtime: "claude-code", systemPrompt: "", enabled: true },
+      ...prev,
     ]);
-    setExpandedIndex(newIndex);
+    setExpandedIndex(0);
   }
 
   function removeConfig(index: number) {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -128,6 +128,17 @@ export function App() {
     refreshWorkspaces();
   }, [state.workspace.id, state.conversation.id]);
 
+  // Auto-expand the active workspace on initial load
+  useEffect(() => {
+    if (state.workspace.id && !expandedWorkspaceIds.has(state.workspace.id)) {
+      setExpandedWorkspaceIds((ids) => {
+        const next = new Set(ids);
+        next.add(state.workspace.id);
+        return next;
+      });
+    }
+  }, [state.workspace.id]);
+
   // Refresh conversations when workspaces list changes
   useEffect(() => {
     if (workspaces.length === 0 && !state.workspace.id) return;
@@ -308,7 +319,6 @@ export function App() {
   }
 
   function handleWorkspaceClick(workspaceId: string) {
-    if (workspaceId === state.workspace.id) return; // active workspace is always expanded
     setExpandedWorkspaceIds((ids) => {
       const next = new Set(ids);
       if (next.has(workspaceId)) {
@@ -520,7 +530,7 @@ export function App() {
             ) : (
               workspaces.map((ws) => {
                 const isActiveWorkspace = ws.id === state.workspace.id;
-                const isWorkspaceConversationOpen = isActiveWorkspace || expandedWorkspaceIds.has(ws.id);
+                const isWorkspaceConversationOpen = expandedWorkspaceIds.has(ws.id);
                 return (
                   <div className="workspaceGroup" key={ws.id}>
                     <div className={`workspaceTreeRow ${isActiveWorkspace ? "active" : ""}`}>

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -315,8 +315,7 @@ button:active:not(:disabled) {
   background: transparent;
   text-align: left;
   box-shadow: none;
-  transition: all var(--transition-base);
-  position: relative;
+  transition: border-color var(--transition-base), background var(--transition-base);
 }
 
 .agentButton:hover {
@@ -331,6 +330,16 @@ button:active:not(:disabled) {
   border-left-color: var(--accent);
   background: var(--bg-surface);
   box-shadow: var(--shadow-xs);
+}
+
+.agentRunningLabel {
+  font-size: 10px;
+  color: var(--accent);
+  font-weight: 600;
+  background: rgba(15, 118, 110, 0.1);
+  padding: 1px 6px;
+  border-radius: 4px;
+  vertical-align: middle;
 }
 
 /* Running agent highlight */

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -496,9 +496,9 @@ button:active:not(:disabled) {
   background: var(--error);
 }
 
-/* ── Channel ───────────────────────────────────────────────── */
+/* ── Conversation ──────────────────────────────────────────── */
 
-.channel {
+.conversation {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
   min-width: 0;
@@ -506,7 +506,7 @@ button:active:not(:disabled) {
   background: var(--bg-base);
 }
 
-.channelHeader {
+.conversationHeader {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -520,12 +520,12 @@ button:active:not(:disabled) {
   z-index: 1;
 }
 
-.channelHeader h1,
+.conversationHeaderh1,
 .eyebrow {
   margin: 0;
 }
 
-.channelHeader h1 {
+.conversationHeaderh1 {
   overflow: hidden;
   color: var(--text-primary);
   font-size: 22px;
@@ -919,7 +919,7 @@ button:active:not(:disabled) {
   box-shadow: var(--shadow-xs);
 }
 
-.sidebarCollapsed .channelHeader {
+.sidebarCollapsed .conversationHeader {
   padding-left: 82px;
 }
 
@@ -2680,7 +2680,7 @@ button:active:not(:disabled) {
 }
 
 @media (max-width: 620px) {
-  .channelHeader {
+  .conversationHeader {
     align-items: flex-start;
     flex-direction: column;
   }
@@ -2696,7 +2696,7 @@ button:active:not(:disabled) {
 
 /* ── Workspace & Conversation Selectors ──────────────────── */
 
-.channelHeader {
+.conversationHeader {
   position: relative;
   display: flex;
   align-items: flex-start;
@@ -2704,11 +2704,11 @@ button:active:not(:disabled) {
   gap: 8px;
 }
 
-.channelHeaderLeft {
+.conversationHeaderLeft {
   min-width: 0;
 }
 
-.channelHeaderRight {
+.conversationHeaderRight {
   flex-shrink: 0;
 }
 

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1719,7 +1719,13 @@ button:active:not(:disabled) {
   margin-left: 30px;
 }
 
-.conversationRow > button:first-child {
+.conversationRowName {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.conversationRowName > button {
   display: block;
   min-width: 0;
   width: 100%;
@@ -1733,18 +1739,18 @@ button:active:not(:disabled) {
   font-size: 15px;
 }
 
-.conversationRow > button:first-child span {
+.conversationRowName > button span {
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.conversationRow:hover > button:first-child {
+.conversationRow:hover .conversationRowName > button {
   background: transparent;
 }
 
-.conversationRow.active > button:first-child {
+.conversationRow.active .conversationRowName > button {
   color: var(--text-primary);
   background: transparent;
   font-weight: 700;

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -146,10 +146,10 @@ button:active:not(:disabled) {
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
   min-width: 0;
   min-height: 0;
-  padding: 18px 14px;
+  padding: 18px 14px 12px;
   border-right: 1px solid var(--border);
   background: #f3f5f7;
 }
@@ -357,8 +357,8 @@ button:active:not(:disabled) {
 
 .sidebarFooter {
   margin-top: auto;
-  padding-top: 10px;
-  border-top: 1px solid #dfe4ea;
+  padding-top: 8px;
+  border-top: 0;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -1510,10 +1510,10 @@ button:active:not(:disabled) {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  min-height: 28px;
+  min-height: 24px;
   padding: 0 5px;
   color: #8a929b;
-  font-size: 13px;
+  font-size: 12.5px;
   font-weight: 700;
   letter-spacing: 0.02em;
 }
@@ -1541,8 +1541,8 @@ button:active:not(:disabled) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   border: 0;
   border-radius: 6px;
   color: #6f7882;
@@ -1645,6 +1645,162 @@ button:active:not(:disabled) {
   text-align: center;
 }
 
+.workspaceTree {
+  display: grid;
+  gap: 2px;
+  min-height: 0;
+  flex: 1 1 auto;
+  align-content: start;
+  overflow: visible;
+  padding-bottom: 16px;
+}
+
+.workspaceGroup {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.workspaceTreeRow {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  min-height: 32px;
+  border-radius: 7px;
+}
+
+.workspaceTreeRow.active {
+  color: var(--text-primary);
+}
+
+.workspaceNameButton {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  min-height: 32px;
+  border: 0;
+  border-radius: 7px;
+  padding: 5px 7px;
+  color: #4d5660;
+  background: transparent;
+  text-align: left;
+  font-size: 16px;
+}
+
+.workspaceNameButton:hover {
+  color: var(--text-primary);
+  background: #e9edf1;
+}
+
+.workspaceNameButton span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspaceNameButton .navIcon {
+  width: 20px;
+  height: 20px;
+  color: #6d7680;
+}
+
+.conversationRow {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 2px;
+  min-height: 32px;
+  border-radius: 7px;
+  margin-left: 30px;
+}
+
+.conversationRow > button:first-child {
+  display: block;
+  min-width: 0;
+  width: 100%;
+  min-height: 32px;
+  border: 0;
+  border-radius: 7px;
+  padding: 5px 8px;
+  color: #3d454e;
+  background: transparent;
+  text-align: left;
+  font-size: 15px;
+}
+
+.conversationRow > button:first-child span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.conversationRow:hover > button:first-child {
+  background: transparent;
+}
+
+.conversationRow.active > button:first-child {
+  color: var(--text-primary);
+  background: transparent;
+  font-weight: 700;
+}
+
+.rowMenuWrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  z-index: 2;
+}
+
+.rowIconButton.persistent {
+  opacity: 1;
+}
+
+.conversationMenuButton {
+  opacity: 0;
+}
+
+.conversationRow:hover .conversationMenuButton,
+.conversationMenuButton:focus,
+.rowMenuWrap:focus-within .conversationMenuButton {
+  opacity: 1;
+}
+
+.rowActionMenu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 120;
+  display: grid;
+  gap: 2px;
+  min-width: 132px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 4px;
+  background: var(--bg-surface);
+  box-shadow: var(--shadow-md);
+}
+
+.rowActionMenu button {
+  border: 0;
+  border-radius: 6px;
+  padding: 7px 9px;
+  color: var(--text-secondary);
+  background: transparent;
+  font-size: 13px;
+  text-align: left;
+}
+
+.rowActionMenu button:hover {
+  color: var(--text-primary);
+  background: #eef2f5;
+}
+
 .nestedConversations {
   display: flex;
   flex-direction: column;
@@ -1691,9 +1847,9 @@ button:active:not(:disabled) {
 
 .conversationList {
   min-height: 0;
-  flex: 1 1 auto;
-  overflow-y: auto;
-  padding-right: 2px;
+  flex: 0 0 auto;
+  overflow: visible;
+  padding-right: 0;
 }
 
 .navRow {
@@ -1746,58 +1902,6 @@ button:active:not(:disabled) {
   opacity: 1;
 }
 
-.inlineCreateForm {
-  display: grid;
-  gap: 6px;
-  padding: 10px;
-  border: 1px solid #dfe4ea;
-  border-radius: 10px;
-  background: var(--bg-surface);
-}
-
-.inlineCreateForm input {
-  min-width: 0;
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  padding: 9px 10px;
-  color: var(--text-primary);
-  background: #fbfbfa;
-  font-size: 14px;
-  outline: none;
-}
-
-.inlineCreateForm input:focus {
-  border-color: var(--accent-border);
-}
-
-.pathPickerRow {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 8px;
-}
-
-.inlineCreateForm div {
-  display: flex;
-  gap: 6px;
-}
-
-.inlineCreateForm button {
-  flex: 1;
-  min-height: 34px;
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  color: var(--text-secondary);
-  background: #f7f7f5;
-  font-size: 13px;
-  font-weight: 650;
-}
-
-.inlineCreateForm button[type="submit"] {
-  border-color: var(--accent);
-  color: var(--text-inverse);
-  background: var(--accent);
-}
-
 .rowRenameForm {
   display: grid;
   gap: 2px;
@@ -1835,9 +1939,11 @@ button:active:not(:disabled) {
 .compactAgents {
   flex: 0 0 auto;
   max-height: 220px;
-  min-height: 148px;
+  min-height: 0;
   overflow-y: auto;
   padding-right: 2px;
+  margin-top: 10px;
+  padding-top: 8px;
 }
 
 .compactAgents .agentButton {
@@ -1866,11 +1972,11 @@ button:active:not(:disabled) {
 .agentManagerIntro {
   display: grid;
   gap: 5px;
-  border: 1px dashed #d7dde4;
-  border-radius: 10px;
-  padding: 12px;
+  border: 0;
+  border-radius: 7px;
+  padding: 6px 5px;
   color: var(--text-secondary);
-  background: rgba(255, 255, 255, 0.62);
+  background: transparent;
   font-size: 13px;
   line-height: 1.55;
 }
@@ -1879,11 +1985,13 @@ button:active:not(:disabled) {
 .settingsPlaceholder strong,
 .agentManagerIntro strong {
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: 13px;
 }
 
 .agentManagerIntro {
+  border: 1px solid #d7dde4;
   border-style: solid;
+  padding: 12px;
   background: #f7faf9;
 }
 

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1765,6 +1765,22 @@ button:active:not(:disabled) {
   opacity: 0;
 }
 
+.conversationRunningDot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  margin-left: auto;
+  flex-shrink: 0;
+  animation: pulse 2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 0.4; }
+  50% { opacity: 1; }
+}
+
 .conversationRow:hover .conversationMenuButton,
 .conversationMenuButton:focus,
 .rowMenuWrap:focus-within .conversationMenuButton {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -333,26 +333,11 @@ button:active:not(:disabled) {
   box-shadow: var(--shadow-xs);
 }
 
-/* Running progress bar */
+/* Running agent highlight */
 .agentRunning {
-  overflow: hidden;
-}
-
-.agentProgressBar {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: linear-gradient(90deg, var(--accent), var(--success), var(--accent));
-  background-size: 200% 100%;
-  animation: progressFlow 2s linear infinite;
-  border-radius: var(--radius-md) var(--radius-md) 0 0;
-}
-
-@keyframes progressFlow {
-  from { background-position: 200% 0; }
-  to { background-position: 0 0; }
+  background: rgba(15, 118, 110, 0.06);
+  border-left: 3px solid var(--accent);
+  transition: background 0.25s var(--ease-out), border-left-color 0.25s var(--ease-out);
 }
 
 .sidebarFooter {
@@ -520,12 +505,12 @@ button:active:not(:disabled) {
   z-index: 1;
 }
 
-.conversationHeaderh1,
+.conversationHeader h1,
 .eyebrow {
   margin: 0;
 }
 
-.conversationHeaderh1 {
+.conversationHeader h1 {
   overflow: hidden;
   color: var(--text-primary);
   font-size: 22px;
@@ -2670,8 +2655,7 @@ button:active:not(:disabled) {
     border-left-width: 3px;
   }
 
-  .agentStatusPill,
-  .agentProgressBar {
+  .agentStatusPill {
     display: none;
   }
 

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -98,6 +98,7 @@ body,
 body {
   margin: 0;
   overflow: hidden;
+  font-size: 15px;
 }
 
 button,
@@ -129,8 +130,9 @@ button:active:not(:disabled) {
 /* ── Layout ────────────────────────────────────────────────── */
 
 .shell {
+  position: relative;
   display: grid;
-  grid-template-columns: 248px minmax(0, 1fr);
+  grid-template-columns: 336px minmax(0, 1fr);
   width: 100vw;
   height: 100vh;
   min-width: 0;
@@ -141,50 +143,135 @@ button:active:not(:disabled) {
 /* ── Sidebar ───────────────────────────────────────────────── */
 
 .sidebar {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 16px;
   min-width: 0;
   min-height: 0;
-  padding: 20px 16px;
+  padding: 18px 14px;
   border-right: 1px solid var(--border);
-  background:
-    radial-gradient(ellipse at 50% 100%, rgba(15, 118, 110, 0.06) 0%, transparent 50%),
-    radial-gradient(ellipse at 20% 0%, rgba(15, 118, 110, 0.04) 0%, transparent 60%),
-    linear-gradient(180deg, #f0ede8 0%, #e8e4dd 100%);
+  background: #f3f5f7;
+}
+
+.sidebarCollapsed .sidebar {
+  visibility: hidden;
+  overflow: hidden;
+  padding: 0;
+  border-right: 0;
+}
+
+.sidebarCollapseBtn,
+.sidebarRevealBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: #64707a;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.sidebarCollapseBtn:hover,
+.sidebarRevealBtn:hover {
+  color: var(--text-primary);
+  border-color: #cbd4dd;
+  background: var(--bg-surface);
+}
+
+.sidebarRevealBtn {
+  position: absolute;
+  top: 14px;
+  left: 14px;
+  z-index: 20;
+  display: none;
+  box-shadow: var(--shadow-xs);
+}
+
+.sidebarCollapsed .sidebarRevealBtn {
+  display: inline-flex;
+}
+
+.sidebarResizeHandle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: var(--sidebar-resize-left, 336px);
+  z-index: 15;
+  width: 8px;
+  cursor: col-resize;
+  transform: translateX(-4px);
+}
+
+.sidebarResizeHandle::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 3px;
+  width: 1px;
+  background: transparent;
+}
+
+.sidebarResizeHandle:hover::after,
+.sidebarResizing .sidebarResizeHandle::after {
+  background: var(--accent);
+}
+
+.sidebarCollapsed .sidebarResizeHandle {
+  display: none;
+}
+
+.sidebarResizing {
+  cursor: col-resize;
+  user-select: none;
+}
+
+.sidebarTop {
+  display: grid;
+  gap: 12px;
 }
 
 .brandBlock {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 10px;
 }
 
 .brandMark {
-  font-size: 22px;
-  font-weight: 800;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #101820;
+  font-size: 23px;
+  font-weight: 850;
   line-height: 1;
-  letter-spacing: -0.03em;
-  color: var(--text-primary);
+  letter-spacing: 0;
   position: relative;
 }
 
-.brandMark::first-letter {
-  background: linear-gradient(135deg, var(--accent) 0%, #2dd4bf 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+.brandMark::before {
+  content: "";
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--accent);
+  border-right-color: #d96b34;
+  border-radius: 999px;
+  box-shadow: inset 0 0 0 3px #f3f5f7;
 }
 
 .connection {
+  margin-left: auto;
   max-width: 88px;
   overflow: hidden;
   border: 1px solid var(--border);
   border-radius: var(--radius-full);
-  padding: 3px 9px;
+  padding: 4px 10px;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 600;
   line-height: 1.3;
   text-overflow: ellipsis;
@@ -207,7 +294,7 @@ button:active:not(:disabled) {
 
 .agentList {
   display: grid;
-  gap: 8px;
+  gap: 4px;
   min-width: 0;
 }
 
@@ -219,36 +306,31 @@ button:active:not(:disabled) {
     ". status";
   gap: 3px 12px;
   width: 100%;
-  min-height: 64px;
-  border: 1px solid var(--border);
+  min-height: 46px;
+  border: 1px solid transparent;
   border-left: 3px solid transparent;
-  border-radius: var(--radius-md);
-  padding: 12px 14px;
+  border-radius: 8px;
+  padding: 9px 11px;
   color: var(--text-secondary);
-  background: var(--bg-surface);
+  background: transparent;
   text-align: left;
-  box-shadow: var(--shadow-xs);
+  box-shadow: none;
   transition: all var(--transition-base);
   position: relative;
 }
 
 .agentButton:hover {
-  border-color: var(--accent-border);
-  border-left-color: var(--accent-border);
-  border-left-width: 4px;
-  background: var(--accent-subtle);
-  box-shadow: var(--shadow-sm);
-  transform: translateY(-1px) scale(1.01);
+  border-color: var(--border);
+  background: rgba(255, 255, 255, 0.7);
+  box-shadow: none;
+  transform: none;
 }
 
 .agentButton.selected {
-  border-color: var(--accent-border);
+  border-color: var(--border);
   border-left-color: var(--accent);
-  border-left-width: 4px;
-  background: var(--accent-subtle);
-  box-shadow:
-    var(--shadow-sm),
-    inset 0 0 0 1px rgba(15, 118, 110, 0.06);
+  background: var(--bg-surface);
+  box-shadow: var(--shadow-xs);
 }
 
 /* Running progress bar */
@@ -275,8 +357,8 @@ button:active:not(:disabled) {
 
 .sidebarFooter {
   margin-top: auto;
-  padding-top: 12px;
-  border-top: 1px solid var(--border-light);
+  padding-top: 10px;
+  border-top: 1px solid #dfe4ea;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -337,7 +419,7 @@ button:active:not(:disabled) {
   align-items: center;
   gap: 6px;
   min-width: 0;
-  font-size: 13.5px;
+  font-size: 14px;
   font-weight: 700;
   color: var(--text-primary);
   letter-spacing: -0.01em;
@@ -430,7 +512,7 @@ button:active:not(:disabled) {
   justify-content: space-between;
   gap: 16px;
   min-width: 0;
-  padding: 16px 28px;
+  padding: 18px 32px;
   border-bottom: 1px solid var(--border);
   background: var(--bg-surface);
   box-shadow: var(--shadow-xs);
@@ -446,7 +528,7 @@ button:active:not(:disabled) {
 .channelHeader h1 {
   overflow: hidden;
   color: var(--text-primary);
-  font-size: 19px;
+  font-size: 22px;
   font-weight: 800;
   line-height: 1.25;
   text-overflow: ellipsis;
@@ -465,7 +547,7 @@ button:active:not(:disabled) {
 .eyebrow {
   margin-bottom: 2px;
   color: var(--accent);
-  font-size: 10.5px;
+  font-size: 12px;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -474,17 +556,14 @@ button:active:not(:disabled) {
 .workspacePath {
   margin: 2px 0 0;
   color: var(--text-muted);
-  font-size: 11.5px;
+  font-size: 12.5px;
   font-weight: 500;
   font-family: var(--font-mono);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  background: var(--bg-muted);
-  display: inline-block;
-  padding: 1px 6px;
-  border-radius: 3px;
-  max-width: 300px;
+  display: block;
+  max-width: min(680px, 58vw);
 }
 
 /* ── Messages ──────────────────────────────────────────────── */
@@ -496,14 +575,8 @@ button:active:not(:disabled) {
   min-width: 0;
   min-height: 0;
   overflow-y: auto;
-  padding: 24px 28px;
-  background: var(--bg-base);
-  /* Subtle dot grid pattern + warm atmospheric gradients */
-  background-image:
-    radial-gradient(circle, rgba(26, 24, 21, 0.04) 1px, transparent 1px),
-    radial-gradient(circle at 80% 20%, rgba(15, 118, 110, 0.025) 0%, transparent 50%),
-    radial-gradient(circle at 20% 80%, rgba(194, 65, 12, 0.018) 0%, transparent 50%);
-  background-size: 24px 24px, 100% 100%, 100% 100%;
+  padding: 28px 32px;
+  background: #fbfbfa;
 }
 
 .scrollToBottomHint {
@@ -541,11 +614,11 @@ button:active:not(:disabled) {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 18px;
-  max-width: 320px;
-  padding: 36px 32px 32px;
+  gap: 20px;
+  max-width: 380px;
+  padding: 42px 40px 38px;
   border: 1px dashed var(--border);
-  border-radius: var(--radius-xl);
+  border-radius: 18px;
   background: var(--bg-surface);
   box-shadow: var(--shadow-sm);
   text-align: center;
@@ -844,6 +917,10 @@ button:active:not(:disabled) {
 .activityPanel:hover {
   border-color: var(--border);
   box-shadow: var(--shadow-xs);
+}
+
+.sidebarCollapsed .channelHeader {
+  padding-left: 82px;
 }
 
 .activityHeader {
@@ -1207,10 +1284,10 @@ button:active:not(:disabled) {
   bottom: 0;
   z-index: 2;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 92px;
-  gap: 10px;
+  grid-template-columns: minmax(0, 1fr) 108px;
+  gap: 12px;
   min-width: 0;
-  padding: 16px 28px;
+  padding: 18px 32px;
   border-top: 1px solid var(--border);
   background: var(--bg-surface);
   box-shadow: 0 -2px 16px rgba(26, 24, 21, 0.05);
@@ -1224,15 +1301,15 @@ button:active:not(:disabled) {
 .composer textarea {
   width: 100%;
   min-width: 0;
-  min-height: 46px;
+  min-height: 54px;
   max-height: calc(22px * 6 + 16px);
   border: 1.5px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 12px 16px;
+  border-radius: 14px;
+  padding: 15px 18px;
   color: var(--text-primary);
   background: var(--bg-input);
   outline: none;
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 500;
   line-height: 22px;
   resize: none;
@@ -1254,13 +1331,13 @@ button:active:not(:disabled) {
 
 .composer > button {
   min-width: 0;
-  min-height: 46px;
+  min-height: 54px;
   color: var(--text-inverse);
   border: none;
-  border-radius: var(--radius-lg);
+  border-radius: 14px;
   background: var(--accent);
   font-weight: 700;
-  font-size: 14px;
+  font-size: 15px;
   letter-spacing: -0.01em;
   box-shadow: var(--shadow-sm), 0 0 0 1px rgba(15, 118, 110, 0.3);
   transition: all var(--transition-base);
@@ -1382,6 +1459,465 @@ button:active:not(:disabled) {
   border-top: 1px solid var(--border-light);
   margin-top: 2px;
   letter-spacing: 0.02em;
+}
+
+.primaryNavButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 42px;
+  border: 1px solid #d7dde4;
+  border-radius: 10px;
+  color: #20242a;
+  background: var(--bg-surface);
+  font-size: 14px;
+  font-weight: 650;
+  box-shadow: var(--shadow-xs);
+}
+
+.primaryNavButton:hover {
+  border-color: #c6d0da;
+  background: #fdfdfc;
+}
+
+.primaryNavButton span {
+  color: var(--accent);
+  font-size: 18px;
+  line-height: 1;
+}
+
+.navSection {
+  display: grid;
+  gap: 9px;
+  min-width: 0;
+}
+
+.navSectionGrow {
+  min-height: 0;
+  flex: 1 1 auto;
+}
+
+.workspaceStack {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1 1 auto;
+}
+
+.navSectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 28px;
+  padding: 0 5px;
+  color: #8a929b;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.navSectionHeader span,
+.settingsBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.navIcon {
+  width: 15px;
+  height: 15px;
+  flex: 0 0 auto;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.navSectionHeader button,
+.rowIconButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 0;
+  border-radius: 6px;
+  color: #6f7882;
+  background: transparent;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.navSectionHeader button:hover,
+.rowIconButton:hover {
+  color: var(--text-primary);
+  background: #e7ebef;
+}
+
+.workspaceCard {
+  border: 1px solid #dfe4ea;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.72);
+  overflow: hidden;
+  flex: 0 0 auto;
+}
+
+.workspaceCardMain {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr);
+  gap: 10px;
+  width: 100%;
+  border: 0;
+  padding: 12px;
+  color: var(--text-primary);
+  background: transparent;
+  text-align: left;
+}
+
+.workspaceCardMain:hover {
+  background: var(--bg-surface);
+}
+
+.workspaceCardMain strong,
+.workspaceCardMain small,
+.navRow span,
+.navRow small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspaceCardMain strong {
+  display: block;
+  font-size: 15px;
+  line-height: 1.35;
+}
+
+.workspaceCardMain small {
+  display: block;
+  margin-top: 2px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.workspaceGlyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border: 1px solid #d8dee5;
+  border-radius: 8px;
+  color: var(--accent);
+  background: #f7faf9;
+  font-size: 14px;
+}
+
+.workspaceGlyph .navIcon {
+  width: 17px;
+  height: 17px;
+}
+
+.navList {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  align-content: start;
+  grid-auto-rows: max-content;
+}
+
+.workspaceList {
+  padding: 4px;
+}
+
+.workspaceRow {
+  grid-template-columns: minmax(0, 1fr) auto auto;
+}
+
+.emptyNavHint {
+  padding: 14px 10px;
+  color: var(--text-muted);
+  font-size: 13px;
+  text-align: center;
+}
+
+.nestedConversations {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  min-height: 0;
+  flex: 1 1 auto;
+  margin-left: 14px;
+  padding-left: 14px;
+  border-left: 2px solid #dfe4ea;
+}
+
+.nestedHeader {
+  padding: 0 0 0 2px;
+}
+
+.nestedHeader > span,
+.nestedToggle span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.nestedToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  border: 0;
+  border-radius: 6px;
+  padding: 4px 5px 4px 0;
+  color: inherit;
+  background: transparent;
+  font: inherit;
+}
+
+.nestedToggle:hover:not(:disabled) {
+  color: var(--text-primary);
+}
+
+.nestedToggle .navIcon:first-child {
+  width: 13px;
+  height: 13px;
+}
+
+.conversationList {
+  min-height: 0;
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding-right: 2px;
+}
+
+.navRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 4px;
+  border-radius: 7px;
+}
+
+.navRow > button:first-child {
+  display: grid;
+  gap: 1px;
+  width: 100%;
+  min-height: 34px;
+  border: 0;
+  border-radius: 7px;
+  padding: 7px 10px;
+  color: #4d5660;
+  background: transparent;
+  text-align: left;
+  font-size: 14px;
+}
+
+.navRow > button:first-child:hover {
+  color: var(--text-primary);
+  background: #e9edf1;
+}
+
+.navRow.active > button:first-child {
+  color: var(--text-primary);
+  background: #ffffff;
+  box-shadow: inset 2px 0 0 var(--accent);
+  font-weight: 700;
+}
+
+.navRow small {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.rowIconButton {
+  opacity: 0;
+  font-size: 13px;
+}
+
+.navRow:hover .rowIconButton {
+  opacity: 1;
+}
+
+.inlineCreateForm {
+  display: grid;
+  gap: 6px;
+  padding: 10px;
+  border: 1px solid #dfe4ea;
+  border-radius: 10px;
+  background: var(--bg-surface);
+}
+
+.inlineCreateForm input {
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  padding: 9px 10px;
+  color: var(--text-primary);
+  background: #fbfbfa;
+  font-size: 14px;
+  outline: none;
+}
+
+.inlineCreateForm input:focus {
+  border-color: var(--accent-border);
+}
+
+.pathPickerRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+}
+
+.inlineCreateForm div {
+  display: flex;
+  gap: 6px;
+}
+
+.inlineCreateForm button {
+  flex: 1;
+  min-height: 34px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  color: var(--text-secondary);
+  background: #f7f7f5;
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.inlineCreateForm button[type="submit"] {
+  border-color: var(--accent);
+  color: var(--text-inverse);
+  background: var(--accent);
+}
+
+.rowRenameForm {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  min-height: 34px;
+  border-radius: 7px;
+  padding: 5px 8px;
+  background: #fff;
+}
+
+.rowRenameForm input {
+  min-width: 0;
+  border: 1px solid #cdd6df;
+  border-radius: 6px;
+  padding: 5px 7px;
+  color: var(--text-primary);
+  background: #fbfbfa;
+  font: inherit;
+  outline: none;
+}
+
+.rowRenameForm input:focus {
+  border-color: var(--accent-border);
+}
+
+.rowRenameForm small {
+  overflow: hidden;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compactAgents {
+  flex: 0 0 auto;
+  max-height: 220px;
+  min-height: 148px;
+  overflow-y: auto;
+  padding-right: 2px;
+}
+
+.compactAgents .agentButton {
+  grid-template-areas: "dot text";
+  min-height: 40px;
+  padding: 8px 10px;
+}
+
+.compactAgents .agentText {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.compactAgents .agentText small,
+.compactAgents .agentStatusPill {
+  display: none;
+}
+
+.compactAgents .runtimeBadge {
+  flex: 0 0 auto;
+}
+
+.emptyAgentsHint,
+.settingsPlaceholder,
+.agentManagerIntro {
+  display: grid;
+  gap: 5px;
+  border: 1px dashed #d7dde4;
+  border-radius: 10px;
+  padding: 12px;
+  color: var(--text-secondary);
+  background: rgba(255, 255, 255, 0.62);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.emptyAgentsHint strong,
+.settingsPlaceholder strong,
+.agentManagerIntro strong {
+  color: var(--text-primary);
+  font-size: 14px;
+}
+
+.agentManagerIntro {
+  border-style: solid;
+  background: #f7faf9;
+}
+
+.addBtnTop {
+  margin-bottom: 4px;
+}
+
+.conversationList::-webkit-scrollbar,
+.compactAgents::-webkit-scrollbar {
+  width: 5px;
+}
+
+.conversationList::-webkit-scrollbar-track,
+.compactAgents::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.conversationList::-webkit-scrollbar-thumb,
+.compactAgents::-webkit-scrollbar-thumb {
+  background: #cfd6dd;
+  border-radius: 999px;
+}
+
+.headerMeta {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0 12px;
+  color: var(--text-muted);
+  background: var(--bg-muted);
+  font-size: 13px;
+  font-weight: 650;
 }
 
 /* ── Settings Button ───────────────────────────────────────── */

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -2033,3 +2033,231 @@ button:active:not(:disabled) {
     grid-template-columns: 1fr;
   }
 }
+
+/* ── Workspace & Conversation Selectors ──────────────────── */
+
+.channelHeader {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.channelHeaderLeft {
+  min-width: 0;
+}
+
+.channelHeaderRight {
+  flex-shrink: 0;
+}
+
+.workspaceTitle {
+  cursor: pointer;
+  user-select: none;
+}
+
+.workspaceTitle:hover {
+  color: var(--accent);
+}
+
+.dropdownCaret {
+  font-size: 10px;
+  margin-left: 4px;
+  opacity: 0.5;
+}
+
+.conversationSelector {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--text-secondary);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+.conversationSelector:hover {
+  border-color: var(--accent);
+  color: var(--text-primary);
+}
+
+.contextDropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-lg);
+  padding: 4px;
+  max-height: 280px;
+  overflow-y: auto;
+  animation: dropdownIn 0.12s ease-out;
+}
+
+.workspaceDropdown {
+  left: 0;
+  right: auto;
+  min-width: 280px;
+}
+
+.conversationDropdown {
+  left: auto;
+  right: 0;
+  min-width: 220px;
+}
+
+@keyframes dropdownIn {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.contextItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  font-family: inherit;
+  font-size: 13px;
+  color: var(--text-primary);
+  background: none;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s;
+}
+
+.contextItem:hover:not(:disabled) {
+  background: var(--bg-base);
+}
+
+.contextItem.active {
+  background: var(--bg-base);
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.contextItem:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.contextItemName {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.contextItemPath {
+  font-size: 11px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.contextItemDelete {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  font-size: 11px;
+  color: var(--text-muted);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.1s, background 0.1s, color 0.1s;
+}
+
+.contextItem:hover .contextItemDelete {
+  opacity: 1;
+}
+
+.contextItemDelete:hover {
+  background: var(--secondary);
+  color: white;
+  opacity: 1;
+}
+
+.contextCreateBtn {
+  color: var(--accent);
+  font-weight: 500;
+  justify-content: center;
+  border-top: 1px solid var(--border-light);
+  margin-top: 2px;
+  padding-top: 10px;
+  border-radius: 0 0 6px 6px;
+}
+
+.contextCreateForm {
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border-top: 1px solid var(--border-light);
+  margin-top: 2px;
+}
+
+.contextCreateForm input {
+  padding: 6px 8px;
+  font-family: inherit;
+  font-size: 13px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-base);
+  color: var(--text-primary);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.contextCreateForm input:focus {
+  border-color: var(--accent);
+}
+
+.contextCreateFormActions {
+  display: flex;
+  gap: 6px;
+}
+
+.contextCreateFormActions button {
+  padding: 4px 12px;
+  font-family: inherit;
+  font-size: 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  transition: background 0.1s;
+}
+
+.contextCreateFormActions button:first-child {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+
+.contextCreateFormActions button:first-child:hover {
+  filter: brightness(1.1);
+}
+
+.contextCreateFormActions button:last-child {
+  background: var(--bg-base);
+  color: var(--text-secondary);
+}
+
+.contextCreateFormActions button:last-child:hover {
+  background: var(--border-light);
+}

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -505,6 +505,46 @@ button:active:not(:disabled) {
   z-index: 1;
 }
 
+.conversationHeader.collapsed {
+  padding: 8px 24px;
+}
+
+.conversationHeader.collapsed h1 {
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.conversationHeader.collapsed .eyebrow,
+.conversationHeader.collapsed .workspacePath,
+.conversationHeader.collapsed .headerMeta {
+  display: none;
+}
+
+.headerCollapseBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.15s var(--ease-out), transform 0.25s var(--ease-out), background 0.15s var(--ease-out);
+  flex-shrink: 0;
+}
+
+.headerCollapseBtn:hover {
+  color: var(--text-primary);
+  background: var(--bg-base);
+}
+
+.conversationHeader.collapsed .headerCollapseBtn {
+  transform: rotate(180deg);
+}
+
 .conversationHeader h1,
 .eyebrow {
   margin: 0;

--- a/tests/agent-config-store.test.ts
+++ b/tests/agent-config-store.test.ts
@@ -10,7 +10,7 @@ function tempDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "orbit-test-config-"));
 }
 
-test("DEFAULT_AGENT_CONFIGS seeds four built-in agents", () => {
+test("DEFAULT_AGENT_CONFIGS seeds four disabled built-in templates", () => {
   assert.equal(DEFAULT_AGENT_CONFIGS.length, 4);
   const ids = DEFAULT_AGENT_CONFIGS.map((c) => c.id);
   assert.ok(ids.includes("pm"));
@@ -18,7 +18,7 @@ test("DEFAULT_AGENT_CONFIGS seeds four built-in agents", () => {
   assert.ok(ids.includes("developer"));
   assert.ok(ids.includes("tester"));
   for (const config of DEFAULT_AGENT_CONFIGS) {
-    assert.ok(config.enabled, `${config.id} should be enabled by default`);
+    assert.equal(config.enabled, false, `${config.id} should be disabled by default`);
     assert.ok(config.systemPrompt.length > 0, `${config.id} should have a systemPrompt`);
   }
 });
@@ -137,7 +137,7 @@ test("load returns defaults for valid JSON with duplicate ids", () => {
   }
 });
 
-test("load returns defaults for valid JSON with no enabled agents", () => {
+test("load accepts valid JSON with no enabled agents", () => {
   const dir = tempDir();
   try {
     const store = new AgentConfigStore(dir);
@@ -145,8 +145,9 @@ test("load returns defaults for valid JSON with no enabled agents", () => {
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     fs.writeFileSync(filePath, JSON.stringify([{ id: "a", name: "A", role: "general", runtime: "claude-code", systemPrompt: "x", enabled: false }]));
     const configs = store.load("ws1");
-    assert.equal(configs.length, 4);
-    assert.equal(configs[0].id, "pm");
+    assert.equal(configs.length, 1);
+    assert.equal(configs[0].id, "a");
+    assert.equal(configs[0].enabled, false);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -238,10 +239,10 @@ test("accepts config with valid permissionProfile", () => {
   assert.deepEqual(errors, []);
 });
 
-test("rejects config with no enabled agents", () => {
+test("accepts config with no enabled agents", () => {
   const configs: AgentConfig[] = DEFAULT_AGENT_CONFIGS.map((c) => ({ ...c, enabled: false }));
   const errors = validateAgentConfigs(configs);
-  assert.ok(errors.some((e) => e.includes("enabled")));
+  assert.deepEqual(errors, []);
 });
 
 test("rejects empty config list", () => {

--- a/tests/agent-context-builder.test.ts
+++ b/tests/agent-context-builder.test.ts
@@ -2,32 +2,32 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { createDefaultAgentProfiles } from "../src/core/agent-profiles.ts";
-import { buildChannelContext } from "../src/core/channel-context-builder.ts";
+import { buildAgentContext } from "../src/core/agent-context-builder.ts";
 
 test("builds structured context for current agent", () => {
   const profiles = createDefaultAgentProfiles("D:/project");
-  const context = buildChannelContext({
+  const context = buildAgentContext({
     agentId: "developer",
     profiles,
-    channelMessage: "@developer: implement queue @tester: verify it",
+    agentMessage: "@developer: implement queue @tester: verify it",
   });
 
   assert.ok(context.includes("[Orbit Context]"));
   assert.ok(context.includes("Current agent: Developer (@developer)"));
   assert.ok(context.includes("@tester: Tester — Validates behavior, runs tests, reports risks."));
-  assert.ok(context.includes("[Full channel message]"));
+  assert.ok(context.includes("[Current task]"));
   assert.ok(context.includes("@developer: implement queue @tester: verify it"));
   assert.ok(context.includes("Permission profile:"));
   assert.ok(context.includes("Orbit has already scheduled the other agents"));
-  assert.ok(context.includes("Do not start by repeating the full channel message"));
+  assert.ok(context.includes("Do not start by repeating the conversation"));
 });
 
 test("includes description in available agents list", () => {
   const profiles = createDefaultAgentProfiles("D:/project");
-  const context = buildChannelContext({
+  const context = buildAgentContext({
     agentId: "developer",
     profiles,
-    channelMessage: "@developer: test",
+    agentMessage: "@developer: test",
   });
 
   assert.ok(context.includes("@pm: Product Manager — Clarifies requirements, defines scope and acceptance criteria."));
@@ -73,10 +73,10 @@ test("available agents omits description when empty without extra formatting", (
     },
   ];
 
-  const context = buildChannelContext({
+  const context = buildAgentContext({
     agentId: "dev",
     profiles,
-    channelMessage: "@dev: test",
+    agentMessage: "@dev: test",
   });
 
   assert.ok(context.includes("@pm: PM\n"), "should not have trailing dash for empty description");
@@ -86,10 +86,10 @@ test("available agents omits description when empty without extra formatting", (
 
 test("includes few-shot collaboration examples in context", () => {
   const profiles = createDefaultAgentProfiles("D:/project");
-  const context = buildChannelContext({
+  const context = buildAgentContext({
     agentId: "developer",
     profiles,
-    channelMessage: "@developer: test",
+    agentMessage: "@developer: test",
   });
 
   // Should contain the collaboration examples section
@@ -104,10 +104,10 @@ test("plain mention in agent reply does not trigger routing", () => {
   // This is a documentation/context test: the collaboration rules and examples
   // should make it clear that @agent (no colon) is only a reference.
   const profiles = createDefaultAgentProfiles("D:/project");
-  const context = buildChannelContext({
+  const context = buildAgentContext({
     agentId: "developer",
     profiles,
-    channelMessage: "@developer: implement feature",
+    agentMessage: "@developer: implement feature",
   });
 
   assert.ok(context.includes("Plain @agent mentions without a colon are references only"), "rules must mention plain mentions are references");

--- a/tests/agent-history-builder.test.ts
+++ b/tests/agent-history-builder.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildHistoryForAgent, MAX_HISTORY_CHARS, RECENT_UNTRUNCATED_COUNT } from "../src/core/channel-history.ts";
+import { buildHistoryForAgent, MAX_HISTORY_CHARS, RECENT_UNTRUNCATED_COUNT } from "../src/core/agent-history-builder.ts";
 import type { ChatMessage } from "../src/shared/types.ts";
 
 function msg(overrides: Partial<ChatMessage> & { kind: ChatMessage["kind"]; content: string }): ChatMessage {

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -48,7 +48,6 @@ test("creates sessions with the runtime selected by each profile", async () => {
     new EventBus(),
     createTempSessionStore(),
     "default",
-    "default",
     new Map([
       ["claude-code", claudeRuntime],
       ["codex", codexRuntime],
@@ -85,7 +84,6 @@ test("states include each agent runtime", () => {
     profiles,
     new EventBus(),
     createTempSessionStore(),
-    "default",
     "default",
     new Map([
       ["claude-code", runtime],

--- a/tests/agent-session.test.ts
+++ b/tests/agent-session.test.ts
@@ -34,7 +34,6 @@ function makeSession(store: SessionStore): AgentSession {
     },
     eventBus: new EventBus(),
     sessionStore: store,
-    channelId: "default",
     conversationId: "default",
   });
 }
@@ -65,16 +64,15 @@ test("send without prior session — no resume flag, session persisted", async (
   const session = makeSession(store);
   session.start();
 
-  assert.equal(store.load("claude-code", "default", "default", "developer"), null);
+  assert.equal(store.load("claude-code", "default", "developer"), null);
   assert.equal(session.getStatus(), "idle");
 });
 
 test("send with prior session — resume flag passed", () => {
   const dir = tmpDir();
   const store = new SessionStore(dir);
-  store.save("claude-code", "default", "default", "developer", {
+  store.save("claude-code", "default", "developer", {
     agentId: "developer",
-    channelId: "default",
     runtime: "claude-code",
     sessionId: "existing-sess",
     lastRunAt: new Date().toISOString(),
@@ -84,7 +82,7 @@ test("send with prior session — resume flag passed", () => {
   const session = makeSession(store);
   session.start();
 
-  const loaded = store.load("claude-code", "default", "default", "developer");
+  const loaded = store.load("claude-code", "default", "developer");
   assert.equal(loaded!.sessionId, "existing-sess");
   assert.equal(loaded!.runCount, 3);
 });
@@ -92,58 +90,54 @@ test("send with prior session — resume flag passed", () => {
 test("resume failure clears and retries — store cleared after session-not-found", () => {
   const dir = tmpDir();
   const store = new SessionStore(dir);
-  store.save("claude-code", "default", "default", "developer", {
+  store.save("claude-code", "default", "developer", {
     agentId: "developer",
-    channelId: "default",
     runtime: "claude-code",
     sessionId: "bad-session",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  store.clear("claude-code", "default", "default", "developer");
-  assert.equal(store.load("claude-code", "default", "default", "developer"), null);
+  store.clear("claude-code", "default", "developer");
+  assert.equal(store.load("claude-code", "default", "developer"), null);
 });
 
 test("non-resume failure does not clear store", () => {
   const dir = tmpDir();
   const store = new SessionStore(dir);
-  store.save("claude-code", "default", "default", "developer", {
+  store.save("claude-code", "default", "developer", {
     agentId: "developer",
-    channelId: "default",
     runtime: "claude-code",
     sessionId: "good-session",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  const loaded = store.load("claude-code", "default", "default", "developer");
+  const loaded = store.load("claude-code", "default", "developer");
   assert.equal(loaded!.sessionId, "good-session");
 });
 
 test("persistSession increments runCount", () => {
   const dir = tmpDir();
   const store = new SessionStore(dir);
-  store.save("claude-code", "default", "default", "developer", {
+  store.save("claude-code", "default", "developer", {
     agentId: "developer",
-    channelId: "default",
     runtime: "claude-code",
     sessionId: "sess-1",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  const prev = store.load("claude-code", "default", "default", "developer");
-  store.save("claude-code", "default", "default", "developer", {
+  const prev = store.load("claude-code", "default", "developer");
+  store.save("claude-code", "default", "developer", {
     agentId: "developer",
-    channelId: "default",
     runtime: "claude-code",
     sessionId: "sess-2",
     lastRunAt: new Date().toISOString(),
     runCount: (prev?.runCount ?? 0) + 1,
   });
 
-  const updated = store.load("claude-code", "default", "default", "developer");
+  const updated = store.load("claude-code", "default", "developer");
   assert.equal(updated!.runCount, 2);
   assert.equal(updated!.sessionId, "sess-2");
 });
@@ -167,7 +161,6 @@ test("different conversations use independent sessions", () => {
     runtime: controllableRuntime("unused").runtime,
     eventBus: new EventBus(),
     sessionStore: store,
-    channelId: "default",
     conversationId: "conv-a",
   });
 
@@ -186,41 +179,37 @@ test("different conversations use independent sessions", () => {
     runtime: controllableRuntime("unused").runtime,
     eventBus: new EventBus(),
     sessionStore: store,
-    channelId: "default",
     conversationId: "conv-b",
   });
 
   sessionA.start();
   sessionB.start();
 
-  store.save("codebuddy", "default", "conv-a", "developer", {
+  store.save("codebuddy", "conv-a", "developer", {
     agentId: "developer",
-    channelId: "default",
     runtime: "codebuddy",
     sessionId: "sess-a",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  store.save("codebuddy", "default", "conv-b", "developer", {
+  store.save("codebuddy", "conv-b", "developer", {
     agentId: "developer",
-    channelId: "default",
     runtime: "codebuddy",
     sessionId: "sess-b",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  assert.equal(store.load("codebuddy", "default", "conv-a", "developer")!.sessionId, "sess-a");
-  assert.equal(store.load("codebuddy", "default", "conv-b", "developer")!.sessionId, "sess-b");
+  assert.equal(store.load("codebuddy", "conv-a", "developer")!.sessionId, "sess-a");
+  assert.equal(store.load("codebuddy", "conv-b", "developer")!.sessionId, "sess-b");
 });
 
 test("send executes through configured runtime and passes resume session", async () => {
   const dir = tmpDir();
   const store = new SessionStore(dir);
-  store.save("codebuddy", "default", "default", "developer", {
+  store.save("codebuddy", "default", "developer", {
     agentId: "developer",
-    channelId: "default",
     runtime: "codebuddy",
     sessionId: "existing-sess",
     lastRunAt: new Date().toISOString(),
@@ -242,7 +231,6 @@ test("send executes through configured runtime and passes resume session", async
     runtime,
     eventBus: new EventBus(),
     sessionStore: store,
-    channelId: "default",
     conversationId: "default",
   });
 
@@ -256,15 +244,14 @@ test("send executes through configured runtime and passes resume session", async
   assert.equal(calls[0]!.cwd, "D:/workspace");
   assert.equal(calls[0]!.prompt, "hello");
   assert.equal(calls[0]!.resumeSessionId, "existing-sess");
-  assert.equal(store.load("codebuddy", "default", "default", "developer")!.sessionId, "next-sess");
+  assert.equal(store.load("codebuddy", "default", "developer")!.sessionId, "next-sess");
 });
 
 test("resume failure clears stale session and retries without resume", async () => {
   const dir = tmpDir();
   const store = new SessionStore(dir);
-  store.save("codebuddy", "default", "default", "developer", {
+  store.save("codebuddy", "default", "developer", {
     agentId: "developer",
-    channelId: "default",
     runtime: "codebuddy",
     sessionId: "bad-session",
     lastRunAt: new Date().toISOString(),
@@ -305,7 +292,6 @@ test("resume failure clears stale session and retries without resume", async () 
     runtime,
     eventBus: new EventBus(),
     sessionStore: store,
-    channelId: "default",
     conversationId: "default",
   });
 
@@ -317,15 +303,14 @@ test("resume failure clears stale session and retries without resume", async () 
   assert.equal(calls.length, 2);
   assert.equal(calls[0]!.resumeSessionId, "bad-session");
   assert.equal(calls[1]!.resumeSessionId, undefined);
-  assert.equal(store.load("codebuddy", "default", "default", "developer")!.sessionId, "fresh-session");
+  assert.equal(store.load("codebuddy", "default", "developer")!.sessionId, "fresh-session");
 });
 
 test("Claude API deserialize failure clears stale resume session and retries without resume", async () => {
   const dir = tmpDir();
   const store = new SessionStore(dir);
-  store.save("claude-code", "default", "default", "developer", {
+  store.save("claude-code", "default", "developer", {
     agentId: "developer",
-    channelId: "default",
     runtime: "claude-code",
     sessionId: "bad-claude-session",
     lastRunAt: new Date().toISOString(),
@@ -366,7 +351,6 @@ test("Claude API deserialize failure clears stale resume session and retries wit
     runtime,
     eventBus: new EventBus(),
     sessionStore: store,
-    channelId: "default",
     conversationId: "default",
   });
 
@@ -378,5 +362,5 @@ test("Claude API deserialize failure clears stale resume session and retries wit
   assert.equal(calls.length, 2);
   assert.equal(calls[0]!.resumeSessionId, "bad-claude-session");
   assert.equal(calls[1]!.resumeSessionId, undefined);
-  assert.equal(store.load("claude-code", "default", "default", "developer")!.sessionId, "fresh-claude-session");
+  assert.equal(store.load("claude-code", "default", "developer")!.sessionId, "fresh-claude-session");
 });

--- a/tests/conversation-store.test.ts
+++ b/tests/conversation-store.test.ts
@@ -161,38 +161,6 @@ test("touchLastOpened updates lastOpenedAt", () => {
   assert.notEqual(after.lastOpenedAt, before.lastOpenedAt);
 });
 
-test("ensureDefault creates default conversation when none exist", () => {
-  const dir = tmpDir();
-  const store = new ConversationStore(dir);
-
-  const conv = store.ensureDefault("ws1");
-  assert.equal(conv.id, "default");
-  assert.equal(conv.name, "Default");
-  assert.equal(store.list("ws1").length, 1);
-});
-
-test("ensureDefault creates default even when other conversations exist", () => {
-  const dir = tmpDir();
-  const store = new ConversationStore(dir);
-  store.create("ws1", "Existing");
-
-  const conv = store.ensureDefault("ws1");
-  assert.equal(conv.id, "default");
-  assert.equal(conv.name, "Default");
-  assert.equal(store.list("ws1").length, 2, "should have both existing and default");
-});
-
-test("ensureDefault returns existing default without creating duplicate", () => {
-  const dir = tmpDir();
-  const store = new ConversationStore(dir);
-  const first = store.ensureDefault("ws1");
-
-  const second = store.ensureDefault("ws1");
-  assert.equal(second.id, "default");
-  assert.equal(first.id, second.id);
-  assert.equal(store.list("ws1").length, 1, "should not create duplicate");
-});
-
 test("data persists across store instances", () => {
   const dir = tmpDir();
   const store1 = new ConversationStore(dir);

--- a/tests/conversation-store.test.ts
+++ b/tests/conversation-store.test.ts
@@ -171,14 +171,26 @@ test("ensureDefault creates default conversation when none exist", () => {
   assert.equal(store.list("ws1").length, 1);
 });
 
-test("ensureDefault is a no-op when conversations already exist", () => {
+test("ensureDefault creates default even when other conversations exist", () => {
   const dir = tmpDir();
   const store = new ConversationStore(dir);
   store.create("ws1", "Existing");
 
   const conv = store.ensureDefault("ws1");
-  assert.equal(conv.name, "Existing");
-  assert.equal(store.list("ws1").length, 1, "should not create a second conversation");
+  assert.equal(conv.id, "default");
+  assert.equal(conv.name, "Default");
+  assert.equal(store.list("ws1").length, 2, "should have both existing and default");
+});
+
+test("ensureDefault returns existing default without creating duplicate", () => {
+  const dir = tmpDir();
+  const store = new ConversationStore(dir);
+  const first = store.ensureDefault("ws1");
+
+  const second = store.ensureDefault("ws1");
+  assert.equal(second.id, "default");
+  assert.equal(first.id, second.id);
+  assert.equal(store.list("ws1").length, 1, "should not create duplicate");
 });
 
 test("data persists across store instances", () => {

--- a/tests/conversation-store.test.ts
+++ b/tests/conversation-store.test.ts
@@ -107,9 +107,9 @@ test("delete cleans up channels, transcripts and sessions directories for the co
   const other = store.create("ws1", "Keep Me");
 
   // Create directories that should be removed
-  const channelsDir = path.join(dir, "channels", "ws1", "default", conv.id);
-  const transcriptsDir = path.join(dir, "transcripts", "ws1", "default", conv.id);
-  const sessionsDir = path.join(dir, "sessions", "ws1", "claude-code", "default", conv.id);
+  const channelsDir = path.join(dir, "conversations", "ws1", conv.id);
+  const transcriptsDir = path.join(dir, "transcripts", "ws1", conv.id);
+  const sessionsDir = path.join(dir, "sessions", "ws1", "claude-code", conv.id);
 
   fs.mkdirSync(channelsDir, { recursive: true });
   fs.mkdirSync(transcriptsDir, { recursive: true });
@@ -121,8 +121,8 @@ test("delete cleans up channels, transcripts and sessions directories for the co
   fs.writeFileSync(path.join(sessionsDir, "developer.json"), '{"sessionId":"abc"}');
 
   // Create directories for the other conversation that should NOT be removed
-  const otherChannelsDir = path.join(dir, "channels", "ws1", "default", other.id);
-  const otherTranscriptsDir = path.join(dir, "transcripts", "ws1", "default", other.id);
+  const otherChannelsDir = path.join(dir, "conversations", "ws1", other.id);
+  const otherTranscriptsDir = path.join(dir, "transcripts", "ws1", other.id);
   fs.mkdirSync(otherChannelsDir, { recursive: true });
   fs.writeFileSync(path.join(otherChannelsDir, "messages.json"), '{"messages":[],"nextId":1}');
 

--- a/tests/conversation-store.test.ts
+++ b/tests/conversation-store.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { ConversationStore } from "../src/core/conversation-store.ts";
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "orbit-conv-test-"));
+}
+
+test("create returns a conversation with generated id and timestamps", () => {
+  const dir = tmpDir();
+  const store = new ConversationStore(dir);
+  const conv = store.create("ws1", "My Conversation");
+
+  assert.ok(conv.id.startsWith("conv_"), `id should start with conv_, got ${conv.id}`);
+  assert.equal(conv.workspaceId, "ws1");
+  assert.equal(conv.name, "My Conversation");
+  assert.ok(conv.createdAt);
+  assert.ok(conv.lastOpenedAt);
+});
+
+test("list returns conversations for a workspace sorted by lastOpenedAt descending", () => {
+  const dir = tmpDir();
+  const store = new ConversationStore(dir);
+  store.create("ws1", "First");
+  const second = store.create("ws1", "Second");
+
+  // Touch first to make it more recent
+  const first = store.list("ws1").find((c) => c.name === "First")!;
+  store.touchLastOpened("ws1", first.id);
+
+  const list = store.list("ws1");
+  assert.equal(list.length, 2);
+  assert.equal(list[0].id, first.id, "most recently opened should be first");
+  assert.equal(list[1].id, second.id);
+});
+
+test("list returns empty array for workspace with no conversations", () => {
+  const dir = tmpDir();
+  const store = new ConversationStore(dir);
+  assert.deepEqual(store.list("ws1"), []);
+});
+
+test("list isolates conversations by workspace", () => {
+  const dir = tmpDir();
+  const store = new ConversationStore(dir);
+  store.create("ws1", "WS1 Conv");
+  store.create("ws2", "WS2 Conv");
+
+  assert.equal(store.list("ws1").length, 1);
+  assert.equal(store.list("ws2").length, 1);
+  assert.equal(store.list("ws1")[0].name, "WS1 Conv");
+});
+
+test("get returns a conversation by id", () => {
+  const dir = tmpDir();
+  const store = new ConversationStore(dir);
+  const created = store.create("ws1", "Find Me");
+
+  const result = store.get("ws1", created.id);
+  assert.ok(result);
+  assert.equal(result!.name, "Find Me");
+});
+
+test("get returns null for unknown id", () => {
+  const dir = tmpDir();
+  const store = new ConversationStore(dir);
+  assert.equal(store.get("ws1", "conv_nonexistent"), null);
+});
+
+test("update renames a conversation", () => {
+  const dir = tmpDir();
+  const store = new ConversationStore(dir);
+  const conv = store.create("ws1", "Old Name");
+
+  const updated = store.update("ws1", conv.id, { name: "New Name" });
+  assert.equal(updated.name, "New Name");
+
+  const reloaded = store.get("ws1", conv.id);
+  assert.equal(reloaded!.name, "New Name");
+});
+
+test("update throws for unknown id", () => {
+  const dir = tmpDir();
+  const store = new ConversationStore(dir);
+  assert.throws(() => store.update("ws1", "conv_nonexistent", { name: "X" }), /not found/);
+});
+
+test("delete removes a conversation", () => {
+  const dir = tmpDir();
+  const store = new ConversationStore(dir);
+  const conv = store.create("ws1", "Delete Me");
+
+  store.delete("ws1", conv.id);
+
+  assert.equal(store.get("ws1", conv.id), null);
+  assert.equal(store.list("ws1").length, 0);
+});
+
+test("delete throws for unknown id", () => {
+  const dir = tmpDir();
+  const store = new ConversationStore(dir);
+  assert.throws(() => store.delete("ws1", "conv_nonexistent"), /not found/);
+});
+
+test("touchLastOpened updates lastOpenedAt", () => {
+  const dir = tmpDir();
+  const store = new ConversationStore(dir);
+  const conv = store.create("ws1", "Touch");
+
+  const before = store.get("ws1", conv.id)!;
+  // Small delay to ensure different timestamp
+  const start = Date.now();
+  while (Date.now() === start) { /* spin */ }
+
+  store.touchLastOpened("ws1", conv.id);
+  const after = store.get("ws1", conv.id)!;
+
+  assert.equal(before.id, after.id);
+  assert.notEqual(after.lastOpenedAt, before.lastOpenedAt);
+});
+
+test("ensureDefault creates default conversation when none exist", () => {
+  const dir = tmpDir();
+  const store = new ConversationStore(dir);
+
+  const conv = store.ensureDefault("ws1");
+  assert.equal(conv.id, "default");
+  assert.equal(conv.name, "Default");
+  assert.equal(store.list("ws1").length, 1);
+});
+
+test("ensureDefault is a no-op when conversations already exist", () => {
+  const dir = tmpDir();
+  const store = new ConversationStore(dir);
+  store.create("ws1", "Existing");
+
+  const conv = store.ensureDefault("ws1");
+  assert.equal(conv.name, "Existing");
+  assert.equal(store.list("ws1").length, 1, "should not create a second conversation");
+});
+
+test("data persists across store instances", () => {
+  const dir = tmpDir();
+  const store1 = new ConversationStore(dir);
+  const created = store1.create("ws1", "Persist Me");
+
+  const store2 = new ConversationStore(dir);
+  const list = store2.list("ws1");
+  assert.equal(list.length, 1);
+  assert.equal(list[0].id, created.id);
+  assert.equal(list[0].name, "Persist Me");
+});

--- a/tests/conversation-store.test.ts
+++ b/tests/conversation-store.test.ts
@@ -100,6 +100,44 @@ test("delete removes a conversation", () => {
   assert.equal(store.list("ws1").length, 0);
 });
 
+test("delete cleans up channels, transcripts and sessions directories for the conversation", () => {
+  const dir = tmpDir();
+  const store = new ConversationStore(dir);
+  const conv = store.create("ws1", "Delete Me");
+  const other = store.create("ws1", "Keep Me");
+
+  // Create directories that should be removed
+  const channelsDir = path.join(dir, "channels", "ws1", "default", conv.id);
+  const transcriptsDir = path.join(dir, "transcripts", "ws1", "default", conv.id);
+  const sessionsDir = path.join(dir, "sessions", "ws1", "claude-code", "default", conv.id);
+
+  fs.mkdirSync(channelsDir, { recursive: true });
+  fs.mkdirSync(transcriptsDir, { recursive: true });
+  fs.mkdirSync(sessionsDir, { recursive: true });
+
+  // Write some data files
+  fs.writeFileSync(path.join(channelsDir, "messages.json"), '{"messages":[],"nextId":1}');
+  fs.writeFileSync(path.join(transcriptsDir, "developer.log"), "transcript data");
+  fs.writeFileSync(path.join(sessionsDir, "developer.json"), '{"sessionId":"abc"}');
+
+  // Create directories for the other conversation that should NOT be removed
+  const otherChannelsDir = path.join(dir, "channels", "ws1", "default", other.id);
+  const otherTranscriptsDir = path.join(dir, "transcripts", "ws1", "default", other.id);
+  fs.mkdirSync(otherChannelsDir, { recursive: true });
+  fs.writeFileSync(path.join(otherChannelsDir, "messages.json"), '{"messages":[],"nextId":1}');
+
+  store.delete("ws1", conv.id);
+
+  // Deleted conversation's data should be gone
+  assert.ok(!fs.existsSync(channelsDir), "channels dir should be removed");
+  assert.ok(!fs.existsSync(transcriptsDir), "transcripts dir should be removed");
+  assert.ok(!fs.existsSync(sessionsDir), "sessions dir should be removed");
+
+  // Other conversation's data should still exist
+  assert.ok(fs.existsSync(otherChannelsDir), "other channels dir should remain");
+  assert.ok(fs.existsSync(path.join(otherChannelsDir, "messages.json")), "other messages should remain");
+});
+
 test("delete throws for unknown id", () => {
   const dir = tmpDir();
   const store = new ConversationStore(dir);

--- a/tests/message-router.test.ts
+++ b/tests/message-router.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { ChannelRouter } from "../src/core/channel-router.ts";
+import { MessageRouter } from "../src/core/message-router.ts";
 import type { AgentId, ChatMessage, MessageRouteState } from "../src/shared/types.ts";
 
 const agents: readonly AgentId[] = ["agent1", "agent2"];
@@ -34,7 +34,7 @@ function createRouter(options?: Partial<{ availableAgents: readonly AgentId[]; m
   const agentRuns: Array<{ agentId: AgentId; prompt: string; source: ChatMessage }> = [];
   const routeStates: Array<{ id: string; state: MessageRouteState }> = [];
 
-  const router = new ChannelRouter({
+  const router = new MessageRouter({
     availableAgents: options?.availableAgents ?? agents,
     maxRouteDepth: options?.maxRouteDepth ?? 5,
     createSystemMessage(content: string, parentMessageId?: string) {
@@ -52,7 +52,7 @@ function createRouter(options?: Partial<{ availableAgents: readonly AgentId[]; m
   return { router, systemMessages, agentRuns, routeStates };
 }
 
-test("user assignment triggers agent run with full channel message", () => {
+test("user assignment triggers agent run with full message", () => {
   const { router, agentRuns, routeStates } = createRouter();
   const content = "@agent1: do something";
   router.process(createUserMessage(content));
@@ -64,7 +64,7 @@ test("user assignment triggers agent run with full channel message", () => {
   assert.equal(routeStates[0]?.state, "routed");
 });
 
-test("multi-agent assignment starts one run per assigned agent with the full channel message", () => {
+test("multi-agent assignment starts one run per assigned agent with the full message", () => {
   const { router, agentRuns, routeStates } = createRouter();
   const content = "@agent1: design requirements; @agent2: implement code based on @agent1 output";
   router.process(createUserMessage(content));

--- a/tests/run-manager.test.ts
+++ b/tests/run-manager.test.ts
@@ -41,6 +41,7 @@ test("queues a second run for the same agent until the first completes", async (
   const pending = [first, second];
 
   const manager = new RunManager({
+    conversationId: "test-conv",
     messages,
     eventBus,
     agents: {
@@ -86,6 +87,7 @@ test("terminal chunks append visible activity to the running message", async () 
   let activeRunId = "";
 
   const manager = new RunManager({
+    conversationId: "test-conv",
     messages,
     eventBus,
     agents: {
@@ -108,7 +110,7 @@ test("terminal chunks append visible activity to the running message", async () 
   const source = createSourceMessage();
   const run = manager.enqueue("developer", "first", source);
 
-  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: "Running Bash(command)" });
+  eventBus.publish({ type: "terminal.chunk", conversationId: "test-conv", agentId: "developer", runId: activeRunId, text: "Running Bash(command)" });
   const runningMessage = messages.get(run.resultMessageId);
   assert.ok(runningMessage?.activity?.some((activity) => activity.type === "tool.started" && activity.name === "Bash"));
 
@@ -328,6 +330,7 @@ test("split Claude tool_use across two terminal chunks still produces tool.start
   let activeRunId = "";
 
   const manager = new RunManager({
+    conversationId: "test-conv",
     messages,
     eventBus,
     agents: {
@@ -353,8 +356,8 @@ test("split Claude tool_use across two terminal chunks still produces tool.start
     message: { content: [{ type: "tool_use", name: "Read", input: { file_path: "src/main.ts" } }] },
   });
   const mid = Math.floor(fullJson.length / 2);
-  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: fullJson.slice(0, mid) });
-  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: fullJson.slice(mid) });
+  eventBus.publish({ type: "terminal.chunk", conversationId: "test-conv", agentId: "developer", runId: activeRunId, text: fullJson.slice(0, mid) });
+  eventBus.publish({ type: "terminal.chunk", conversationId: "test-conv", agentId: "developer", runId: activeRunId, text: fullJson.slice(mid) });
 
   const msg = messages.get(run.resultMessageId);
   const toolStarted = msg?.activity?.find((a) => a.type === "tool.started");
@@ -375,6 +378,7 @@ test("split Claude tool_use_result across chunks still produces tool.completed w
   let activeRunId = "";
 
   const manager = new RunManager({
+    conversationId: "test-conv",
     messages,
     eventBus,
     agents: {
@@ -399,15 +403,15 @@ test("split Claude tool_use_result across chunks still produces tool.completed w
     type: "assistant",
     message: { content: [{ type: "tool_use", name: "Bash", input: { command: "ls" } }] },
   });
-  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: `${started}\n` });
+  eventBus.publish({ type: "terminal.chunk", conversationId: "test-conv", agentId: "developer", runId: activeRunId, text: `${started}\n` });
 
   const resultJson = JSON.stringify({
     type: "user",
     tool_use_result: { stdout: "file1.ts\nfile2.ts", stderr: "", is_error: false },
   });
   const mid = Math.floor(resultJson.length / 2);
-  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: resultJson.slice(0, mid) });
-  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: resultJson.slice(mid) });
+  eventBus.publish({ type: "terminal.chunk", conversationId: "test-conv", agentId: "developer", runId: activeRunId, text: resultJson.slice(0, mid) });
+  eventBus.publish({ type: "terminal.chunk", conversationId: "test-conv", agentId: "developer", runId: activeRunId, text: resultJson.slice(mid) });
 
   const msg = messages.get(run.resultMessageId);
   const toolCompleted = msg?.activity?.find((a) => a.type === "tool.completed");
@@ -428,6 +432,7 @@ test("split Claude tool_use_result error across chunks still produces tool.faile
   let activeRunId = "";
 
   const manager = new RunManager({
+    conversationId: "test-conv",
     messages,
     eventBus,
     agents: {
@@ -452,15 +457,15 @@ test("split Claude tool_use_result error across chunks still produces tool.faile
     type: "assistant",
     message: { content: [{ type: "tool_use", name: "Bash", input: { command: "bad" } }] },
   });
-  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: `${started}\n` });
+  eventBus.publish({ type: "terminal.chunk", conversationId: "test-conv", agentId: "developer", runId: activeRunId, text: `${started}\n` });
 
   const failedJson = JSON.stringify({
     type: "user",
     tool_use_result: { stdout: "", stderr: "command not found", is_error: true },
   });
   const mid = Math.floor(failedJson.length / 2);
-  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: failedJson.slice(0, mid) });
-  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: failedJson.slice(mid) });
+  eventBus.publish({ type: "terminal.chunk", conversationId: "test-conv", agentId: "developer", runId: activeRunId, text: failedJson.slice(0, mid) });
+  eventBus.publish({ type: "terminal.chunk", conversationId: "test-conv", agentId: "developer", runId: activeRunId, text: failedJson.slice(mid) });
 
   const msg = messages.get(run.resultMessageId);
   const toolFailed = msg?.activity?.find((a) => a.type === "tool.failed");
@@ -481,6 +486,7 @@ test("split Codex command_execution completion across chunks still produces tool
   let activeRunId = "";
 
   const manager = new RunManager({
+    conversationId: "test-conv",
     messages,
     eventBus,
     agents: {
@@ -505,15 +511,15 @@ test("split Codex command_execution completion across chunks still produces tool
     type: "item.started",
     item: { id: "item_1", type: "command_execution", command: "git status", status: "in_progress" },
   });
-  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: `${started}\n` });
+  eventBus.publish({ type: "terminal.chunk", conversationId: "test-conv", agentId: "developer", runId: activeRunId, text: `${started}\n` });
 
   const completedJson = JSON.stringify({
     type: "item.completed",
     item: { id: "item_1", type: "command_execution", command: "git status", aggregated_output: "On branch main", exit_code: 0, status: "completed" },
   });
   const mid = Math.floor(completedJson.length / 2);
-  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: completedJson.slice(0, mid) });
-  eventBus.publish({ type: "terminal.chunk", agentId: "developer", runId: activeRunId, text: completedJson.slice(mid) });
+  eventBus.publish({ type: "terminal.chunk", conversationId: "test-conv", agentId: "developer", runId: activeRunId, text: completedJson.slice(0, mid) });
+  eventBus.publish({ type: "terminal.chunk", conversationId: "test-conv", agentId: "developer", runId: activeRunId, text: completedJson.slice(mid) });
 
   const msg = messages.get(run.resultMessageId);
   const toolCompleted = msg?.activity?.find((a) => a.type === "tool.completed");
@@ -533,6 +539,7 @@ test("run failures store a concise error instead of raw stream output", async ()
   const failure = deferred();
 
   const manager = new RunManager({
+    conversationId: "test-conv",
     messages,
     eventBus,
     agents: {

--- a/tests/session-store.test.ts
+++ b/tests/session-store.test.ts
@@ -12,7 +12,7 @@ function tmpDir(): string {
 
 test("load returns null for missing file", () => {
   const store = new SessionStore(tmpDir());
-  assert.equal(store.load("claude-code", "default", "default", "pm"), null);
+  assert.equal(store.load("claude-code", "default", "pm"), null);
 });
 
 test("save then load round-trips", () => {
@@ -20,15 +20,14 @@ test("save then load round-trips", () => {
   const store = new SessionStore(dir);
   const record = {
     agentId: "pm",
-    channelId: "default",
     runtime: "claude-code" as const,
     sessionId: "sess-123",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   };
 
-  store.save("claude-code", "default", "default", "pm", record);
-  const loaded = store.load("claude-code", "default", "default", "pm");
+  store.save("claude-code", "default", "pm", record);
+  const loaded = store.load("claude-code", "default", "pm");
 
   assert.deepEqual(loaded, record);
 });
@@ -37,127 +36,102 @@ test("save creates directories", () => {
   const dir = path.join(tmpDir(), "nested", "deep");
   const store = new SessionStore(dir);
 
-  store.save("claude-code", "default", "default", "developer", {
+  store.save("claude-code", "default", "developer", {
     agentId: "developer",
-    channelId: "default",
     runtime: "claude-code",
     sessionId: "s1",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  assert.ok(fs.existsSync(path.join(dir, "claude-code", "default", "default", "developer.json")));
+  assert.ok(fs.existsSync(path.join(dir, "claude-code", "default", "developer.json")));
 });
 
 test("clear removes the file", () => {
   const dir = tmpDir();
   const store = new SessionStore(dir);
 
-  store.save("claude-code", "default", "default", "architect", {
+  store.save("claude-code", "default", "architect", {
     agentId: "architect",
-    channelId: "default",
     runtime: "claude-code",
     sessionId: "s2",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  store.clear("claude-code", "default", "default", "architect");
-  assert.equal(store.load("claude-code", "default", "default", "architect"), null);
+  store.clear("claude-code", "default", "architect");
+  assert.equal(store.load("claude-code", "default", "architect"), null);
 });
 
 test("save overwrites previous", () => {
   const dir = tmpDir();
   const store = new SessionStore(dir);
 
-  store.save("claude-code", "default", "default", "tester", {
+  store.save("claude-code", "default", "tester", {
     agentId: "tester",
-    channelId: "default",
     runtime: "claude-code",
     sessionId: "old",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  store.save("claude-code", "default", "default", "tester", {
+  store.save("claude-code", "default", "tester", {
     agentId: "tester",
-    channelId: "default",
     runtime: "claude-code",
     sessionId: "new",
     lastRunAt: new Date().toISOString(),
     runCount: 2,
   });
 
-  const loaded = store.load("claude-code", "default", "default", "tester");
+  const loaded = store.load("claude-code", "default", "tester");
   assert.equal(loaded!.sessionId, "new");
   assert.equal(loaded!.runCount, 2);
-});
-
-test("custom baseDir is used", () => {
-  const dir = tmpDir();
-  const store = new SessionStore(dir);
-
-  store.save("claude-code", "ch1", "conv1", "pm", {
-    agentId: "pm",
-    channelId: "ch1",
-    runtime: "claude-code",
-    sessionId: "s3",
-    lastRunAt: new Date().toISOString(),
-    runCount: 1,
-  });
-
-  const expectedPath = path.join(dir, "claude-code", "ch1", "conv1", "pm.json");
-  assert.ok(fs.existsSync(expectedPath));
 });
 
 test("different conversations for the same agent are independent", () => {
   const dir = tmpDir();
   const store = new SessionStore(dir);
 
-  store.save("claude-code", "default", "conv-a", "developer", {
+  store.save("claude-code", "conv-a", "developer", {
     agentId: "developer",
-    channelId: "default",
     runtime: "claude-code",
     sessionId: "sess-conv-a",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  store.save("claude-code", "default", "conv-b", "developer", {
+  store.save("claude-code", "conv-b", "developer", {
     agentId: "developer",
-    channelId: "default",
     runtime: "claude-code",
     sessionId: "sess-conv-b",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  assert.equal(store.load("claude-code", "default", "conv-a", "developer")!.sessionId, "sess-conv-a");
-  assert.equal(store.load("claude-code", "default", "conv-b", "developer")!.sessionId, "sess-conv-b");
+  assert.equal(store.load("claude-code", "conv-a", "developer")!.sessionId, "sess-conv-a");
+  assert.equal(store.load("claude-code", "conv-b", "developer")!.sessionId, "sess-conv-b");
 });
 
 test("different runtimes for the same agent are independent", () => {
   const dir = tmpDir();
   const store = new SessionStore(dir);
 
-  store.save("claude-code", "default", "default", "developer", {
+  store.save("claude-code", "default", "developer", {
     agentId: "developer",
-    channelId: "default",
     runtime: "claude-code",
     sessionId: "claude-session",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  store.save("codebuddy", "default", "default", "developer", {
+  store.save("codebuddy", "default", "developer", {
     agentId: "developer",
-    channelId: "default",
     runtime: "codebuddy",
     sessionId: "codebuddy-session",
     lastRunAt: new Date().toISOString(),
     runCount: 1,
   });
 
-  assert.equal(store.load("claude-code", "default", "default", "developer")!.sessionId, "claude-session");
-  assert.equal(store.load("codebuddy", "default", "default", "developer")!.sessionId, "codebuddy-session");
+  assert.equal(store.load("claude-code", "default", "developer")!.sessionId, "claude-session");
+  assert.equal(store.load("codebuddy", "default", "developer")!.sessionId, "codebuddy-session");
 });

--- a/tests/workspace-store.test.ts
+++ b/tests/workspace-store.test.ts
@@ -39,7 +39,7 @@ test("resolve returns workspace info from existing metadata file", () => {
 
   const workspace = store.resolve(cwd);
   assert.ok(workspace.id);
-  assert.equal(workspace.path, cwd);
+  assert.equal(workspace.path, path.resolve(cwd));
   assert.equal(workspace.name, "orbit");
   assert.ok(fs.existsSync(path.join(dir, "workspaces", workspace.id, "workspace.json")));
 });
@@ -54,7 +54,7 @@ test("resolve creates workspace directory and metadata on first call", () => {
   assert.ok(fs.existsSync(metadataPath));
   const metadata = JSON.parse(fs.readFileSync(metadataPath, "utf8"));
   assert.equal(metadata.id, workspace.id);
-  assert.equal(metadata.path, "/home/user/projects/new-project");
+  assert.equal(metadata.path, path.resolve("/home/user/projects/new-project"));
   assert.equal(metadata.name, "new-project");
   assert.ok(metadata.createdAt, "metadata should include createdAt");
   assert.ok(new Date(metadata.createdAt).getTime() > 0, "createdAt should be a valid ISO date");
@@ -197,7 +197,7 @@ test("create creates a new workspace", () => {
 
   assert.ok(ws.id);
   assert.equal(ws.name, "My Project");
-  assert.equal(ws.path, "/projects/my-project");
+  assert.equal(ws.path, path.resolve("/projects/my-project"));
   assert.ok(ws.createdAt);
   assert.ok(ws.lastOpenedAt);
   assert.ok(store.get(ws.id));
@@ -269,4 +269,21 @@ test("touchLastOpened updates lastOpenedAt", () => {
 
   assert.equal(before.id, after.id);
   assert.notEqual(after.lastOpenedAt, before.lastOpenedAt);
+});
+
+test("create normalizes relative paths to absolute paths", () => {
+  const dir = tmpDir();
+  const store = new WorkspaceStore(dir);
+  const ws = store.create("Relative", "some/relative/path");
+
+  assert.ok(path.isAbsolute(ws.path), `path should be absolute, got: ${ws.path}`);
+  assert.ok(ws.path.includes("some" + path.sep + "relative" + path.sep + "path"));
+});
+
+test("resolve normalizes relative cwd to absolute path", () => {
+  const dir = tmpDir();
+  const store = new WorkspaceStore(dir);
+  const ws = store.resolve("some/relative/project");
+
+  assert.ok(path.isAbsolute(ws.path), `path should be absolute, got: ${ws.path}`);
 });

--- a/tests/workspace-store.test.ts
+++ b/tests/workspace-store.test.ts
@@ -13,7 +13,7 @@ function tmpDir(): string {
 
 test("deriveId returns deterministic short hash from cwd", () => {
   const id = WorkspaceStore.deriveId("/home/user/projects/my-app");
-  assert.match(id, /^[0-9a-f]{12}$/);
+  assert.match(id, /^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*_[a-f0-9]{6}$/);
   assert.equal(id, WorkspaceStore.deriveId("/home/user/projects/my-app"));
 });
 

--- a/tests/workspace-store.test.ts
+++ b/tests/workspace-store.test.ts
@@ -156,18 +156,17 @@ test("transcriptsDir defaults to 'default' for channel and conversation", () => 
 
 // --- New CRUD tests ---
 
-test("list returns all workspaces sorted by lastOpenedAt descending", () => {
+test("list returns all workspaces in stable creation order", () => {
   const dir = tmpDir();
   const store = new WorkspaceStore(dir);
   const ws1 = store.resolve("/projects/alpha");
   const ws2 = store.resolve("/projects/beta");
 
-  // Re-resolve ws1 to update its lastOpenedAt
-  store.touchLastOpened(ws1.id);
+  store.touchLastOpened(ws2.id);
 
   const list = store.list();
   assert.equal(list.length, 2);
-  assert.equal(list[0].id, ws1.id, "most recently opened should be first");
+  assert.equal(list[0].id, ws1.id, "clicking/opening should not move a workspace");
   assert.equal(list[1].id, ws2.id);
 });
 

--- a/tests/workspace-store.test.ts
+++ b/tests/workspace-store.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { WorkspaceStore } from "../src/core/workspace-store.ts";
+import type { Workspace } from "../src/shared/types.ts";
 
 function tmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "orbit-workspace-test-"));
@@ -151,4 +152,121 @@ test("transcriptsDir defaults to 'default' for channel and conversation", () => 
   const ws = store.resolve("/tmp/project-defaults");
 
   assert.equal(store.transcriptsDir(ws.id), path.join(dir, "transcripts", ws.id, "default", "default"));
+});
+
+// --- New CRUD tests ---
+
+test("list returns all workspaces sorted by lastOpenedAt descending", () => {
+  const dir = tmpDir();
+  const store = new WorkspaceStore(dir);
+  const ws1 = store.resolve("/projects/alpha");
+  const ws2 = store.resolve("/projects/beta");
+
+  // Re-resolve ws1 to update its lastOpenedAt
+  store.touchLastOpened(ws1.id);
+
+  const list = store.list();
+  assert.equal(list.length, 2);
+  assert.equal(list[0].id, ws1.id, "most recently opened should be first");
+  assert.equal(list[1].id, ws2.id);
+});
+
+test("get returns workspace by id", () => {
+  const dir = tmpDir();
+  const store = new WorkspaceStore(dir);
+  const ws = store.resolve("/projects/my-app");
+
+  const result = store.get(ws.id);
+  assert.ok(result);
+  assert.equal(result!.id, ws.id);
+  assert.equal(result!.name, ws.name);
+  assert.ok(result!.createdAt);
+  assert.ok(result!.lastOpenedAt);
+});
+
+test("get returns null for unknown id", () => {
+  const dir = tmpDir();
+  const store = new WorkspaceStore(dir);
+  assert.equal(store.get("nonexistent"), null);
+});
+
+test("create creates a new workspace", () => {
+  const dir = tmpDir();
+  const store = new WorkspaceStore(dir);
+  const ws = store.create("My Project", "/projects/my-project");
+
+  assert.ok(ws.id);
+  assert.equal(ws.name, "My Project");
+  assert.equal(ws.path, "/projects/my-project");
+  assert.ok(ws.createdAt);
+  assert.ok(ws.lastOpenedAt);
+  assert.ok(store.get(ws.id));
+});
+
+test("create throws if workspace already exists for path", () => {
+  const dir = tmpDir();
+  const store = new WorkspaceStore(dir);
+  store.create("First", "/projects/same-path");
+
+  assert.throws(() => store.create("Second", "/projects/same-path"), /already exists/);
+});
+
+test("update renames a workspace", () => {
+  const dir = tmpDir();
+  const store = new WorkspaceStore(dir);
+  const ws = store.create("Old Name", "/projects/rename-me");
+
+  const updated = store.update(ws.id, { name: "New Name" });
+  assert.equal(updated.name, "New Name");
+
+  const reloaded = store.get(ws.id);
+  assert.equal(reloaded!.name, "New Name");
+});
+
+test("update throws for unknown id", () => {
+  const dir = tmpDir();
+  const store = new WorkspaceStore(dir);
+  assert.throws(() => store.update("nonexistent", { name: "X" }), /not found/);
+});
+
+test("delete removes workspace and all related directories", () => {
+  const dir = tmpDir();
+  const store = new WorkspaceStore(dir);
+  const ws = store.create("ToDelete", "/projects/delete-me");
+
+  // Create some related directories
+  fs.mkdirSync(store.sessionsDir(ws.id), { recursive: true });
+  fs.mkdirSync(store.channelsDir(ws.id), { recursive: true });
+  fs.mkdirSync(store.transcriptsDir(ws.id), { recursive: true });
+
+  store.delete(ws.id);
+
+  assert.equal(store.get(ws.id), null);
+  assert.ok(!fs.existsSync(path.join(dir, "workspaces", ws.id)));
+  assert.ok(!fs.existsSync(store.sessionsDir(ws.id)));
+  assert.ok(!fs.existsSync(store.channelsDir(ws.id)));
+  assert.ok(!fs.existsSync(store.transcriptsDir(ws.id)));
+});
+
+test("delete throws for unknown id", () => {
+  const dir = tmpDir();
+  const store = new WorkspaceStore(dir);
+  assert.throws(() => store.delete("nonexistent"), /not found/);
+});
+
+test("touchLastOpened updates lastOpenedAt", () => {
+  const dir = tmpDir();
+  const store = new WorkspaceStore(dir);
+  const ws = store.create("Touch", "/projects/touch");
+
+  const before = store.get(ws.id)!;
+  // Small delay to ensure different timestamp
+  const start = Date.now();
+  while (Date.now() === start) { /* spin */ }
+
+  store.touchLastOpened(ws.id);
+  const after = store.get(ws.id)!;
+
+  assert.equal(before.id, after.id);
+  assert.notEqual(after.lastOpenedAt, before.lastOpenedAt);
 });

--- a/tests/workspace-store.test.ts
+++ b/tests/workspace-store.test.ts
@@ -116,42 +116,26 @@ test("dataDir returns workspace data path", () => {
   assert.equal(dataDir, path.join(dir, "data", ws.id));
 });
 
-test("channelsDir returns path with workspace, channel and conversation", () => {
+test("channelsDir returns path with workspace and conversation", () => {
   const dir = tmpDir();
   const store = new WorkspaceStore(dir);
   const ws = store.resolve("/tmp/project-channels");
 
   assert.equal(
-    store.channelsDir(ws.id, "general", "conv-1"),
-    path.join(dir, "channels", ws.id, "general", "conv-1"),
+    store.channelsDir(ws.id, "conv-1"),
+    path.join(dir, "conversations", ws.id, "conv-1"),
   );
 });
 
-test("channelsDir defaults to 'default' for channel and conversation", () => {
-  const dir = tmpDir();
-  const store = new WorkspaceStore(dir);
-  const ws = store.resolve("/tmp/project-defaults");
-
-  assert.equal(store.channelsDir(ws.id), path.join(dir, "channels", ws.id, "default", "default"));
-});
-
-test("transcriptsDir returns path with workspace, channel and conversation", () => {
+test("transcriptsDir returns path with workspace and conversation", () => {
   const dir = tmpDir();
   const store = new WorkspaceStore(dir);
   const ws = store.resolve("/tmp/project-transcripts");
 
   assert.equal(
-    store.transcriptsDir(ws.id, "general", "conv-1"),
-    path.join(dir, "transcripts", ws.id, "general", "conv-1"),
+    store.transcriptsDir(ws.id, "conv-1"),
+    path.join(dir, "transcripts", ws.id, "conv-1"),
   );
-});
-
-test("transcriptsDir defaults to 'default' for channel and conversation", () => {
-  const dir = tmpDir();
-  const store = new WorkspaceStore(dir);
-  const ws = store.resolve("/tmp/project-defaults");
-
-  assert.equal(store.transcriptsDir(ws.id), path.join(dir, "transcripts", ws.id, "default", "default"));
 });
 
 // --- New CRUD tests ---
@@ -235,16 +219,16 @@ test("delete removes workspace and all related directories", () => {
 
   // Create some related directories
   fs.mkdirSync(store.sessionsDir(ws.id), { recursive: true });
-  fs.mkdirSync(store.channelsDir(ws.id), { recursive: true });
-  fs.mkdirSync(store.transcriptsDir(ws.id), { recursive: true });
+  fs.mkdirSync(path.join(dir, "conversations", ws.id), { recursive: true });
+  fs.mkdirSync(path.join(dir, "transcripts", ws.id), { recursive: true });
 
   store.delete(ws.id);
 
   assert.equal(store.get(ws.id), null);
   assert.ok(!fs.existsSync(path.join(dir, "workspaces", ws.id)));
   assert.ok(!fs.existsSync(store.sessionsDir(ws.id)));
-  assert.ok(!fs.existsSync(store.channelsDir(ws.id)));
-  assert.ok(!fs.existsSync(store.transcriptsDir(ws.id)));
+  assert.ok(!fs.existsSync(path.join(dir, "conversations", ws.id)));
+  assert.ok(!fs.existsSync(path.join(dir, "transcripts", ws.id)));
 });
 
 test("delete throws for unknown id", () => {


### PR DESCRIPTION
Closes #22
Closes #23

## Summary

Workspace and conversation management MVP — removes the `channel` middle layer, implements multi-conversation parallel execution with LRU context management, and adds full workspace/conversation CRUD.

## Changes

1. **Remove channel layer** — flattened `workspace/channel/conversation` to `workspace/conversation`, migrated legacy data
2. **Multi-conversation parallel execution** — LRU context map allows multiple conversations to run agents concurrently
3. **Workspace CRUD** — list, create, update, delete, switch workspaces
4. **Conversation CRUD** — list, create, update (rename), delete, switch conversations
5. **Collapsible conversation header** — toggle button to show/hide the conversation header area

## Review fixes applied

- `createRunId` uses `crypto.randomBytes()` instead of `Math.random()`
- Safe workspace deletion without temporary empty-string state
- Removed inaccurate `readonly` from hot-swapped fields in `ConversationContext`
- LRU eviction warning when all active contexts have running agents
- UI "channel" classes and labels renamed to "conversation"

## Latest fixes (eb75401)

- **Sync conversation rename to header**: `PUT /api/conversations/:id` now updates `activeConversation` and publishes `context.switched` so the header title updates immediately after rename
- **Fix AgentButton visual states**: removed `isFirst` special-casing; running highlight always takes priority; `selected` style only applied when agent is not running, avoiding visual conflict between selected and running states

All 226 tests pass, build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
