### PR TITLE
fix: persist agent permission profiles and surface runtime availability

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dev": "tsx src/server/index.ts",
     "build": "tsc --noEmit && vite build && node scripts/build-server.mjs",
     "pack:check": "node scripts/check-package.mjs",
-    "test": "node --test --import tsx tests/mention-router.test.ts tests/message-store.test.ts tests/message-router.test.ts tests/ansi-text-extractor.test.ts tests/terminal-transcript-store.test.ts tests/claude-output-detector.test.ts tests/claude-cli-runtime.test.ts tests/codex-cli-runtime.test.ts tests/codebuddy-cli-runtime.test.ts tests/agent-profiles.test.ts tests/agent-registry.test.ts tests/agent-context-builder.test.ts tests/agent-history-builder.test.ts tests/run-manager.test.ts tests/session-store.test.ts tests/agent-session.test.ts tests/workspace-store.test.ts tests/conversation-store.test.ts tests/markdown-renderer.test.ts tests/agent-config-store.test.ts tests/package-manifest.test.ts",
+    "test": "node --test --import tsx tests/mention-router.test.ts tests/message-store.test.ts tests/message-router.test.ts tests/ansi-text-extractor.test.ts tests/terminal-transcript-store.test.ts tests/claude-output-detector.test.ts tests/claude-cli-runtime.test.ts tests/codex-cli-runtime.test.ts tests/codebuddy-cli-runtime.test.ts tests/agent-profiles.test.ts tests/agent-registry.test.ts tests/agent-context-builder.test.ts tests/agent-history-builder.test.ts tests/run-manager.test.ts tests/session-store.test.ts tests/agent-session.test.ts tests/workspace-store.test.ts tests/conversation-store.test.ts tests/markdown-renderer.test.ts tests/agent-config-store.test.ts tests/runtime-probe.test.ts tests/package-manifest.test.ts",
     "test:glob": "node --test --import tsx tests/*.test.ts"
   },
   "dependencies": {

--- a/src/core/agent-config-store.ts
+++ b/src/core/agent-config-store.ts
@@ -153,7 +153,13 @@ export class AgentConfigStore {
         }
       }
       if (migrated) {
-        this.save(workspaceId, configs);
+        try {
+          this.save(workspaceId, configs);
+        } catch (err) {
+          // Don't lose the user's configs just because we couldn't persist
+          // the migration — warn and return the in-memory fix anyway.
+          console.warn("[orbit] Failed to persist permissionProfile migration:", (err as Error).message ?? String(err));
+        }
       }
       return configs;
     } catch {

--- a/src/core/agent-config-store.ts
+++ b/src/core/agent-config-store.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { AgentConfig, AgentId, AgentRole, AgentRuntimeKind } from "../shared/types.ts";
+import { permissionProfile } from "./agent-profiles.ts";
 
 export type { AgentConfig };
 
@@ -20,6 +21,7 @@ export const DEFAULT_AGENT_CONFIGS: AgentConfig[] = [
     systemPrompt:
       "You are Orbit's product manager. Clarify requirements, define scope, acceptance criteria, and review whether implementation matches user needs. Do not edit code unless explicitly assigned.",
     enabled: false,
+    permissionProfile: permissionProfile("pm"),
   },
   {
     id: "architect",
@@ -30,6 +32,7 @@ export const DEFAULT_AGENT_CONFIGS: AgentConfig[] = [
     systemPrompt:
       "You are Orbit's architect. Design technical boundaries, module responsibilities, migration plans, and review implementation risk. Prefer scoped, testable changes.",
     enabled: false,
+    permissionProfile: permissionProfile("architect"),
   },
   {
     id: "developer",
@@ -40,6 +43,7 @@ export const DEFAULT_AGENT_CONFIGS: AgentConfig[] = [
     systemPrompt:
       "You are Orbit's developer. Follow strict TDD: write failing tests first, then implement the minimal code to pass them. Before writing any code, always create a feature branch from main (e.g. feat/issue-N-description). Run npm run test && npm run build after each meaningful change. Commit, push, and open a draft PR. Never commit directly to main.",
     enabled: false,
+    permissionProfile: permissionProfile("developer"),
   },
   {
     id: "tester",
@@ -50,6 +54,7 @@ export const DEFAULT_AGENT_CONFIGS: AgentConfig[] = [
     systemPrompt:
       "You are Orbit's tester. Validate behavior, run tests, inspect regressions, and report risks. Do not modify production code unless explicitly assigned.",
     enabled: false,
+    permissionProfile: permissionProfile("tester"),
   },
 ];
 
@@ -138,6 +143,17 @@ export class AgentConfigStore {
       if (errors.length > 0) {
         console.error(`[orbit] Invalid agents.json, using defaults: ${errors.join("; ")}`);
         return structuredClone(DEFAULT_AGENT_CONFIGS);
+      }
+      // Migrate old configs missing permissionProfile
+      let migrated = false;
+      for (const config of configs) {
+        if (!config.permissionProfile) {
+          config.permissionProfile = permissionProfile(config.role);
+          migrated = true;
+        }
+      }
+      if (migrated) {
+        this.save(workspaceId, configs);
       }
       return configs;
     } catch {

--- a/src/core/agent-context-builder.ts
+++ b/src/core/agent-context-builder.ts
@@ -22,7 +22,7 @@ function renderHistory(entries: AgentHistoryEntry[]): string[] {
 export function buildAgentContext(input: AgentContextInput): string {
   const profile = input.profiles.find((agent) => agent.id === input.agentId);
   const availableAgents = input.profiles.map((agent) => {
-    const desc = agent.description ? ` — ${agent.description}` : "";
+    const desc = agent.description ? ` - ${agent.description}` : "";
     return `@${agent.id}: ${agent.name}${desc}`;
   }).join("\n");
   const permissions = profile
@@ -65,13 +65,13 @@ export function buildAgentContext(input: AgentContextInput): string {
     "Good: @reviewer: Please review the changes above, focusing on edge cases.",
     "",
     "# Typical handoff loop:",
-    "Planner → @worker: Build the first version, then decide if others are needed.",
-    "Worker → @reviewer: Review this for completeness and risks.",
-    "Reviewer → @worker: Fix issues X and Y, then re-submit.",
-    "Worker → @reviewer: Fixes applied, please re-verify.",
-    "Reviewer → Done. No further work needed.",
+    "Planner -> @worker: Build the first version, then decide if others are needed.",
+    "Worker -> @reviewer: Review this for completeness and risks.",
+    "Reviewer -> @worker: Fix issues X and Y, then re-submit.",
+    "Worker -> @reviewer: Fixes applied, please re-verify.",
+    "Reviewer -> Done. No further work needed.",
     "",
-    "# No further work — just end naturally:",
+    "# No further work - just end naturally:",
     "Good: Task complete. No further agent work is needed at this time.",
     "",
     "Final answer rules:",

--- a/src/core/runtime-meta.ts
+++ b/src/core/runtime-meta.ts
@@ -1,0 +1,20 @@
+/** Map AgentRuntimeKind to CLI probe key: claude-code → claude */
+export function runtimeKindToCliKey(runtime: string): string {
+  return runtime === "claude-code" ? "claude" : runtime;
+}
+
+/** Shared runtime metadata — labels and install URLs in one place */
+export type RuntimeMeta = { label: string; installUrl: string };
+
+export function runtimeMeta(runtime: string): RuntimeMeta {
+  switch (runtime) {
+    case "claude-code":
+      return { label: "Claude Code", installUrl: "https://docs.anthropic.com/en/docs/claude-code/overview" };
+    case "codex":
+      return { label: "OpenAI Codex", installUrl: "https://github.com/openai/codex" };
+    case "codebuddy":
+      return { label: "CodeBuddy", installUrl: "https://www.codebuddy.ai/cli" };
+    default:
+      return { label: runtime, installUrl: "" };
+  }
+}

--- a/src/core/runtime-probe.ts
+++ b/src/core/runtime-probe.ts
@@ -52,6 +52,11 @@ export async function probeRuntime(command: string): Promise<RuntimeProbeResult>
 
 export type RuntimeAvailabilityMap = Record<string, RuntimeProbeResult>;
 
+/** Map AgentRuntimeKind to CLI probe key: claude-code → claude */
+export function runtimeKindToCliKey(runtime: string): string {
+  return runtime === "claude-code" ? "claude" : runtime;
+}
+
 export async function probeAllRuntimes(): Promise<RuntimeProbeResult[]> {
   return Promise.all([
     probeRuntime("claude"),

--- a/src/core/runtime-probe.ts
+++ b/src/core/runtime-probe.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import fs from "node:fs";
-import path from "node:path";
 import { promisify } from "node:util";
+import { resolveCodexCommand } from "./codex-cli-runtime.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -52,69 +52,6 @@ export async function probeRuntime(command: string): Promise<RuntimeProbeResult>
   }
 }
 
-/**
- * Probe for codex using the same resolution logic as the Codex CLI runtime
- * (ORBIT_CODEX_PATH, CODEX_CLI_PATH, Windows install locations, PATH fallback).
- */
-export function resolveCodexCommandPath(env: NodeJS.ProcessEnv = process.env): string | null {
-  // 1. Explicit env var overrides
-  const configured = env.ORBIT_CODEX_PATH || env.CODEX_CLI_PATH;
-  if (configured) {
-    // Absolute paths must exist; relative/bare names are trusted (spawn resolves via PATH)
-    if (path.isAbsolute(configured)) {
-      return fs.existsSync(configured) ? configured : null;
-    }
-    return configured;
-  }
-
-  if (process.platform !== "win32") {
-    // On Unix: PATH-only (checked via exec in probe, not fs)
-    return null;
-  }
-
-  // 2. Windows: search known install locations
-  const candidates = resolveWindowsCodexCommand(env);
-  return candidates[0] ?? null;
-}
-
-function resolveWindowsCodexCommand(env: NodeJS.ProcessEnv): string[] {
-  const candidates: string[] = [];
-
-  // OpenAI Codex install directory
-  const codexBin = env.LOCALAPPDATA ? [env.LOCALAPPDATA, "OpenAI", "Codex", "bin"].join(String.fromCharCode(92)) : "";
-  if (codexBin && fs.existsSync(codexBin)) {
-    try {
-      const files = fs.readdirSync(codexBin).map((f) => [codexBin, f].join(String.fromCharCode(92)));
-      candidates.push(...files.filter((f) => f.toLowerCase().endsWith("codex.exe")));
-    } catch { /* ignore read errors */ }
-  }
-
-  // Standalone releases directory
-  const releasesDir = [env.USERPROFILE ?? "", ".codex", "packages", "standalone", "releases"].join(String.fromCharCode(92));
-  if (fs.existsSync(releasesDir)) {
-    try {
-      for (const entry of fs.readdirSync(releasesDir, { withFileTypes: true })) {
-        if (entry.isDirectory()) {
-          const exe = [releasesDir, entry.name, "codex.exe"].join(String.fromCharCode(92));
-          if (fs.existsSync(exe)) candidates.push(exe);
-        }
-      }
-    } catch { /* ignore read errors */ }
-  }
-
-  // PATH-based candidates (excluding WindowsApps)
-  const pathValue = env.PATH || env.Path || "";
-  for (const dir of pathValue.split(";").filter(Boolean)) {
-    if (dir.toLowerCase().includes("\\windowsapps")) continue;
-    const cmd = [dir, "codex.cmd"].join(String.fromCharCode(92));
-    const exe = [dir, "codex.exe"].join(String.fromCharCode(92));
-    if (fs.existsSync(cmd)) candidates.push(cmd);
-    if (fs.existsSync(exe)) candidates.push(exe);
-  }
-
-  return candidates;
-}
-
 export type RuntimeAvailabilityMap = Record<string, RuntimeProbeResult>;
 
 /** Map AgentRuntimeKind to CLI probe key: claude-code → claude */
@@ -131,11 +68,15 @@ export async function probeAllRuntimes(): Promise<RuntimeProbeResult[]> {
 }
 
 async function probeCodexRuntime(): Promise<RuntimeProbeResult> {
-  // First check full resolution (env vars, known install dirs)
-  const resolved = resolveCodexCommandPath();
-  if (resolved) {
-    return { runtime: "codex", available: true, path: resolved };
+  // Use the same resolver as the actual Codex CLI runtime
+  const resolved = resolveCodexCommand();
+  // If the resolver returned an absolute path, check it exists on disk
+  if (resolved !== "codex") {
+    // Not the bare fallback — the resolver found a specific installation
+    return fs.existsSync(resolved)
+      ? { runtime: "codex", available: true, path: resolved }
+      : { runtime: "codex", available: false, path: null, error: `Configured path not found: ${resolved}` };
   }
-  // Fall back to PATH-based probe
+  // Bare "codex" — fall back to PATH probe
   return probeRuntime("codex");
 }

--- a/src/core/runtime-probe.ts
+++ b/src/core/runtime-probe.ts
@@ -1,4 +1,6 @@
 import { execFile } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
@@ -50,6 +52,69 @@ export async function probeRuntime(command: string): Promise<RuntimeProbeResult>
   }
 }
 
+/**
+ * Probe for codex using the same resolution logic as the Codex CLI runtime
+ * (ORBIT_CODEX_PATH, CODEX_CLI_PATH, Windows install locations, PATH fallback).
+ */
+export function resolveCodexCommandPath(env: NodeJS.ProcessEnv = process.env): string | null {
+  // 1. Explicit env var overrides
+  const configured = env.ORBIT_CODEX_PATH || env.CODEX_CLI_PATH;
+  if (configured) {
+    // Absolute paths must exist; relative/bare names are trusted (spawn resolves via PATH)
+    if (path.isAbsolute(configured)) {
+      return fs.existsSync(configured) ? configured : null;
+    }
+    return configured;
+  }
+
+  if (process.platform !== "win32") {
+    // On Unix: PATH-only (checked via exec in probe, not fs)
+    return null;
+  }
+
+  // 2. Windows: search known install locations
+  const candidates = resolveWindowsCodexCommand(env);
+  return candidates[0] ?? null;
+}
+
+function resolveWindowsCodexCommand(env: NodeJS.ProcessEnv): string[] {
+  const candidates: string[] = [];
+
+  // OpenAI Codex install directory
+  const codexBin = env.LOCALAPPDATA ? [env.LOCALAPPDATA, "OpenAI", "Codex", "bin"].join(String.fromCharCode(92)) : "";
+  if (codexBin && fs.existsSync(codexBin)) {
+    try {
+      const files = fs.readdirSync(codexBin).map((f) => [codexBin, f].join(String.fromCharCode(92)));
+      candidates.push(...files.filter((f) => f.toLowerCase().endsWith("codex.exe")));
+    } catch { /* ignore read errors */ }
+  }
+
+  // Standalone releases directory
+  const releasesDir = [env.USERPROFILE ?? "", ".codex", "packages", "standalone", "releases"].join(String.fromCharCode(92));
+  if (fs.existsSync(releasesDir)) {
+    try {
+      for (const entry of fs.readdirSync(releasesDir, { withFileTypes: true })) {
+        if (entry.isDirectory()) {
+          const exe = [releasesDir, entry.name, "codex.exe"].join(String.fromCharCode(92));
+          if (fs.existsSync(exe)) candidates.push(exe);
+        }
+      }
+    } catch { /* ignore read errors */ }
+  }
+
+  // PATH-based candidates (excluding WindowsApps)
+  const pathValue = env.PATH || env.Path || "";
+  for (const dir of pathValue.split(";").filter(Boolean)) {
+    if (dir.toLowerCase().includes("\\windowsapps")) continue;
+    const cmd = [dir, "codex.cmd"].join(String.fromCharCode(92));
+    const exe = [dir, "codex.exe"].join(String.fromCharCode(92));
+    if (fs.existsSync(cmd)) candidates.push(cmd);
+    if (fs.existsSync(exe)) candidates.push(exe);
+  }
+
+  return candidates;
+}
+
 export type RuntimeAvailabilityMap = Record<string, RuntimeProbeResult>;
 
 /** Map AgentRuntimeKind to CLI probe key: claude-code → claude */
@@ -60,7 +125,17 @@ export function runtimeKindToCliKey(runtime: string): string {
 export async function probeAllRuntimes(): Promise<RuntimeProbeResult[]> {
   return Promise.all([
     probeRuntime("claude"),
-    probeRuntime("codex"),
+    probeCodexRuntime(),
     probeRuntime("codebuddy"),
   ]);
+}
+
+async function probeCodexRuntime(): Promise<RuntimeProbeResult> {
+  // First check full resolution (env vars, known install dirs)
+  const resolved = resolveCodexCommandPath();
+  if (resolved) {
+    return { runtime: "codex", available: true, path: resolved };
+  }
+  // Fall back to PATH-based probe
+  return probeRuntime("codex");
 }

--- a/src/core/runtime-probe.ts
+++ b/src/core/runtime-probe.ts
@@ -84,6 +84,9 @@ async function probeCodexRuntime(): Promise<RuntimeProbeResult> {
       : { runtime: "codex", available: false, path: null, error: `Configured path not found: ${resolved}`, checkedAt };
   }
   // Non-absolute command name (e.g. "custom-codex" from CODEX_CLI_PATH) —
-  // resolve via PATH just like the actual runtime does with spawn
-  return probeRuntime(resolved);
+  // resolve via PATH just like the actual runtime does with spawn.
+  // Always report runtime: "codex" so UI/server look up the right key;
+  // the actual resolved command path goes in `path`.
+  const result = await probeRuntime(resolved);
+  return { ...result, runtime: "codex" };
 }

--- a/src/core/runtime-probe.ts
+++ b/src/core/runtime-probe.ts
@@ -4,6 +4,9 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { resolveCodexCommand } from "./codex-cli-runtime.ts";
 
+// Re-export from shared browser-safe module
+export { runtimeKindToCliKey, runtimeMeta, type RuntimeMeta } from "./runtime-meta.ts";
+
 const execFileAsync = promisify(execFile);
 
 export type RuntimeProbeResult = {
@@ -56,11 +59,6 @@ export async function probeRuntime(command: string): Promise<RuntimeProbeResult>
 }
 
 export type RuntimeAvailabilityMap = Record<string, RuntimeProbeResult>;
-
-/** Map AgentRuntimeKind to CLI probe key: claude-code → claude */
-export function runtimeKindToCliKey(runtime: string): string {
-  return runtime === "claude-code" ? "claude" : runtime;
-}
 
 export async function probeAllRuntimes(): Promise<RuntimeProbeResult[]> {
   return Promise.all([

--- a/src/core/runtime-probe.ts
+++ b/src/core/runtime-probe.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import fs from "node:fs";
+import path from "node:path";
 import { promisify } from "node:util";
 import { resolveCodexCommand } from "./codex-cli-runtime.ts";
 
@@ -10,6 +11,7 @@ export type RuntimeProbeResult = {
   available: boolean;
   path: string | null;
   error?: string;
+  checkedAt: string;
 };
 
 const TIMEOUT_MS = 5000;
@@ -37,18 +39,19 @@ async function resolveCommand(command: string): Promise<{ available: boolean; pa
 }
 
 export async function probeRuntime(command: string): Promise<RuntimeProbeResult> {
+  const checkedAt = new Date().toISOString();
   if (!command || !command.trim()) {
-    return { runtime: command, available: false, path: null, error: "Empty command name" };
+    return { runtime: command, available: false, path: null, error: "Empty command name", checkedAt };
   }
   try {
     const result = await resolveCommand(command);
     if (result.available) {
-      return { runtime: command, available: true, path: result.path };
+      return { runtime: command, available: true, path: result.path, checkedAt };
     }
-    return { runtime: command, available: false, path: null, error: `Command not found: ${command}` };
+    return { runtime: command, available: false, path: null, error: `Command not found: ${command}`, checkedAt };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    return { runtime: command, available: false, path: null, error: message };
+    return { runtime: command, available: false, path: null, error: message, checkedAt };
   }
 }
 
@@ -68,15 +71,21 @@ export async function probeAllRuntimes(): Promise<RuntimeProbeResult[]> {
 }
 
 async function probeCodexRuntime(): Promise<RuntimeProbeResult> {
+  const checkedAt = new Date().toISOString();
   // Use the same resolver as the actual Codex CLI runtime
   const resolved = resolveCodexCommand();
-  // If the resolver returned an absolute path, check it exists on disk
-  if (resolved !== "codex") {
-    // Not the bare fallback — the resolver found a specific installation
-    return fs.existsSync(resolved)
-      ? { runtime: "codex", available: true, path: resolved }
-      : { runtime: "codex", available: false, path: null, error: `Configured path not found: ${resolved}` };
+  if (resolved === "codex") {
+    // Bare fallback — use PATH probe
+    return probeRuntime("codex");
   }
-  // Bare "codex" — fall back to PATH probe
-  return probeRuntime("codex");
+  // Resolver found a non-default command (env var, install dir, etc.)
+  if (path.isAbsolute(resolved)) {
+    // Absolute path — verify on disk
+    return fs.existsSync(resolved)
+      ? { runtime: "codex", available: true, path: resolved, checkedAt }
+      : { runtime: "codex", available: false, path: null, error: `Configured path not found: ${resolved}`, checkedAt };
+  }
+  // Non-absolute command name (e.g. "custom-codex" from CODEX_CLI_PATH) —
+  // resolve via PATH just like the actual runtime does with spawn
+  return probeRuntime(resolved);
 }

--- a/src/core/runtime-probe.ts
+++ b/src/core/runtime-probe.ts
@@ -1,0 +1,61 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export type RuntimeProbeResult = {
+  runtime: string;
+  available: boolean;
+  path: string | null;
+  error?: string;
+};
+
+const TIMEOUT_MS = 5000;
+
+async function resolveCommand(command: string): Promise<{ available: boolean; path: string | null }> {
+  try {
+    // On Windows, use `where`; on Unix, use `which`
+    if (process.platform === "win32") {
+      const { stdout } = await execFileAsync("where", [command], { timeout: TIMEOUT_MS, windowsHide: true });
+      const firstLine = stdout.split("\r\n")[0]?.trim() ?? "";
+      if (firstLine) {
+        return { available: true, path: firstLine };
+      }
+    } else {
+      const { stdout } = await execFileAsync("which", [command], { timeout: TIMEOUT_MS });
+      const resolved = stdout.trim();
+      if (resolved) {
+        return { available: true, path: resolved };
+      }
+    }
+    return { available: false, path: null };
+  } catch {
+    return { available: false, path: null };
+  }
+}
+
+export async function probeRuntime(command: string): Promise<RuntimeProbeResult> {
+  if (!command || !command.trim()) {
+    return { runtime: command, available: false, path: null, error: "Empty command name" };
+  }
+  try {
+    const result = await resolveCommand(command);
+    if (result.available) {
+      return { runtime: command, available: true, path: result.path };
+    }
+    return { runtime: command, available: false, path: null, error: `Command not found: ${command}` };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { runtime: command, available: false, path: null, error: message };
+  }
+}
+
+export type RuntimeAvailabilityMap = Record<string, RuntimeProbeResult>;
+
+export async function probeAllRuntimes(): Promise<RuntimeProbeResult[]> {
+  return Promise.all([
+    probeRuntime("claude"),
+    probeRuntime("codex"),
+    probeRuntime("codebuddy"),
+  ]);
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -7,6 +7,7 @@ import { promisify } from "node:util";
 
 import { configsToProfiles } from "../core/agent-profiles.ts";
 import { AgentConfigStore, validateAgentConfigs } from "../core/agent-config-store.ts";
+import { probeAllRuntimes, type RuntimeProbeResult } from "../core/runtime-probe.ts";
 import type { AgentConfig } from "../core/agent-config-store.ts";
 import { ConversationStore } from "../core/conversation-store.ts";
 import { EventBus } from "../core/event-bus.ts";
@@ -29,6 +30,27 @@ const eventBus = new EventBus();
 const sseHub = new SseHub();
 const workspaceStore = new WorkspaceStore();
 const configStore = new AgentConfigStore();
+
+// --- Runtime availability cache ---
+let runtimeAvailability: Map<string, RuntimeProbeResult> = new Map();
+
+async function probeRuntimesOnStartup(): Promise<void> {
+  const results = await probeAllRuntimes();
+  for (const result of results) {
+    runtimeAvailability.set(result.runtime, result);
+  }
+  // Map CLI names to AgentRuntimeKind for agent state lookup
+  // claude -> claude-code, codex -> codex, codebuddy -> codebuddy
+  console.log(
+    "[orbit] runtime availability: " +
+    results.map((r) => `${r.runtime}=${r.available ? "found" : "missing"}`).join(", "),
+  );
+}
+
+function runtimeAvailable(runtime: string): boolean {
+  const result = runtimeAvailability.get(runtime);
+  return result?.available ?? false;
+}
 
 // Forward all events to SSE clients (single global subscriber)
 eventBus.subscribe((event) => {
@@ -316,7 +338,10 @@ function clearActiveConversation(): void {
 function currentAgentStates() {
   const ctx = getActiveContext();
   if (ctx) {
-    return ctx.agents.states();
+    return ctx.agents.states().map((s) => ({
+      ...s,
+      runtimeAvailable: runtimeAvailable(s.runtime),
+    }));
   }
   return allConfigs
     .filter((config) => config.enabled)
@@ -326,12 +351,16 @@ function currentAgentStates() {
       runtime: config.runtime,
       status: "idle" as const,
       selected: index === 0,
+      runtimeAvailable: runtimeAvailable(config.runtime),
     }));
 }
 
 // --- Initialize ---
 migrateChannelLayer();
 initActiveContext();
+probeRuntimesOnStartup().catch((err) => {
+  console.warn("[orbit] runtime probe failed:", err instanceof Error ? err.message : String(err));
+});
 
 // --- HTTP Server ---
 const server = http.createServer(async (req, res) => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -7,7 +7,7 @@ import { promisify } from "node:util";
 
 import { configsToProfiles } from "../core/agent-profiles.ts";
 import { AgentConfigStore, validateAgentConfigs } from "../core/agent-config-store.ts";
-import { probeAllRuntimes, type RuntimeProbeResult } from "../core/runtime-probe.ts";
+import { probeAllRuntimes, runtimeKindToCliKey, type RuntimeProbeResult } from "../core/runtime-probe.ts";
 import type { AgentConfig } from "../core/agent-config-store.ts";
 import { ConversationStore } from "../core/conversation-store.ts";
 import { EventBus } from "../core/event-bus.ts";
@@ -48,7 +48,7 @@ async function probeRuntimesOnStartup(): Promise<void> {
 }
 
 function runtimeAvailable(runtime: string): boolean {
-  const result = runtimeAvailability.get(runtime);
+  const result = runtimeAvailability.get(runtimeKindToCliKey(runtime));
   return result?.available ?? false;
 }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -358,11 +358,8 @@ function currentAgentStates() {
 // --- Initialize ---
 migrateChannelLayer();
 initActiveContext();
-probeRuntimesOnStartup().catch((err) => {
-  console.warn("[orbit] runtime probe failed:", err instanceof Error ? err.message : String(err));
-});
 
-// --- HTTP Server ---
+// --- HTTP Server (created before probe to avoid blocking setup) ---
 const server = http.createServer(async (req, res) => {
   try {
     const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
@@ -650,9 +647,15 @@ const server = http.createServer(async (req, res) => {
   }
 });
 
-server.listen(port, () => {
-  console.log(`[orbit] listening on http://localhost:${port}`);
-});
+// Probe runtimes before accepting connections to avoid startup race
+(async () => {
+  await probeRuntimesOnStartup().catch((err) => {
+    console.warn("[orbit] runtime probe failed:", err instanceof Error ? err.message : String(err));
+  });
+  server.listen(port, () => {
+    console.log(`[orbit] listening on http://localhost:${port}`);
+  });
+})();
 
 // --- Helpers ---
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -31,20 +31,52 @@ const sseHub = new SseHub();
 const workspaceStore = new WorkspaceStore();
 const configStore = new AgentConfigStore();
 
-// --- Runtime availability cache ---
+// --- Runtime availability ---
+const PROBE_INTERVAL_MS = Number(process.env.ORBIT_RUNTIME_PROBE_INTERVAL_MS ?? 60000);
 let runtimeAvailability: Map<string, RuntimeProbeResult> = new Map();
+let probeTimer: ReturnType<typeof setInterval> | null = null;
 
-async function probeRuntimesOnStartup(): Promise<void> {
+async function probeRuntimes(): Promise<void> {
   const results = await probeAllRuntimes();
+  let changed = false;
   for (const result of results) {
+    const previous = runtimeAvailability.get(result.runtime);
+    if (!previous || previous.available !== result.available) {
+      changed = true;
+    }
     runtimeAvailability.set(result.runtime, result);
   }
-  // Map CLI names to AgentRuntimeKind for agent state lookup
-  // claude -> claude-code, codex -> codex, codebuddy -> codebuddy
   console.log(
     "[orbit] runtime availability: " +
     results.map((r) => `${r.runtime}=${r.available ? "found" : "missing"}`).join(", "),
   );
+  if (changed) {
+    sseHub.publish({ type: "runtime.availability.updated", availability: getRuntimeAvailabilityArray() });
+  }
+}
+
+function startPeriodicProbe(): void {
+  if (probeTimer) return;
+  probeTimer = setInterval(() => {
+    probeRuntimes().catch((err) => {
+      console.warn("[orbit] periodic runtime probe failed:", err instanceof Error ? err.message : String(err));
+    });
+  }, PROBE_INTERVAL_MS);
+  // Prevent timer from keeping the process alive during tests
+  if (probeTimer && typeof probeTimer === "object" && "unref" in probeTimer) {
+    (probeTimer as NodeJS.Timeout).unref();
+  }
+}
+
+function stopPeriodicProbe(): void {
+  if (probeTimer) {
+    clearInterval(probeTimer);
+    probeTimer = null;
+  }
+}
+
+function getRuntimeAvailabilityArray(): RuntimeProbeResult[] {
+  return Array.from(runtimeAvailability.values());
 }
 
 function runtimeAvailable(runtime: string): boolean {
@@ -380,6 +412,7 @@ const server = http.createServer(async (req, res) => {
         messages: ctx?.messages.list() ?? [],
         terminal: ctx?.transcripts.all() ?? {},
         runningSummaries: buildRunningSummaries(),
+        runtimeAvailability: getRuntimeAvailabilityArray(),
       });
       return;
     }
@@ -649,9 +682,10 @@ const server = http.createServer(async (req, res) => {
 
 // Probe runtimes before accepting connections to avoid startup race
 (async () => {
-  await probeRuntimesOnStartup().catch((err) => {
+  await probeRuntimes().catch((err) => {
     console.warn("[orbit] runtime probe failed:", err instanceof Error ? err.message : String(err));
   });
+  startPeriodicProbe();
   server.listen(port, () => {
     console.log(`[orbit] listening on http://localhost:${port}`);
   });
@@ -797,6 +831,7 @@ async function handlePutAgents(req: http.IncomingMessage, res: http.ServerRespon
 }
 
 function shutdown(): void {
+  stopPeriodicProbe();
   for (const ctx of contextMap.values()) {
     ctx.dispose();
   }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -48,6 +48,7 @@ export type AgentState = {
   runtime: AgentRuntimeKind;
   status: AgentStatus;
   selected?: boolean;
+  runtimeAvailable?: boolean;
 };
 
 export type ChatMessageKind = "user" | "agent" | "system";

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -109,6 +109,7 @@ export type RuntimeEvent =
   | { type: "run.failed"; conversationId: string; agentId: AgentId; runId: string; error: string }
   | { type: "run.sessionId"; conversationId: string; agentId: AgentId; runId: string; sessionId: string }
   | { type: "running.updated"; summaries: RunningSummary[] }
+  | { type: "runtime.availability.updated"; availability: RuntimeAvailability[] }
   | { type: "context.switched"; workspace: WorkspaceInfo; conversation: ConversationInfo };
 
 export type TerminalState = Record<string, string>;
@@ -135,6 +136,14 @@ export type Conversation = ConversationInfo & {
   lastOpenedAt: string;
 };
 
+export type RuntimeAvailability = {
+  runtime: string;
+  available: boolean;
+  path: string | null;
+  error?: string;
+  checkedAt: string;
+};
+
 export type AppState = {
   workspace: WorkspaceInfo;
   conversation: ConversationInfo;
@@ -142,4 +151,5 @@ export type AppState = {
   agents: AgentState[];
   terminal: TerminalState;
   runningSummaries: RunningSummary[];
+  runtimeAvailability: RuntimeAvailability[];
 };

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -10,6 +10,7 @@ const initialState: AppState = {
   messages: [],
   terminal: {},
   runningSummaries: [],
+  runtimeAvailability: [],
 };
 
 export function App() {
@@ -864,6 +865,7 @@ export function App() {
         <AgentManagerPanel
           onClose={() => setShowAgentManager(false)}
           onSaved={() => { setShowAgentManager(false); window.location.reload(); }}
+          runtimeAvailability={state.runtimeAvailability}
         />
       ) : null}
     </main>
@@ -1182,12 +1184,27 @@ function SystemSettingsPanel({ onClose }: { onClose: () => void }) {
   );
 }
 
-function AgentManagerPanel({ onClose, onSaved }: { onClose: () => void; onSaved: () => void }) {
+function AgentManagerPanel({ onClose, onSaved, runtimeAvailability }: { onClose: () => void; onSaved: () => void; runtimeAvailability: AppState["runtimeAvailability"] }) {
   const [configs, setConfigs] = useState<AgentConfig[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
   const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
+
+  const availByRuntime = useMemo(() => {
+    const map = new Map<string, boolean>();
+    for (const a of runtimeAvailability) {
+      map.set(a.runtime, a.available);
+    }
+    return map;
+  }, [runtimeAvailability]);
+
+  const firstAvailableRuntime = useMemo((): AgentRuntimeKind => {
+    for (const rt of RUNTIMES) {
+      if (availByRuntime.get(rt) !== false) return rt; // prefer available or unprobed
+    }
+    return "claude-code";
+  }, [availByRuntime]);
 
   useEffect(() => {
     fetch("/api/agents")
@@ -1202,7 +1219,7 @@ function AgentManagerPanel({ onClose, onSaved }: { onClose: () => void; onSaved:
 
   function addConfig() {
     setConfigs((prev) => [
-      { id: `agent-${Date.now()}`, name: "", role: "general", runtime: "claude-code", systemPrompt: "", enabled: true },
+      { id: `agent-${Date.now()}`, name: "", role: "general", runtime: firstAvailableRuntime, systemPrompt: "", enabled: true },
       ...prev,
     ]);
     setExpandedIndex(0);
@@ -1318,9 +1335,26 @@ function AgentManagerPanel({ onClose, onSaved }: { onClose: () => void; onSaved:
                         <div className="pillGroup">
                           <span className="pillLabel">Runtime <span className="fieldHint" title="驱动该智能体的命令行工具。claude-code = Claude CLI，codex = OpenAI Codex，codebuddy = CodeBuddy CLI。">?</span></span>
                           <div className="pillOptions">
-                            {RUNTIMES.map((r) => (
-                              <button key={r} type="button" className={`pillBtn ${config.runtime === r ? "pillActive" : ""}`} onClick={() => updateConfig(i, { runtime: r })}>{r}</button>
-                            ))}
+                            {RUNTIMES.map((r) => {
+                              const isAvailable = availByRuntime.get(r);
+                              const isMissing = isAvailable === false;
+                              const installUrl = r === "claude-code" ? "https://docs.anthropic.com/en/docs/claude-code/overview" :
+                                r === "codex" ? "https://github.com/openai/codex" : "https://www.codebuddy.ai/cli";
+                              return (
+                                <button
+                                  key={r}
+                                  type="button"
+                                  className={`pillBtn ${config.runtime === r ? "pillActive" : ""} ${isMissing ? "pillMissing" : ""}`}
+                                  onClick={() => updateConfig(i, { runtime: r })}
+                                  title={isMissing ? `${r} 未安装 — 点击查看安装说明` : isAvailable === true ? `${r} 已就绪` : `${r} 检测中...`}
+                                >
+                                  {r}
+                                  {isMissing ? (
+                                    <a href={installUrl} target="_blank" rel="noopener noreferrer" className="runtimeInstallLink" onClick={(e) => e.stopPropagation()} title="安装说明">↗</a>
+                                  ) : isAvailable === true ? <span className="pillCheck"> ✓</span> : <span className="pillUnknown"> ?</span>}
+                                </button>
+                              );
+                            })}
                           </div>
                         </div>
                         <div className="fieldWithHint fieldFullWidth">
@@ -1377,6 +1411,10 @@ function PlainText({ content }: { content: string }) {
 function applyEvent(state: AppState, event: RuntimeEvent): AppState {
   if (event.type === "running.updated") {
     return { ...state, runningSummaries: event.summaries };
+  }
+
+  if (event.type === "runtime.availability.updated") {
+    return { ...state, runtimeAvailability: event.availability };
   }
 
   // For conversation-scoped events, only process if they match the active conversation
@@ -1442,6 +1480,7 @@ function normalizeState(nextState: AppState): AppState {
       ...(nextState.terminal ?? {}),
     },
     runningSummaries: nextState.runningSummaries ?? [],
+    runtimeAvailability: nextState.runtimeAvailability ?? [],
   };
 }
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1223,8 +1223,17 @@ function AgentManagerPanel({ onClose, onSaved, runtimeAvailability }: { onClose:
   }
 
   function addConfig() {
+    const role: AgentRole = "general";
     setConfigs((prev) => [
-      { id: `agent-${Date.now()}`, name: "", role: "general", runtime: firstAvailableRuntime, systemPrompt: "", enabled: true },
+      {
+        id: `agent-${Date.now()}`,
+        name: "",
+        role,
+        runtime: firstAvailableRuntime,
+        systemPrompt: "",
+        enabled: true,
+        permissionProfile: permissionProfile(role),
+      },
       ...prev,
     ]);
     setExpandedIndex(0);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -960,18 +960,26 @@ function NavIcon({ kind }: { kind: "workspace" | "conversation" | "agents" | "se
 
 function AgentButton(props: { agent: AgentState; selected: boolean; onClick: () => void }) {
   const isRunning = props.agent.status === "running" || props.agent.status === "starting";
+  const isRuntimeMissing = props.agent.runtimeAvailable === false;
   return (
-    <button className={`agentButton ${props.selected && !isRunning ? "selected" : ""} ${isRunning ? "agentRunning" : ""}`} onClick={props.onClick} type="button">
-      <span className={`statusDot ${props.agent.status}`} aria-hidden="true" />
+    <button
+      className={`agentButton ${props.selected && !isRunning ? "selected" : ""} ${isRunning ? "agentRunning" : ""} ${isRuntimeMissing ? "agentRuntimeMissing" : ""}`}
+      onClick={props.onClick}
+      type="button"
+      title={isRuntimeMissing ? `${props.agent.runtime} not found on PATH — agent cannot run` : undefined}
+    >
+      <span className={`statusDot ${isRuntimeMissing ? "runtimeMissing" : props.agent.status}`} aria-hidden="true" />
       <span className="agentText">
         <strong>
           {props.agent.label}
           {isRunning && <span className="agentRunningLabel">Running</span>}
           <RuntimeBadge runtime={props.agent.runtime} />
         </strong>
-        <small>{props.agent.id}</small>
+        <small>{props.agent.id}{isRuntimeMissing ? " · unavailable" : ""}</small>
       </span>
-      <span className={`agentStatusPill ${props.agent.status}`}>{props.agent.status}</span>
+      <span className={`agentStatusPill ${isRuntimeMissing ? "runtimeMissing" : props.agent.status}`}>
+        {isRuntimeMissing ? "missing" : props.agent.status}
+      </span>
     </button>
   );
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1347,19 +1347,21 @@ function AgentManagerPanel({ onClose, onSaved, runtimeAvailability }: { onClose:
                               const meta = runtimeMeta(r);
                               const disabled = isMissing && !isCurrent;
                               return (
-                                <button
-                                  key={r}
-                                  type="button"
-                                  className={`pillBtn ${isCurrent ? "pillActive" : ""} ${isMissing ? "pillMissing" : ""}`}
-                                  onClick={() => { if (!disabled) updateConfig(i, { runtime: r }); }}
-                                  disabled={disabled}
-                                  title={isMissing ? `${r} 未安装 — 点击 ↗ 查看安装说明` : isAvail === true ? `${r} 已就绪` : `${r} 检测中...`}
-                                >
-                                  {r}
+                                <span key={r} className={`pillBtnWrapper ${isMissing && !isCurrent ? "pillBtnWrapperDisabled" : ""}`}>
+                                  <button
+                                    type="button"
+                                    className={`pillBtn ${isCurrent ? "pillActive" : ""} ${isMissing ? "pillMissing" : ""}`}
+                                    onClick={() => { if (!disabled) updateConfig(i, { runtime: r }); }}
+                                    aria-disabled={disabled || undefined}
+                                    title={isMissing ? `${r} 未安装` : isAvail === true ? `${r} 已就绪` : `${r} 检测中...`}
+                                  >
+                                    {r}
+                                    {isAvail === true ? <span className="pillCheck"> ✓</span> : isAvail === undefined ? <span className="pillUnknown"> ?</span> : null}
+                                  </button>
                                   {isMissing ? (
-                                    <a href={meta.installUrl} target="_blank" rel="noopener noreferrer" className="runtimeInstallLink" onClick={(e) => e.stopPropagation()} title="安装说明">↗</a>
-                                  ) : isAvail === true ? <span className="pillCheck"> ✓</span> : <span className="pillUnknown"> ?</span>}
-                                </button>
+                                    <a href={meta.installUrl} target="_blank" rel="noopener noreferrer" className="runtimeInstallLink" title={`安装 ${meta.label}`}>↗</a>
+                                  ) : null}
+                                </span>
                               );
                             })}
                           </div>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,6 +1,7 @@
 import { CSSProperties, FormEvent, KeyboardEvent, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { renderMarkdown } from "./markdown-renderer.ts";
 import { permissionProfile } from "../core/agent-profiles.ts";
+import { runtimeKindToCliKey, runtimeMeta } from "../core/runtime-meta.ts";
 import type { AgentActivityEvent, AgentConfig, AgentId, AgentRole, AgentRuntimeKind, AgentState, AppState, ChatMessage, Conversation, ConversationInfo, PermissionProfile, RunningSummary, RuntimeEvent, Workspace } from "../shared/types.ts";
 
 const initialState: AppState = {
@@ -1199,9 +1200,13 @@ function AgentManagerPanel({ onClose, onSaved, runtimeAvailability }: { onClose:
     return map;
   }, [runtimeAvailability]);
 
+  function isRuntimeAvailable(runtime: AgentRuntimeKind): boolean | undefined {
+    return availByRuntime.get(runtimeKindToCliKey(runtime));
+  }
+
   const firstAvailableRuntime = useMemo((): AgentRuntimeKind => {
     for (const rt of RUNTIMES) {
-      if (availByRuntime.get(rt) !== false) return rt; // prefer available or unprobed
+      if (isRuntimeAvailable(rt) !== false) return rt; // prefer available or unprobed
     }
     return "claude-code";
   }, [availByRuntime]);
@@ -1336,22 +1341,24 @@ function AgentManagerPanel({ onClose, onSaved, runtimeAvailability }: { onClose:
                           <span className="pillLabel">Runtime <span className="fieldHint" title="驱动该智能体的命令行工具。claude-code = Claude CLI，codex = OpenAI Codex，codebuddy = CodeBuddy CLI。">?</span></span>
                           <div className="pillOptions">
                             {RUNTIMES.map((r) => {
-                              const isAvailable = availByRuntime.get(r);
-                              const isMissing = isAvailable === false;
-                              const installUrl = r === "claude-code" ? "https://docs.anthropic.com/en/docs/claude-code/overview" :
-                                r === "codex" ? "https://github.com/openai/codex" : "https://www.codebuddy.ai/cli";
+                              const isAvail = isRuntimeAvailable(r);
+                              const isMissing = isAvail === false;
+                              const isCurrent = config.runtime === r;
+                              const meta = runtimeMeta(r);
+                              const disabled = isMissing && !isCurrent;
                               return (
                                 <button
                                   key={r}
                                   type="button"
-                                  className={`pillBtn ${config.runtime === r ? "pillActive" : ""} ${isMissing ? "pillMissing" : ""}`}
-                                  onClick={() => updateConfig(i, { runtime: r })}
-                                  title={isMissing ? `${r} 未安装 — 点击查看安装说明` : isAvailable === true ? `${r} 已就绪` : `${r} 检测中...`}
+                                  className={`pillBtn ${isCurrent ? "pillActive" : ""} ${isMissing ? "pillMissing" : ""}`}
+                                  onClick={() => { if (!disabled) updateConfig(i, { runtime: r }); }}
+                                  disabled={disabled}
+                                  title={isMissing ? `${r} 未安装 — 点击 ↗ 查看安装说明` : isAvail === true ? `${r} 已就绪` : `${r} 检测中...`}
                                 >
                                   {r}
                                   {isMissing ? (
-                                    <a href={installUrl} target="_blank" rel="noopener noreferrer" className="runtimeInstallLink" onClick={(e) => e.stopPropagation()} title="安装说明">↗</a>
-                                  ) : isAvailable === true ? <span className="pillCheck"> ✓</span> : <span className="pillUnknown"> ?</span>}
+                                    <a href={meta.installUrl} target="_blank" rel="noopener noreferrer" className="runtimeInstallLink" onClick={(e) => e.stopPropagation()} title="安装说明">↗</a>
+                                  ) : isAvail === true ? <span className="pillCheck"> ✓</span> : <span className="pillUnknown"> ?</span>}
                                 </button>
                               );
                             })}
@@ -1414,7 +1421,19 @@ function applyEvent(state: AppState, event: RuntimeEvent): AppState {
   }
 
   if (event.type === "runtime.availability.updated") {
-    return { ...state, runtimeAvailability: event.availability };
+    const availMap = new Map<string, boolean>();
+    for (const a of event.availability) {
+      availMap.set(a.runtime, a.available);
+    }
+    return {
+      ...state,
+      runtimeAvailability: event.availability,
+      agents: state.agents.map((agent) => {
+        const cliKey = runtimeKindToCliKey(agent.runtime);
+        const available = availMap.get(cliKey);
+        return { ...agent, runtimeAvailable: available };
+      }),
+    };
   }
 
   // For conversation-scoped events, only process if they match the active conversation

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -2439,6 +2439,34 @@ button:active:not(:disabled) {
   background: var(--accent-hover);
 }
 
+.pillMissing {
+  opacity: 0.6;
+  border-color: var(--error-border);
+  color: var(--error);
+}
+
+.pillCheck {
+  color: var(--success);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.pillUnknown {
+  color: var(--subtext);
+  font-size: 11px;
+}
+
+.runtimeInstallLink {
+  margin-left: 2px;
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 12px;
+}
+
+.runtimeInstallLink:hover {
+  text-decoration: underline;
+}
+
 .configFields {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -2439,21 +2439,20 @@ button:active:not(:disabled) {
   background: var(--accent-hover);
 }
 
+.pillBtnWrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.pillBtnWrapperDisabled .pillBtn {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
 .pillMissing {
-  opacity: 0.6;
   border-color: var(--error-border);
   color: var(--error);
-}
-
-.pillBtn:disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-.pillBtn:disabled:hover {
-  border-color: var(--border);
-  color: inherit;
-  background: transparent;
 }
 
 .pillCheck {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -349,6 +349,11 @@ button:active:not(:disabled) {
   transition: background 0.25s var(--ease-out), border-left-color 0.25s var(--ease-out);
 }
 
+/* Runtime missing agent */
+.agentRuntimeMissing {
+  opacity: 0.75;
+}
+
 .sidebarFooter {
   margin-top: auto;
   padding-top: 8px;
@@ -386,6 +391,11 @@ button:active:not(:disabled) {
 .statusDot.stopped {
   background: var(--error);
   box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.12);
+}
+
+.statusDot.runtimeMissing {
+  background: var(--subtext);
+  box-shadow: 0 0 0 3px rgba(100, 116, 139, 0.12);
 }
 
 @keyframes statusPulse {
@@ -488,6 +498,16 @@ button:active:not(:disabled) {
 .agentStatusPill.error::before,
 .agentStatusPill.stopped::before {
   background: var(--error);
+}
+
+.agentStatusPill.runtimeMissing {
+  border-color: var(--shadow-border);
+  color: var(--subtext);
+  background: var(--bg-sidebar);
+}
+
+.agentStatusPill.runtimeMissing::before {
+  background: var(--subtext);
 }
 
 /* ── Conversation ──────────────────────────────────────────── */

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -2445,6 +2445,17 @@ button:active:not(:disabled) {
   color: var(--error);
 }
 
+.pillBtn:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.pillBtn:disabled:hover {
+  border-color: var(--border);
+  color: inherit;
+  background: transparent;
+}
+
 .pillCheck {
   color: var(--success);
   font-size: 11px;

--- a/tests/agent-config-store.test.ts
+++ b/tests/agent-config-store.test.ts
@@ -339,3 +339,107 @@ test("rejects non-object array element without throwing", () => {
   const errors = validateAgentConfigs(["bad"] as unknown as AgentConfig[]);
   assert.ok(errors.some((e) => e.includes("object")), `Expected an object error, got: ${JSON.stringify(errors)}`);
 });
+
+// --- Permission profile persistence (#26) ---
+
+test("DEFAULT_AGENT_CONFIGS include permissionProfile for each agent", () => {
+  for (const config of DEFAULT_AGENT_CONFIGS) {
+    assert.ok(config.permissionProfile, `${config.id} should have permissionProfile`);
+    assert.equal(typeof config.permissionProfile!.canReadFiles, "boolean", `${config.id} canReadFiles`);
+    assert.equal(typeof config.permissionProfile!.canWriteFiles, "boolean", `${config.id} canWriteFiles`);
+    assert.equal(typeof config.permissionProfile!.canRunCommands, "boolean", `${config.id} canRunCommands`);
+    assert.equal(typeof config.permissionProfile!.canInstallDependencies, "boolean", `${config.id} canInstallDependencies`);
+    assert.equal(typeof config.permissionProfile!.canGitCommit, "boolean", `${config.id} canGitCommit`);
+    assert.ok(Array.isArray(config.permissionProfile!.allowedDirectories), `${config.id} allowedDirectories`);
+    assert.ok(config.permissionProfile!.allowedDirectories.length > 0, `${config.id} allowedDirectories non-empty`);
+  }
+});
+
+test("save persists permissionProfile in agents.json on disk", () => {
+  const dir = tempDir();
+  try {
+    const store = new AgentConfigStore(dir);
+    const configs: AgentConfig[] = [
+      {
+        id: "agent1", name: "A", role: "general", runtime: "claude-code",
+        systemPrompt: "do stuff", enabled: true,
+        permissionProfile: {
+          canReadFiles: true, canWriteFiles: false, canRunCommands: true,
+          canInstallDependencies: false, canGitCommit: false, allowedDirectories: ["."],
+        },
+      },
+    ];
+    store.save("ws1", configs);
+    const filePath = path.join(dir, "workspaces", "ws1", "agents.json");
+    const raw = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    assert.ok(raw[0].permissionProfile, "file should contain permissionProfile");
+    assert.equal(raw[0].permissionProfile.canReadFiles, true);
+    assert.equal(raw[0].permissionProfile.canWriteFiles, false);
+    assert.equal(raw[0].permissionProfile.canRunCommands, true);
+    assert.equal(raw[0].permissionProfile.canInstallDependencies, false);
+    assert.equal(raw[0].permissionProfile.canGitCommit, false);
+    assert.deepEqual(raw[0].permissionProfile.allowedDirectories, ["."]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("load migrates old configs missing permissionProfile to role defaults", () => {
+  const dir = tempDir();
+  try {
+    const store = new AgentConfigStore(dir);
+    const filePath = path.join(dir, "workspaces", "ws1", "agents.json");
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    // Old config without permissionProfile (simulating pre-#26 format)
+    fs.writeFileSync(filePath, JSON.stringify([
+      { id: "old-dev", name: "Old Dev", description: "", role: "developer", runtime: "claude-code", systemPrompt: "dev", enabled: true },
+    ]));
+    const loaded = store.load("ws1");
+    assert.equal(loaded.length, 1);
+    // After migration, should have permissionProfile derived from role
+    assert.ok(loaded[0].permissionProfile, "should migrate old config with permissionProfile");
+    assert.equal(loaded[0].permissionProfile!.canReadFiles, true);
+    assert.equal(loaded[0].permissionProfile!.canWriteFiles, true);
+    assert.equal(loaded[0].permissionProfile!.canRunCommands, true);
+    assert.equal(loaded[0].permissionProfile!.canInstallDependencies, true);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("reset outputs configs with permissionProfile", () => {
+  const dir = tempDir();
+  try {
+    const store = new AgentConfigStore(dir);
+    const reset = store.reset("ws1");
+    for (const config of reset) {
+      assert.ok(config.permissionProfile, `${config.id} should have permissionProfile after reset`);
+    }
+    // Check file on disk too
+    const filePath = path.join(dir, "workspaces", "ws1", "agents.json");
+    const raw = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    for (const entry of raw) {
+      assert.ok(entry.permissionProfile, `${entry.id} on disk should have permissionProfile`);
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("validate still permits configs without permissionProfile (backward compat)", () => {
+  const configs: AgentConfig[] = [
+    { id: "old", name: "Old", role: "general", runtime: "claude-code", systemPrompt: "x", enabled: true },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.deepEqual(errors, []);
+});
+
+test("validate does not require permissionProfile for each config", () => {
+  // permissionProfile is optional in AgentConfig by design
+  const configs: AgentConfig[] = [
+    { id: "a", name: "A", role: "pm", runtime: "codex", systemPrompt: "do pm stuff", enabled: true },
+    { id: "b", name: "B", role: "developer", runtime: "claude-code", systemPrompt: "do dev stuff", enabled: true, permissionProfile: undefined },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.deepEqual(errors, []);
+});

--- a/tests/agent-context-builder.test.ts
+++ b/tests/agent-context-builder.test.ts
@@ -14,12 +14,24 @@ test("builds structured context for current agent", () => {
 
   assert.ok(context.includes("[Orbit Context]"));
   assert.ok(context.includes("Current agent: Developer (@developer)"));
-  assert.ok(context.includes("@tester: Tester — Validates behavior, runs tests, reports risks."));
+  assert.ok(context.includes("@tester: Tester - Validates behavior, runs tests, reports risks."));
   assert.ok(context.includes("[Current task]"));
   assert.ok(context.includes("@developer: implement queue @tester: verify it"));
   assert.ok(context.includes("Permission profile:"));
   assert.ok(context.includes("Orbit has already scheduled the other agents"));
   assert.ok(context.includes("Do not start by repeating the conversation"));
+});
+
+test("agent context uses ASCII collaboration punctuation", () => {
+  const profiles = createDefaultAgentProfiles("D:/project");
+  const context = buildAgentContext({
+    agentId: "developer",
+    profiles,
+    agentMessage: "@developer: test",
+  });
+
+  assert.ok(!context.includes("\u2014"));
+  assert.ok(!context.includes("\u2192"));
 });
 
 test("includes description in available agents list", () => {
@@ -30,9 +42,9 @@ test("includes description in available agents list", () => {
     agentMessage: "@developer: test",
   });
 
-  assert.ok(context.includes("@pm: Product Manager — Clarifies requirements, defines scope and acceptance criteria."));
-  assert.ok(context.includes("@architect: Architect — Designs technical boundaries, reviews implementation risk."));
-  assert.ok(context.includes("@developer: Developer — Implements features with TDD, creates branches and draft PRs."));
+  assert.ok(context.includes("@pm: Product Manager - Clarifies requirements, defines scope and acceptance criteria."));
+  assert.ok(context.includes("@architect: Architect - Designs technical boundaries, reviews implementation risk."));
+  assert.ok(context.includes("@developer: Developer - Implements features with TDD, creates branches and draft PRs."));
 });
 
 test("available agents omits description when empty without extra formatting", () => {
@@ -81,7 +93,7 @@ test("available agents omits description when empty without extra formatting", (
 
   assert.ok(context.includes("@pm: PM\n"), "should not have trailing dash for empty description");
   assert.ok(context.includes("@dev: Dev\n"), "should not have trailing dash for empty-string description");
-  assert.ok(!context.includes(" — \n"), "no bare em-dash separator");
+  assert.ok(!context.includes(" -\n"), "no bare separator");
 });
 
 test("includes few-shot collaboration examples in context", () => {
@@ -92,17 +104,12 @@ test("includes few-shot collaboration examples in context", () => {
     agentMessage: "@developer: test",
   });
 
-  // Should contain the collaboration examples section
   assert.ok(context.includes("Collaboration examples:"), "should have examples section header");
-  // Should mention the key distinction between @agent (reference) and @agent: (assignment)
   assert.ok(context.includes("@reviewer") || context.includes("@agent:"), "examples should demonstrate assignment syntax");
-  // Should include guidance on when NOT to hand off
-  assert.ok(context.includes("No further work") || context.includes("不需要交接"), "should show when not to hand off");
+  assert.ok(context.includes("No further work"), "should show when not to hand off");
 });
 
 test("plain mention in agent reply does not trigger routing", () => {
-  // This is a documentation/context test: the collaboration rules and examples
-  // should make it clear that @agent (no colon) is only a reference.
   const profiles = createDefaultAgentProfiles("D:/project");
   const context = buildAgentContext({
     agentId: "developer",

--- a/tests/runtime-probe.test.ts
+++ b/tests/runtime-probe.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import os from "node:os";
 import path from "node:path";
-import { probeRuntime, probeAllRuntimes, type RuntimeProbeResult } from "../src/core/runtime-probe.ts";
+import { probeRuntime, probeAllRuntimes, runtimeKindToCliKey, type RuntimeProbeResult } from "../src/core/runtime-probe.ts";
 
 test("probeRuntime finds node on PATH", async () => {
   const result = await probeRuntime("node");
@@ -41,4 +41,22 @@ test("probeRuntime handles special characters in command name", async () => {
   const result = await probeRuntime("");
   assert.equal(result.available, false);
   assert.ok(result.error);
+});
+
+// --- runtimeKindToCliKey mapping ---
+
+test("runtimeKindToCliKey maps claude-code to claude CLI key", () => {
+  assert.equal(runtimeKindToCliKey("claude-code"), "claude");
+});
+
+test("runtimeKindToCliKey passes through codex unchanged", () => {
+  assert.equal(runtimeKindToCliKey("codex"), "codex");
+});
+
+test("runtimeKindToCliKey passes through codebuddy unchanged", () => {
+  assert.equal(runtimeKindToCliKey("codebuddy"), "codebuddy");
+});
+
+test("runtimeKindToCliKey handles unknown runtime types gracefully", () => {
+  assert.equal(runtimeKindToCliKey("unknown-runtime"), "unknown-runtime");
 });

--- a/tests/runtime-probe.test.ts
+++ b/tests/runtime-probe.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { probeRuntime, probeAllRuntimes, resolveCodexCommandPath, runtimeKindToCliKey, type RuntimeProbeResult } from "../src/core/runtime-probe.ts";
+import { probeRuntime, probeAllRuntimes, runtimeKindToCliKey, type RuntimeProbeResult } from "../src/core/runtime-probe.ts";
 
 test("probeRuntime finds node on PATH", async () => {
   const result = await probeRuntime("node");
@@ -59,29 +59,32 @@ test("runtimeKindToCliKey handles unknown runtime types gracefully", () => {
   assert.equal(runtimeKindToCliKey("unknown-runtime"), "unknown-runtime");
 });
 
-// --- resolveCodexCommandPath ---
+// --- Codex probe uses the real runtime resolver ---
 
-test("resolveCodexCommandPath respects ORBIT_CODEX_PATH env var", () => {
-  const result = resolveCodexCommandPath({ ORBIT_CODEX_PATH: process.execPath });
-  assert.ok(result, "should resolve when ORBIT_CODEX_PATH points to an existing executable");
-  assert.equal(result, process.execPath);
+test("probeCodexRuntime via probeAllRuntimes returns record for codex", async () => {
+  const results = await probeAllRuntimes();
+  const codex = results.find((r) => r.runtime === "codex");
+  assert.ok(codex, "should include codex probe result");
+  // The real resolveCodexCommand is used internally; we verify it doesn't throw
+  // and returns a properly structured result
+  assert.equal(typeof codex!.available, "boolean");
+  if (codex!.available) {
+    assert.ok(codex!.path, "should have path when available");
+  } else {
+    // When unavailable, should have error message or null path
+    assert.ok(codex!.error || codex!.path === null, "should have error or null path when missing");
+  }
 });
 
-test("resolveCodexCommandPath respects CODEX_CLI_PATH env var", () => {
-  const result = resolveCodexCommandPath({ CODEX_CLI_PATH: process.execPath });
-  assert.ok(result, "should resolve when CODEX_CLI_PATH points to an existing executable");
-  assert.equal(result, process.execPath);
-});
-
-test("resolveCodexCommandPath returns null for nonexistent absolute configured path", () => {
-  const fakePath = process.platform === "win32" ? "C:\\nonexistent\\codex.exe" : "/nonexistent/codex";
-  const result = resolveCodexCommandPath({ ORBIT_CODEX_PATH: fakePath });
-  assert.equal(result, null, "should return null when configured absolute path does not exist");
-});
-
-test("resolveCodexCommandPath returns null when no env var is set and not on PATH", () => {
-  // Clear env vars that might resolve codex
-  const result = resolveCodexCommandPath({});
-  // May or may not find codex depending on system, but should not throw
-  assert.equal(typeof result, typeof result === "string" ? "string" : "object");
+test("probeCodexRuntime is consistent with resolveCodexCommand", async () => {
+  // Verify that probeAllRuntimes' codex probe uses resolveCodexCommand by
+  // checking it runs without throwing for all env var configurations
+  const results = await probeAllRuntimes();
+  const codex = results.find((r) => r.runtime === "codex");
+  assert.ok(codex, "codex probe should always return a result");
+  // available must be boolean, path must be string|null
+  assert.equal(typeof codex!.available, "boolean");
+  if (codex!.path !== null) {
+    assert.equal(typeof codex!.path, "string");
+  }
 });

--- a/tests/runtime-probe.test.ts
+++ b/tests/runtime-probe.test.ts
@@ -102,6 +102,27 @@ test("runtimeMeta returns runtime name as label for unknown runtime", () => {
   assert.equal(meta.installUrl, "");
 });
 
+test("Codex probe always returns runtime: codex even with custom CODEX_CLI_PATH", async () => {
+  // When CODEX_CLI_PATH points to a different executable (e.g. node),
+  // the probe result must still use runtime: "codex" so UI/server lookups work
+  const prevCliPath = process.env.CODEX_CLI_PATH;
+  try {
+    process.env.CODEX_CLI_PATH = "node"; // node is always on PATH
+    const results = await probeAllRuntimes();
+    const codex = results.find((r) => r.runtime === "codex");
+    assert.ok(codex, "should find result with runtime: codex even with custom CODEX_CLI_PATH");
+    assert.equal(codex!.available, true);
+    // path should reflect the actual resolved command
+    assert.ok(codex!.path, "should have a resolved path");
+  } finally {
+    if (prevCliPath !== undefined) {
+      process.env.CODEX_CLI_PATH = prevCliPath;
+    } else {
+      delete process.env.CODEX_CLI_PATH;
+    }
+  }
+});
+
 test("probeCodexRuntime is consistent with resolveCodexCommand", async () => {
   // Verify that probeAllRuntimes' codex probe uses resolveCodexCommand by
   // checking it runs without throwing for all env var configurations

--- a/tests/runtime-probe.test.ts
+++ b/tests/runtime-probe.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import os from "node:os";
+import path from "node:path";
+import { probeRuntime, probeAllRuntimes, type RuntimeProbeResult } from "../src/core/runtime-probe.ts";
+
+test("probeRuntime finds node on PATH", async () => {
+  const result = await probeRuntime("node");
+  assert.ok(result.available, "node should be available on PATH");
+  assert.ok(result.path, "should have a path when available");
+  assert.equal(result.runtime, "node");
+});
+
+test("probeRuntime returns not available for nonexistent command", async () => {
+  const result = await probeRuntime("this-command-does-not-exist-xyz");
+  assert.equal(result.available, false);
+  assert.equal(result.runtime, "this-command-does-not-exist-xyz");
+  assert.equal(result.path, null);
+  assert.ok(result.error, "should have error message");
+});
+
+test("probeAllRuntimes returns results for all three runtimes", async () => {
+  const results = await probeAllRuntimes();
+  assert.equal(results.length, 3);
+  const names = results.map((r) => r.runtime);
+  assert.ok(names.includes("claude"));
+  assert.ok(names.includes("codex"));
+  assert.ok(names.includes("codebuddy"));
+  for (const result of results) {
+    assert.equal(typeof result.available, "boolean");
+    if (result.available) {
+      assert.ok(result.path, `${result.runtime} should have path when available`);
+    } else {
+      assert.equal(result.path, null, `${result.runtime} should have null path when unavailable`);
+    }
+  }
+});
+
+test("probeRuntime handles special characters in command name", async () => {
+  // where on Windows handles basic names safely
+  const result = await probeRuntime("");
+  assert.equal(result.available, false);
+  assert.ok(result.error);
+});

--- a/tests/runtime-probe.test.ts
+++ b/tests/runtime-probe.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { probeRuntime, probeAllRuntimes, runtimeKindToCliKey, type RuntimeProbeResult } from "../src/core/runtime-probe.ts";
+import { probeRuntime, probeAllRuntimes, runtimeKindToCliKey, runtimeMeta, type RuntimeProbeResult } from "../src/core/runtime-probe.ts";
 
 test("probeRuntime finds node on PATH", async () => {
   const result = await probeRuntime("node");
@@ -74,6 +74,32 @@ test("probeCodexRuntime via probeAllRuntimes returns record for codex", async ()
     // When unavailable, should have error message or null path
     assert.ok(codex!.error || codex!.path === null, "should have error or null path when missing");
   }
+});
+
+// --- runtimeMeta ---
+
+test("runtimeMeta returns label and installUrl for claude-code", () => {
+  const meta = runtimeMeta("claude-code");
+  assert.equal(meta.label, "Claude Code");
+  assert.ok(meta.installUrl.includes("anthropic"), "should have anthropic install URL");
+});
+
+test("runtimeMeta returns label and installUrl for codex", () => {
+  const meta = runtimeMeta("codex");
+  assert.equal(meta.label, "OpenAI Codex");
+  assert.ok(meta.installUrl.includes("openai"), "should have openai install URL");
+});
+
+test("runtimeMeta returns label and installUrl for codebuddy", () => {
+  const meta = runtimeMeta("codebuddy");
+  assert.equal(meta.label, "CodeBuddy");
+  assert.ok(meta.installUrl.includes("codebuddy"), "should have codebuddy install URL");
+});
+
+test("runtimeMeta returns runtime name as label for unknown runtime", () => {
+  const meta = runtimeMeta("unknown");
+  assert.equal(meta.label, "unknown");
+  assert.equal(meta.installUrl, "");
 });
 
 test("probeCodexRuntime is consistent with resolveCodexCommand", async () => {

--- a/tests/runtime-probe.test.ts
+++ b/tests/runtime-probe.test.ts
@@ -1,8 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import os from "node:os";
-import path from "node:path";
-import { probeRuntime, probeAllRuntimes, runtimeKindToCliKey, type RuntimeProbeResult } from "../src/core/runtime-probe.ts";
+import { probeRuntime, probeAllRuntimes, resolveCodexCommandPath, runtimeKindToCliKey, type RuntimeProbeResult } from "../src/core/runtime-probe.ts";
 
 test("probeRuntime finds node on PATH", async () => {
   const result = await probeRuntime("node");
@@ -59,4 +57,31 @@ test("runtimeKindToCliKey passes through codebuddy unchanged", () => {
 
 test("runtimeKindToCliKey handles unknown runtime types gracefully", () => {
   assert.equal(runtimeKindToCliKey("unknown-runtime"), "unknown-runtime");
+});
+
+// --- resolveCodexCommandPath ---
+
+test("resolveCodexCommandPath respects ORBIT_CODEX_PATH env var", () => {
+  const result = resolveCodexCommandPath({ ORBIT_CODEX_PATH: process.execPath });
+  assert.ok(result, "should resolve when ORBIT_CODEX_PATH points to an existing executable");
+  assert.equal(result, process.execPath);
+});
+
+test("resolveCodexCommandPath respects CODEX_CLI_PATH env var", () => {
+  const result = resolveCodexCommandPath({ CODEX_CLI_PATH: process.execPath });
+  assert.ok(result, "should resolve when CODEX_CLI_PATH points to an existing executable");
+  assert.equal(result, process.execPath);
+});
+
+test("resolveCodexCommandPath returns null for nonexistent absolute configured path", () => {
+  const fakePath = process.platform === "win32" ? "C:\\nonexistent\\codex.exe" : "/nonexistent/codex";
+  const result = resolveCodexCommandPath({ ORBIT_CODEX_PATH: fakePath });
+  assert.equal(result, null, "should return null when configured absolute path does not exist");
+});
+
+test("resolveCodexCommandPath returns null when no env var is set and not on PATH", () => {
+  // Clear env vars that might resolve codex
+  const result = resolveCodexCommandPath({});
+  // May or may not find codex depending on system, but should not throw
+  assert.equal(typeof result, typeof result === "string" ? "string" : "object");
 });


### PR DESCRIPTION
@
## Changes

### Fix #26: Persist agent permission profiles
- Materialize `permissionProfile` in `DEFAULT_AGENT_CONFIGS` for all four built-in agents
- Auto-migrate old `agents.json` files missing `permissionProfile` on load (derives from role defaults)
- `reset` now outputs configs with explicit `permissionProfile` in the JSON file
- Backward compatible: `validateAgentConfigs` still permits configs without `permissionProfile`

### Fix #25: Runtime availability detection and UI
- **Runtime probe**: New `src/core/runtime-probe.ts` detects `claude`, `codex`, `codebuddy` CLI availability via `where`/`which`, reuses `resolveCodexCommand()` from the real Codex runtime for env-var and Windows install-location resolution
- **Periodic check**: Re-probes every 60s (configurable via `ORBIT_RUNTIME_PROBE_INTERVAL_MS`), timer auto-cleaned on shutdown
- **SSE event**: `runtime.availability.updated` published when availability changes, sidebar agents refresh immediately
- **`/api/state`**: New `runtimeAvailability` array with runtime, available, path, checkedAt, error
- **Sidebar**: Missing runtime agents show grayed-out dot + "missing" pill + tooltip
- **Agent Manager**: Runtime pills show ✓ (available) / ↗ install link (missing) / ? (probing), missing runtimes are guarded from selection (current selection can be kept), new agents default to first available runtime
- **Shared metadata**: `runtime-meta.ts` with `runtimeKindToCliKey()` mapping (`claude-code` → `claude`) and `runtimeMeta()` for labels/install URLs

### Key files changed/added
| File | What |
|---|---|
| `src/core/runtime-probe.ts` | New: CLI availability detection |
| `src/core/runtime-meta.ts` | New: shared runtime labels and install URLs |
| `src/core/agent-config-store.ts` | Materialize permissionProfile in defaults, migrate on load |
| `src/shared/types.ts` | Add `RuntimeAvailability` type, `runtimeAvailable` on `AgentState`, SSE event type |
| `src/server/index.ts` | Probe lifecycle, periodic timer, `/api/state` update, SSE publish |
| `src/ui/App.tsx` | Sidebar missing indicator, Agent Manager availability pills, SSE handler |
| `src/ui/styles.css` | Runtime missing styles, pill wrapper/disabled styles |
| `tests/agent-config-store.test.ts` | 7 new tests for permission persistence and migration |
| `tests/runtime-probe.test.ts` | 14 tests: probe, mapping, metadata |

## Verification
- `npm run test` — 248 tests, 0 failures
- `npm run build` — clean build
- `npm run pack:check` — 8 files in package

Fixes #26
Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@