### PR TITLE
feat: add workspace-level prompt and rules configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ Agent replies can contain `@other_agent:` assignments, enabling delegation chain
 - **`src/core/ansi-text-extractor.ts`** — Strips ANSI codes and extracts readable text
 - **`src/core/agent-prompt.ts`** — Prompt templates for agent role instructions
 - **`src/core/migrate-channel-layer.ts`** — One-time migration for flattening legacy directory structure
+- **`src/core/workspace-config-store.ts`** — Workspace-level system prompt and rules persistence
 
 ### UI Module
 
@@ -119,6 +120,8 @@ The developer agent creates feature branches, commits, pushes, and opens draft P
 | GET | `/api/agents` | List agent configurations |
 | PUT | `/api/agents` | Update agent configurations |
 | POST | `/api/agents/reset` | Reset agents to default configuration |
+| GET | `/api/workspace-config` | Get workspace-level prompt and rules |
+| PUT | `/api/workspace-config` | Update workspace-level prompt and rules |
 | GET | `/api/workspaces` | List workspaces |
 | POST | `/api/workspaces` | Create workspace |
 | PUT | `/api/workspaces/:id` | Update workspace |
@@ -136,7 +139,7 @@ The developer agent creates feature branches, commits, pushes, and opens draft P
 
 - **EventBus pub/sub**: `SseHub`, `TerminalTranscriptStore`, and `RunManager` all subscribe to `RuntimeEvent` variants on a shared bus
 - **Per-agent serial queue**: Each agent runs one CLI process at a time; additional tasks queue automatically
-- **Private context injection**: Each agent prompt is wrapped with a private routing context block; leaked markers are stripped from replies
+- **Private context injection**: Each agent prompt is wrapped with a private routing context block; leaked markers are stripped from replies. Precedence: app fixed rules → workspace config → agent role instruction
 - **Multi-conversation parallel**: Multiple conversations can run agents simultaneously via a context map with LRU eviction
 - **In-memory state**: Messages and agent state live in memory per conversation context; file-based persistence for messages, sessions, and transcripts
 
@@ -148,7 +151,10 @@ The developer agent creates feature branches, commits, pushes, and opens draft P
 ├── conversations/{workspaceId}/conversations.json
 ├── transcripts/{workspaceId}/{conversationId}/{agentId}.log
 ├── sessions/{workspaceId}/{runtime}/{conversationId}/{agentId}.json
-└── workspaces/{workspaceId}/workspace.json
+└── workspaces/{workspaceId}/
+    ├── workspace.json
+    ├── agents.json
+    └── config.json         (workspace-level systemPrompt and rules)
 ```
 
 ### UI Design System ("Warm Observatory")

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dev": "tsx src/server/index.ts",
     "build": "tsc --noEmit && vite build && node scripts/build-server.mjs",
     "pack:check": "node scripts/check-package.mjs",
-    "test": "node --test --import tsx tests/mention-router.test.ts tests/message-store.test.ts tests/message-router.test.ts tests/ansi-text-extractor.test.ts tests/terminal-transcript-store.test.ts tests/claude-output-detector.test.ts tests/claude-cli-runtime.test.ts tests/codex-cli-runtime.test.ts tests/codebuddy-cli-runtime.test.ts tests/agent-profiles.test.ts tests/agent-registry.test.ts tests/agent-context-builder.test.ts tests/agent-history-builder.test.ts tests/run-manager.test.ts tests/session-store.test.ts tests/agent-session.test.ts tests/workspace-store.test.ts tests/conversation-store.test.ts tests/markdown-renderer.test.ts tests/agent-config-store.test.ts tests/runtime-probe.test.ts tests/package-manifest.test.ts",
+    "test": "node --test --import tsx tests/mention-router.test.ts tests/message-store.test.ts tests/message-router.test.ts tests/ansi-text-extractor.test.ts tests/terminal-transcript-store.test.ts tests/claude-output-detector.test.ts tests/claude-cli-runtime.test.ts tests/codex-cli-runtime.test.ts tests/codebuddy-cli-runtime.test.ts tests/agent-profiles.test.ts tests/agent-registry.test.ts tests/agent-context-builder.test.ts tests/agent-history-builder.test.ts tests/run-manager.test.ts tests/session-store.test.ts tests/agent-session.test.ts tests/workspace-store.test.ts tests/conversation-store.test.ts tests/markdown-renderer.test.ts tests/agent-config-store.test.ts tests/workspace-config-store.test.ts tests/runtime-probe.test.ts tests/package-manifest.test.ts",
     "test:glob": "node --test --import tsx tests/*.test.ts"
   },
   "dependencies": {

--- a/src/core/agent-context-builder.ts
+++ b/src/core/agent-context-builder.ts
@@ -1,4 +1,4 @@
-import type { AgentId, AgentProfile } from "../shared/types.ts";
+import type { AgentId, AgentProfile, WorkspaceRuntimeConfig } from "../shared/types.ts";
 
 export type AgentHistoryEntry = {
   sender: string;
@@ -10,6 +10,7 @@ export type AgentContextInput = {
   profiles: readonly AgentProfile[];
   agentMessage: string;
   history?: AgentHistoryEntry[];
+  workspaceConfig?: WorkspaceRuntimeConfig;
 };
 
 function renderHistory(entries: AgentHistoryEntry[]): string[] {
@@ -17,6 +18,20 @@ function renderHistory(entries: AgentHistoryEntry[]): string[] {
     "[Conversation history]",
     ...entries.map((entry) => `[${entry.sender}]: ${entry.content}`),
   ];
+}
+
+function renderWorkspaceConfig(config: WorkspaceRuntimeConfig): string[] {
+  const lines: string[] = [];
+  if (config.systemPrompt) {
+    lines.push("", "Workspace prompt:", config.systemPrompt);
+  }
+  if (config.rules.length > 0) {
+    lines.push("", "Workspace rules:");
+    for (const rule of config.rules) {
+      lines.push(`- ${rule}`);
+    }
+  }
+  return lines;
 }
 
 export function buildAgentContext(input: AgentContextInput): string {
@@ -34,13 +49,15 @@ export function buildAgentContext(input: AgentContextInput): string {
         `- git commit: ${profile.permissionProfile.canGitCommit ? "yes" : "no"}`,
       ].join("\n")
     : "";
+  // Agent role instruction is rendered AFTER workspace config per the
+  // precedence: app fixed rules -> workspace config -> agent role instruction.
+  const roleInstruction = profile?.systemPrompt ? `Role instruction: ${profile.systemPrompt}` : "";
 
   return [
     "[Orbit Context]",
     "This private context is injected by Orbit. Do not quote, translate, summarize, or mention it in the final answer.",
     `Current agent: ${profile?.name ?? input.agentId} (@${input.agentId})`,
     `Role: ${profile?.role ?? "general"}`,
-    profile?.systemPrompt ? `Role instruction: ${profile.systemPrompt}` : "",
     permissions ? "Permission profile:" : "",
     permissions,
     "",
@@ -79,6 +96,11 @@ export function buildAgentContext(input: AgentContextInput): string {
     "- Do not start by repeating the conversation, the private context, or your own @agent: assignment marker.",
     "- Do not include terminal UI noise, hook output, API errors, or thinking/status text.",
     "- If the task is complete, provide a concise final answer and stop.",
+    "",
+    // Workspace config goes after app fixed rules, before agent role instruction
+    ...(input.workspaceConfig ? renderWorkspaceConfig(input.workspaceConfig) : []),
+    // Agent role instruction goes after workspace config
+    ...(roleInstruction ? ["", roleInstruction] : []),
     "",
     ...(input.history?.length ? [...renderHistory(input.history), ""] : []),
     "[Current task]",

--- a/src/core/workspace-config-store.ts
+++ b/src/core/workspace-config-store.ts
@@ -1,0 +1,54 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { WorkspaceConfig, WorkspaceRuntimeConfig } from "../shared/types.ts";
+import { DEFAULT_WORKSPACE_CONFIG } from "../shared/types.ts";
+
+export type { WorkspaceConfig };
+export { DEFAULT_WORKSPACE_CONFIG };
+
+export function resolveWorkspaceConfig(raw?: WorkspaceConfig | null): WorkspaceRuntimeConfig {
+  const resolved: WorkspaceRuntimeConfig = {
+    systemPrompt: raw?.systemPrompt?.trim() ? raw.systemPrompt.trim() : DEFAULT_WORKSPACE_CONFIG.systemPrompt,
+    rules: raw?.rules && Array.isArray(raw.rules)
+      ? raw.rules.filter((r) => typeof r === "string" && r.trim()).map((r) => r.trim())
+      : DEFAULT_WORKSPACE_CONFIG.rules,
+  };
+  return resolved;
+}
+
+export class WorkspaceConfigStore {
+  private readonly baseDir: string;
+
+  constructor(baseDir?: string) {
+    this.baseDir = baseDir ?? path.join(os.homedir(), ".orbit");
+  }
+
+  load(workspaceId: string): WorkspaceRuntimeConfig {
+    const filePath = this.configPath(workspaceId);
+    try {
+      const data = fs.readFileSync(filePath, "utf8");
+      const raw = JSON.parse(data) as WorkspaceConfig;
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+        return structuredClone(DEFAULT_WORKSPACE_CONFIG);
+      }
+      return resolveWorkspaceConfig(raw);
+    } catch {
+      return structuredClone(DEFAULT_WORKSPACE_CONFIG);
+    }
+  }
+
+  save(workspaceId: string, config: WorkspaceConfig): void {
+    const filePath = this.configPath(workspaceId);
+    const dir = path.dirname(filePath);
+    fs.mkdirSync(dir, { recursive: true });
+    const tmpFile = filePath + ".tmp";
+    fs.writeFileSync(tmpFile, JSON.stringify(config, null, 2) + os.EOL);
+    fs.renameSync(tmpFile, filePath);
+  }
+
+  private configPath(workspaceId: string): string {
+    return path.join(this.baseDir, "workspaces", workspaceId, "config.json");
+  }
+}

--- a/src/server/conversation-context.ts
+++ b/src/server/conversation-context.ts
@@ -10,7 +10,8 @@ import { SessionStore } from "../core/session-store.ts";
 import { TerminalTranscriptStore } from "../core/terminal-transcript-store.ts";
 import { WorkspaceStore } from "../core/workspace-store.ts";
 import { MessageRouter } from "../core/message-router.ts";
-import type { AgentId, AgentProfile } from "../shared/types.ts";
+import type { AgentId, AgentProfile, WorkspaceRuntimeConfig } from "../shared/types.ts";
+import { DEFAULT_WORKSPACE_CONFIG } from "../shared/types.ts";
 
 const MAX_ROUTE_DEPTH = 5;
 
@@ -21,6 +22,7 @@ export type ConversationContextOptions = {
   eventBus: EventBus;
   sessionStore: SessionStore;
   workspaceStore: WorkspaceStore;
+  workspaceConfig?: WorkspaceRuntimeConfig;
 };
 
 export class ConversationContext {
@@ -31,11 +33,15 @@ export class ConversationContext {
   messageRouter: MessageRouter;
 
   private _profiles: readonly AgentProfile[];
+  private _workspaceConfig: WorkspaceRuntimeConfig;
   private readonly eventBus: EventBus;
   private readonly unsubscribe: () => void;
 
-  constructor(private readonly options: ConversationContextOptions) {
+  constructor(private options: ConversationContextOptions) {
     const { workspaceId, conversationId, profiles, eventBus, sessionStore, workspaceStore } = options;
+    // Store workspace config as mutable instance field so updateWorkspaceConfig()
+    // can update it at runtime without recreating the context.
+    this._workspaceConfig = options.workspaceConfig ?? structuredClone(DEFAULT_WORKSPACE_CONFIG);
     this._profiles = profiles;
     this.eventBus = eventBus;
 
@@ -69,7 +75,7 @@ export class ConversationContext {
       eventBus,
       buildPrompt: (agentId: AgentId, prompt: string) => {
         const history = buildHistoryForAgent(agentId, this.messages.list());
-        return buildAgentContext({ agentId, profiles, agentMessage: prompt, history });
+        return buildAgentContext({ agentId, profiles, agentMessage: prompt, history, workspaceConfig: this._workspaceConfig });
       },
       onRunCompleted: (message) => {
         this.messageRouter.process(message);
@@ -118,7 +124,7 @@ export class ConversationContext {
       eventBus,
       buildPrompt: (agentId: AgentId, prompt: string) => {
         const history = buildHistoryForAgent(agentId, self.messages.list());
-        return buildAgentContext({ agentId, profiles, agentMessage: prompt, history });
+        return buildAgentContext({ agentId, profiles, agentMessage: prompt, history, workspaceConfig: self._workspaceConfig });
       },
       onRunCompleted: (message) => {
         self.messageRouter.process(message);
@@ -143,6 +149,11 @@ export class ConversationContext {
 
     // Replace readonly fields via Object.assign (intentional hot-swap)
     Object.assign(this, { agents: newAgents, runManager: newRunManager, messageRouter: newMessageRouter });
+  }
+
+  updateWorkspaceConfig(config: WorkspaceRuntimeConfig): void {
+    this._workspaceConfig = config;
+    this.options = { ...this.options, workspaceConfig: config };
   }
 
   dispose(): void {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -9,6 +9,8 @@ import { configsToProfiles } from "../core/agent-profiles.ts";
 import { AgentConfigStore, validateAgentConfigs } from "../core/agent-config-store.ts";
 import { probeAllRuntimes, runtimeKindToCliKey, type RuntimeProbeResult } from "../core/runtime-probe.ts";
 import type { AgentConfig } from "../core/agent-config-store.ts";
+import { WorkspaceConfigStore } from "../core/workspace-config-store.ts";
+import type { WorkspaceConfig } from "../core/workspace-config-store.ts";
 import { ConversationStore } from "../core/conversation-store.ts";
 import { EventBus } from "../core/event-bus.ts";
 import { SessionStore } from "../core/session-store.ts";
@@ -30,6 +32,7 @@ const eventBus = new EventBus();
 const sseHub = new SseHub();
 const workspaceStore = new WorkspaceStore();
 const configStore = new AgentConfigStore();
+const workspaceConfigStore = new WorkspaceConfigStore();
 
 // --- Runtime availability ---
 const PROBE_INTERVAL_MS = Number(process.env.ORBIT_RUNTIME_PROBE_INTERVAL_MS ?? 60000);
@@ -225,6 +228,7 @@ function createContext(workspaceId: string, conversationId: string): Conversatio
   const ws = workspaceStore.get(workspaceId);
   const profiles = configsToProfiles(enabledConfigs, ws!.path);
   const sessStore = new SessionStore(workspaceStore.sessionsDir(workspaceId));
+  const workspaceConfig = workspaceConfigStore.load(workspaceId);
   return new ConversationContext({
     workspaceId,
     conversationId,
@@ -232,6 +236,7 @@ function createContext(workspaceId: string, conversationId: string): Conversatio
     eventBus,
     sessionStore: sessStore,
     workspaceStore,
+    workspaceConfig,
   });
 }
 
@@ -447,6 +452,50 @@ const server = http.createServer(async (req, res) => {
       allConfigs = configStore.reset(activeWorkspaceId);
       refreshEnabledAgents();
       sendJson(res, 200, allConfigs);
+      return;
+    }
+
+    // --- Workspace config ---
+
+    if (req.method === "GET" && url.pathname === "/api/workspace-config") {
+      if (!activeWorkspaceId) {
+        sendJson(res, 200, { systemPrompt: "", rules: [] });
+        return;
+      }
+      sendJson(res, 200, workspaceConfigStore.load(activeWorkspaceId));
+      return;
+    }
+
+    if (req.method === "PUT" && url.pathname === "/api/workspace-config") {
+      if (!activeWorkspaceId) {
+        sendJson(res, 409, { ok: false, message: "Create or select a workspace before saving workspace config." });
+        return;
+      }
+      const input = (await readJson(req)) as WorkspaceConfig;
+      if (!input || typeof input !== "object" || Array.isArray(input)) {
+        sendJson(res, 400, { ok: false, message: "Request body must be a JSON object." });
+        return;
+      }
+      if (input.rules !== undefined) {
+        if (!Array.isArray(input.rules) || input.rules.some((r) => typeof r !== "string")) {
+          sendJson(res, 400, { ok: false, message: "rules must be an array of strings." });
+          return;
+        }
+      }
+      if (input.systemPrompt !== undefined && typeof input.systemPrompt !== "string") {
+        sendJson(res, 400, { ok: false, message: "systemPrompt must be a string." });
+        return;
+      }
+      workspaceConfigStore.save(activeWorkspaceId, input);
+      const resolved = workspaceConfigStore.load(activeWorkspaceId);
+      // Update all active contexts for this workspace so the next agent run
+      // immediately uses the new config.
+      for (const [key, ctx] of contextMap) {
+        if (key.startsWith(`${activeWorkspaceId}:`)) {
+          ctx.updateWorkspaceConfig(resolved);
+        }
+      }
+      sendJson(res, 200, resolved);
       return;
     }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -136,6 +136,21 @@ export type Conversation = ConversationInfo & {
   lastOpenedAt: string;
 };
 
+export type WorkspaceConfig = {
+  systemPrompt?: string;
+  rules?: string[];
+};
+
+export type WorkspaceRuntimeConfig = {
+  systemPrompt: string;
+  rules: string[];
+};
+
+export const DEFAULT_WORKSPACE_CONFIG: WorkspaceRuntimeConfig = {
+  systemPrompt: "",
+  rules: [],
+};
+
 export type RuntimeAvailability = {
   runtime: string;
   available: boolean;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -860,6 +860,7 @@ export function App() {
       {showSettings ? (
         <SystemSettingsPanel
           onClose={() => setShowSettings(false)}
+          hasWorkspace={hasWorkspace}
         />
       ) : null}
       {showAgentManager ? (
@@ -1163,22 +1164,142 @@ function PermissionEditor({ config, onChange }: { config: AgentConfig; onChange:
   );
 }
 
-function SystemSettingsPanel({ onClose }: { onClose: () => void }) {
+function SystemSettingsPanel({ onClose, hasWorkspace }: { onClose: () => void; hasWorkspace: boolean }) {
+  const [systemPrompt, setSystemPrompt] = useState("");
+  const [rules, setRules] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [savedMsg, setSavedMsg] = useState("");
+
+  useEffect(() => {
+    if (!hasWorkspace) {
+      setLoading(false);
+      return;
+    }
+    fetch("/api/workspace-config")
+      .then((r) => r.json())
+      .then((cfg: { systemPrompt?: string; rules?: string[] }) => {
+        setSystemPrompt(cfg.systemPrompt ?? "");
+        setRules(cfg.rules ?? []);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [hasWorkspace]);
+
+  function addRule() {
+    setRules((prev) => [...prev, ""]);
+  }
+
+  function updateRule(index: number, value: string) {
+    setRules((prev) => {
+      const next = [...prev];
+      next[index] = value;
+      return next;
+    });
+  }
+
+  function removeRule(index: number) {
+    setRules((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  function save() {
+    if (!hasWorkspace) return;
+    setSaving(true);
+    setSavedMsg("");
+    fetch("/api/workspace-config", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ systemPrompt: systemPrompt.trim(), rules: rules.map((r) => r.trim()).filter(Boolean) }),
+    })
+      .then((r) => {
+        if (!r.ok) return r.json().then((err) => Promise.reject(err));
+        return r.json();
+      })
+      .then(() => {
+        setSaving(false);
+        setSavedMsg("已保存");
+        setTimeout(() => setSavedMsg(""), 3000);
+      })
+      .catch((err) => {
+        setSaving(false);
+        setSavedMsg(err?.message ?? "保存失败");
+      });
+  }
+
+  const hasChanges = true; // Allow saving always
+
   return (
     <div className="modalOverlay" onClick={onClose}>
-      <div className="modalPanel settingsPlaceholderPanel" onClick={(e) => e.stopPropagation()}>
+      <div className="modalPanel workspaceConfigPanel" onClick={(e) => e.stopPropagation()}>
         <div className="modalHeader">
-          <h2>系统设置</h2>
+          <h2>工作区设置</h2>
           <button type="button" onClick={onClose}>&times;</button>
         </div>
         <div className="settingsBody">
-          <div className="settingsPlaceholder">
-            <strong>暂时没有系统设置项</strong>
-            <span>智能体管理已经移动到左侧“智能体”标题右侧的 +。</span>
-          </div>
+          {!hasWorkspace ? (
+            <div className="settingsPlaceholder">
+              <strong>请先选择或创建工作区</strong>
+              <span>工作区设置作用于当前工作区下的所有会话。</span>
+            </div>
+          ) : loading ? (
+            <div className="settingsPlaceholder">
+              <span>加载中...</span>
+            </div>
+          ) : (
+            <>
+              <div className="settingsSection">
+                <label className="settingsLabel">工作区提示词</label>
+                <span className="fieldHint">对所有会话生效的系统提示词。留空则不注入。</span>
+                <textarea
+                  className="workspaceConfigTextarea"
+                  placeholder="例如：本项目使用 TypeScript + React，所有代码需严格类型检查。"
+                  value={systemPrompt}
+                  onChange={(e) => setSystemPrompt(e.target.value)}
+                  rows={5}
+                />
+              </div>
+              <div className="settingsSection">
+                <label className="settingsLabel">
+                  工作区规则
+                  <button type="button" className="settingsAddBtn" onClick={addRule} title="添加规则">+</button>
+                </label>
+                <span className="fieldHint">对所有会话生效的行为规则。留空则不注入。</span>
+                {rules.length === 0 ? (
+                  <div className="rulesEmptyHint">暂无规则。点击 + 添加一条。</div>
+                ) : (
+                  <div className="rulesList">
+                    {rules.map((rule, i) => (
+                      <div key={i} className="rulesRow">
+                        <span className="rulesIndex">{i + 1}.</span>
+                        <input
+                          className="rulesInput"
+                          value={rule}
+                          onChange={(e) => updateRule(i, e.target.value)}
+                          placeholder={`规则 ${i + 1}`}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                              e.preventDefault();
+                              addRule();
+                            }
+                          }}
+                        />
+                        <button type="button" className="rulesRemoveBtn" onClick={() => removeRule(i)} title="删除规则">&times;</button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </>
+          )}
         </div>
         <div className="modalFooter">
+          {savedMsg ? <span className="settingsSavedMsg">{savedMsg}</span> : null}
           <button type="button" onClick={onClose}>关闭</button>
+          {hasWorkspace ? (
+            <button type="button" className="primaryBtn" onClick={save} disabled={saving}>
+              {saving ? "保存中..." : "保存"}
+            </button>
+          ) : null}
         </div>
       </div>
     </div>

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -2071,6 +2071,144 @@ button:active:not(:disabled) {
   background: #f7faf9;
 }
 
+/* --- Workspace Config Panel --- */
+
+.workspaceConfigPanel {
+  width: 520px;
+  max-width: 95vw;
+}
+
+.workspaceConfigPanel .settingsBody {
+  padding: 16px 20px;
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.settingsSection {
+  margin-bottom: 20px;
+}
+
+.settingsSection:last-child {
+  margin-bottom: 0;
+}
+
+.settingsLabel {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+
+.settingsAddBtn {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  width: 22px;
+  height: 22px;
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.settingsAddBtn:hover {
+  opacity: 0.85;
+}
+
+.workspaceConfigTextarea {
+  width: 100%;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 13px;
+  font-family: inherit;
+  line-height: 1.55;
+  color: var(--text-primary);
+  background: var(--bg-surface);
+  resize: vertical;
+  min-height: 80px;
+  margin-top: 8px;
+}
+
+.workspaceConfigTextarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.12);
+}
+
+.rulesEmptyHint {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 8px;
+  font-style: italic;
+}
+
+.rulesList {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.rulesRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.rulesIndex {
+  font-size: 13px;
+  color: var(--text-secondary);
+  min-width: 20px;
+  text-align: right;
+}
+
+.rulesInput {
+  flex: 1;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 6px 8px;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--text-primary);
+  background: var(--bg-surface);
+}
+
+.rulesInput:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(15, 118, 110, 0.12);
+}
+
+.rulesRemoveBtn {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 16px;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  line-height: 1;
+}
+
+.rulesRemoveBtn:hover {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.settingsSavedMsg {
+  font-size: 12px;
+  color: var(--accent);
+  margin-right: auto;
+}
+
 .addBtnTop {
   margin-bottom: 4px;
 }

--- a/tests/workspace-config-store.test.ts
+++ b/tests/workspace-config-store.test.ts
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  DEFAULT_WORKSPACE_CONFIG,
+  resolveWorkspaceConfig,
+  WorkspaceConfigStore,
+} from "../src/core/workspace-config-store.ts";
+import type { WorkspaceConfig } from "../src/core/workspace-config-store.ts";
+
+function tempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "orbit-test-workspace-config-"));
+}
+
+// --- resolveWorkspaceConfig ---
+
+test("resolveWorkspaceConfig returns defaults for undefined input", () => {
+  const resolved = resolveWorkspaceConfig(undefined);
+  assert.equal(resolved.systemPrompt, "");
+  assert.deepEqual(resolved.rules, []);
+});
+
+test("resolveWorkspaceConfig returns defaults for null input", () => {
+  const resolved = resolveWorkspaceConfig(null);
+  assert.equal(resolved.systemPrompt, "");
+  assert.deepEqual(resolved.rules, []);
+});
+
+test("resolveWorkspaceConfig returns defaults for empty object", () => {
+  const resolved = resolveWorkspaceConfig({});
+  assert.equal(resolved.systemPrompt, "");
+  assert.deepEqual(resolved.rules, []);
+});
+
+test("resolveWorkspaceConfig trims whitespace from systemPrompt", () => {
+  const resolved = resolveWorkspaceConfig({ systemPrompt: "  hello world  " });
+  assert.equal(resolved.systemPrompt, "hello world");
+});
+
+test("resolveWorkspaceConfig filters empty and whitespace-only rules", () => {
+  const resolved = resolveWorkspaceConfig({ rules: ["  valid  ", "   ", ""] });
+  assert.deepEqual(resolved.rules, ["valid"]);
+});
+
+test("resolveWorkspaceConfig preserves valid rules with trimming", () => {
+  const resolved = resolveWorkspaceConfig({ rules: ["  Keep code clean", "Write tests first  "] });
+  assert.deepEqual(resolved.rules, ["Keep code clean", "Write tests first"]);
+});
+
+test("resolveWorkspaceConfig handles non-array rules gracefully", () => {
+  const resolved = resolveWorkspaceConfig({ rules: "not-an-array" as unknown as string[] });
+  assert.deepEqual(resolved.rules, []);
+});
+
+// --- WorkspaceConfigStore ---
+
+test("load returns defaults when no config file exists", () => {
+  const dir = tempDir();
+  try {
+    const store = new WorkspaceConfigStore(dir);
+    const config = store.load("ws1");
+    assert.equal(config.systemPrompt, "");
+    assert.deepEqual(config.rules, []);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("save then load round-trips config", () => {
+  const dir = tempDir();
+  try {
+    const store = new WorkspaceConfigStore(dir);
+    const config: WorkspaceConfig = {
+      systemPrompt: "This is a workspace-level prompt.",
+      rules: ["Always use TypeScript", "Write tests before code"],
+    };
+    store.save("ws1", config);
+    const loaded = store.load("ws1");
+    assert.equal(loaded.systemPrompt, "This is a workspace-level prompt.");
+    assert.deepEqual(loaded.rules, ["Always use TypeScript", "Write tests before code"]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("save creates parent directories", () => {
+  const dir = path.join(tempDir(), "nested", "deep");
+  try {
+    const store = new WorkspaceConfigStore(dir);
+    store.save("ws1", { systemPrompt: "test" });
+    assert.ok(fs.existsSync(path.join(dir, "workspaces", "ws1", "config.json")));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("different workspaces have independent configs", () => {
+  const dir = tempDir();
+  try {
+    const store = new WorkspaceConfigStore(dir);
+    store.save("ws1", { systemPrompt: "prompt for ws1", rules: ["rule1"] });
+    store.save("ws2", { systemPrompt: "prompt for ws2", rules: ["rule2"] });
+    assert.equal(store.load("ws1").systemPrompt, "prompt for ws1");
+    assert.deepEqual(store.load("ws1").rules, ["rule1"]);
+    assert.equal(store.load("ws2").systemPrompt, "prompt for ws2");
+    assert.deepEqual(store.load("ws2").rules, ["rule2"]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("load handles corrupted JSON gracefully", () => {
+  const dir = tempDir();
+  try {
+    const store = new WorkspaceConfigStore(dir);
+    const filePath = path.join(dir, "workspaces", "ws1", "config.json");
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, "not valid json{{{");
+    const config = store.load("ws1");
+    assert.equal(config.systemPrompt, "");
+    assert.deepEqual(config.rules, []);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("load handles valid JSON that is not an object", () => {
+  const dir = tempDir();
+  try {
+    const store = new WorkspaceConfigStore(dir);
+    const filePath = path.join(dir, "workspaces", "ws1", "config.json");
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify(["array", "not", "object"]));
+    const config = store.load("ws1");
+    assert.equal(config.systemPrompt, "");
+    assert.deepEqual(config.rules, []);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("save with empty config stores minimal JSON", () => {
+  const dir = tempDir();
+  try {
+    const store = new WorkspaceConfigStore(dir);
+    store.save("ws1", {});
+    const filePath = path.join(dir, "workspaces", "ws1", "config.json");
+    const raw = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    assert.equal(typeof raw, "object");
+    const loaded = store.load("ws1");
+    assert.equal(loaded.systemPrompt, "");
+    assert.deepEqual(loaded.rules, []);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("load filters out empty systemPrompt (whitespace-only)", () => {
+  const dir = tempDir();
+  try {
+    const store = new WorkspaceConfigStore(dir);
+    store.save("ws1", { systemPrompt: "   " });
+    const loaded = store.load("ws1");
+    assert.equal(loaded.systemPrompt, "");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("save persists file that can be read by a new store instance", () => {
+  const dir = tempDir();
+  try {
+    const store1 = new WorkspaceConfigStore(dir);
+    store1.save("ws1", {
+      systemPrompt: "persist test",
+      rules: ["rule-a", "rule-b"],
+    });
+
+    const store2 = new WorkspaceConfigStore(dir);
+    const loaded = store2.load("ws1");
+    assert.equal(loaded.systemPrompt, "persist test");
+    assert.deepEqual(loaded.rules, ["rule-a", "rule-b"]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Changes

Replace conversation-level channel config with workspace-level system prompt and rules configuration.

### What's new
- **WorkspaceConfigStore** (`src/core/workspace-config-store.ts`) — stores workspace-level `systemPrompt` and `rules` at `~/.orbit/workspaces/{workspaceId}/config.json`
- **API**: `GET /api/workspace-config` and `PUT /api/workspace-config` for reading/updating workspace config
- **UI**: `SystemSettingsPanel` now shows workspace prompt textarea and rules list with add/remove
- **Context injection**: workspace config rendered in agent context with precedence: app fixed rules → workspace config → agent role instruction

### Design decisions
- `maxRouteDepth` kept as hardcoded constant (5) in `conversation-context.ts` — not mixed with user-facing prompt/rules config
- Workspace config is workspace-scoped (not per-conversation), matching the project/AGENTS.md semantic
- Empty prompt/rules don't inject anything into context (no noise)

### Files changed
| File | Change |
|---|---|
| `src/shared/types.ts` | Add `WorkspaceConfig`, `WorkspaceRuntimeConfig`, `DEFAULT_WORKSPACE_CONFIG` |
| `src/core/workspace-config-store.ts` | New: load/save/resolve workspace config |
| `src/core/agent-context-builder.ts` | Add `workspaceConfig` param, `renderWorkspaceConfig()` |
| `src/server/conversation-context.ts` | Accept `workspaceConfig` option, add `updateWorkspaceConfig()` |
| `src/server/index.ts` | New API endpoints, load config in `createContext()` |
| `src/ui/App.tsx` | `SystemSettingsPanel` with prompt/rules editor |
| `src/ui/styles.css` | Styles for workspace config panel |
| `tests/workspace-config-store.test.ts` | 16 new tests |
| `CLAUDE.md` | Document new module and API |
| `package.json` | Add test file to test script |

🤖 Generated with [Claude Code](https://claude.com/claude-code)