### PR TITLE
feat: show coordinator placeholder when supervisor agent is present (#29)

### DIFF
--- a/src/core/agent-config-store.ts
+++ b/src/core/agent-config-store.ts
@@ -6,7 +6,7 @@ import { permissionProfile } from "./agent-profiles.ts";
 
 export type { AgentConfig };
 
-const VALID_ROLES = new Set<AgentRole>(["pm", "architect", "developer", "tester", "general"]);
+const VALID_ROLES = new Set<AgentRole>(["pm", "architect", "developer", "tester", "general", "coordinator"]);
 const VALID_RUNTIMES = new Set<AgentRuntimeKind>(["claude-code", "codex", "codebuddy"]);
 const RESERVED_IDS = new Set(["all"]);
 const ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
@@ -115,8 +115,10 @@ export function validateAgentConfigs(configs: AgentConfig[]): string[] {
           errors.push(`Agent "${config.id}" permissionProfile.${flag} must be a boolean.`);
         }
       }
-      if (!Array.isArray(pp.allowedDirectories) || pp.allowedDirectories.length === 0) {
-        errors.push(`Agent "${config.id}" permissionProfile.allowedDirectories must be non-empty.`);
+      if (!Array.isArray(pp.allowedDirectories)) {
+        errors.push(`Agent "${config.id}" permissionProfile.allowedDirectories must be an array.`);
+      } else if (pp.allowedDirectories.length === 0 && (pp.canReadFiles || pp.canWriteFiles || pp.canRunCommands)) {
+        errors.push(`Agent "${config.id}" permissionProfile.allowedDirectories must be non-empty when file or command access is enabled.`);
       }
     }
   }

--- a/src/core/agent-profiles.ts
+++ b/src/core/agent-profiles.ts
@@ -42,6 +42,15 @@ export function permissionProfile(role: AgentRole): PermissionProfile {
         canGitCommit: false,
         allowedDirectories: ["."],
       };
+    case "coordinator":
+      return {
+        canReadFiles: false,
+        canWriteFiles: false,
+        canRunCommands: false,
+        canInstallDependencies: false,
+        canGitCommit: false,
+        allowedDirectories: [],
+      };
     default:
       return {
         canReadFiles: true,

--- a/src/core/agent-registry.ts
+++ b/src/core/agent-registry.ts
@@ -68,6 +68,7 @@ export class AgentRegistry {
       id: profile.id,
       label: profile.name,
       runtime: profile.runtime,
+      role: profile.role,
       status: this.get(profile.id).getStatus(),
       selected: index === 0,
     }));

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -386,6 +386,7 @@ function currentAgentStates() {
       id: config.id,
       label: config.name,
       runtime: config.runtime,
+      role: config.role,
       status: "idle" as const,
       selected: index === 0,
       runtimeAvailable: runtimeAvailable(config.runtime),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,6 +1,6 @@
 export type AgentId = string;
 
-export type AgentRole = "pm" | "architect" | "developer" | "tester" | "general";
+export type AgentRole = "pm" | "architect" | "developer" | "tester" | "general" | "coordinator";
 
 export type PermissionProfile = {
   canReadFiles: boolean;
@@ -47,6 +47,7 @@ export type AgentState = {
   label: string;
   runtime: AgentRuntimeKind;
   status: AgentStatus;
+  role: AgentRole;
   selected?: boolean;
   runtimeAvailable?: boolean;
 };

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -151,6 +151,7 @@ export function App() {
   const agentsById = useMemo(() => new Map(state.agents.map((agent) => [agent.id, agent])), [state.agents]);
   const agentIds = useMemo(() => state.agents.map((agent) => agent.id), [state.agents]);
   const hasEnabledAgent = agentIds.length > 0;
+  const hasCoordinator = useMemo(() => state.agents.some((agent) => agent.role === "coordinator"), [state.agents]);
   const scrollKey = useMemo(
     () =>
       state.messages
@@ -706,7 +707,7 @@ export function App() {
               agentIds.map((agentId) => (
                 <AgentButton
                   key={agentId}
-                  agent={agentsById.get(agentId) ?? { id: agentId, label: agentId, runtime: "claude-code", status: "idle" }}
+                  agent={agentsById.get(agentId) ?? { id: agentId, label: agentId, runtime: "claude-code", role: "general", status: "idle" }}
                   selected={selectedAgent === agentId}
                   onClick={() => chooseAgent(agentId)}
                 />
@@ -849,7 +850,7 @@ export function App() {
                 handleComposerKeyDown(event as unknown as KeyboardEvent<HTMLInputElement>);
               }}
               onKeyUp={updateCursorFromInput}
-              placeholder={!hasWorkspace ? "先选择或创建工作区" : hasEnabledAgent ? `@${selectedAgent}: 输入任务` : "先添加或启用智能体"}
+              placeholder={!hasWorkspace ? "先选择或创建工作区" : hasCoordinator ? "直接输入消息，或使用 @agent: 指派具体智能体" : hasEnabledAgent ? `@${selectedAgent}: 输入任务` : "先添加或启用智能体"}
               aria-label="Message to agent"
               disabled={!hasWorkspace || !hasEnabledAgent}
               spellCheck={false}
@@ -1160,7 +1161,7 @@ function ActivityList({ activity, status }: { activity: AgentActivityEvent[]; st
 }
 
 const RUNTIMES: AgentRuntimeKind[] = ["claude-code", "codex", "codebuddy"];
-const ROLES: AgentRole[] = ["pm", "architect", "developer", "tester", "general"];
+const ROLES: AgentRole[] = ["pm", "architect", "developer", "tester", "general", "coordinator"];
 const PERM_FLAGS: { key: keyof PermissionProfile; label: string; hint: string }[] = [
   { key: "canReadFiles", label: "读取文件", hint: "允许智能体读取工作区中的文件内容。" },
   { key: "canWriteFiles", label: "写入文件", hint: "允许智能体创建、修改或删除工作区中的文件。" },


### PR DESCRIPTION
## Summary

When a `coordinator` (supervisor) agent exists in the current conversation, the chat input placeholder changes to guide the user.

**Before (all cases):** `@pm: 输入任务`

**After (with supervisor):** `直接输入消息，或使用 @agent: 指派具体智能体`

**After (without supervisor):** unchanged — still `@pm: 输入任务`

Other placeholder states remain unchanged:
- No workspace: `先选择或创建工作区`
- No enabled agents: `先添加或启用智能体`

## Changes

| File | Change |
|---|---|
| `src/shared/types.ts` | Add `coordinator` to `AgentRole`, add `role` field to `AgentState` |
| `src/core/agent-config-store.ts` | Add `coordinator` to `VALID_ROLES`; allow empty `allowedDirectories` when no file/cmd access |
| `src/core/agent-profiles.ts` | Add coordinator permission profile (no file/command access) |
| `src/core/agent-registry.ts` | Include `role: profile.role` in `states()` |
| `src/server/index.ts` | Include `role: config.role` in fallback `currentAgentStates()` |
| `src/ui/App.tsx` | Add `hasCoordinator` memo; update placeholder logic; update ROLES array |

## Verification

- `npm run test` — **304/304 passed**, 0 failures
- `npm run build` — **passed** (tsc + vite + server bundle)

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)