### PR TITLE
feat: add configurable supervisor agent and channel watch triggers (#29)

### DIFF
--- a/src/core/agent-config-store.ts
+++ b/src/core/agent-config-store.ts
@@ -10,6 +10,7 @@ const VALID_ROLES = new Set<AgentRole>(["pm", "architect", "developer", "tester"
 const VALID_RUNTIMES = new Set<AgentRuntimeKind>(["claude-code", "codex", "codebuddy"]);
 const RESERVED_IDS = new Set(["all"]);
 const ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const CURRENT_MIGRATION_VERSION = 1;
 
 export const DEFAULT_AGENT_CONFIGS: AgentConfig[] = [
   {
@@ -203,7 +204,21 @@ export class AgentConfigStore {
     const filePath = this.configPath(workspaceId);
     try {
       const data = fs.readFileSync(filePath, "utf8");
-      const configs = JSON.parse(data) as AgentConfig[];
+      const parsed = JSON.parse(data) as AgentConfig[] | { configs: AgentConfig[]; _meta?: { migrationVersion?: number } };
+
+      let configs: AgentConfig[];
+      let storedVersion = 0;
+
+      if (Array.isArray(parsed)) {
+        // Legacy format: plain array
+        configs = parsed;
+      } else if (parsed && typeof parsed === "object" && Array.isArray((parsed as { configs: AgentConfig[] }).configs)) {
+        configs = (parsed as { configs: AgentConfig[] }).configs;
+        storedVersion = (parsed as { _meta?: { migrationVersion?: number } })._meta?.migrationVersion ?? 0;
+      } else {
+        return structuredClone(DEFAULT_AGENT_CONFIGS);
+      }
+
       if (!Array.isArray(configs) || configs.length === 0) {
         return structuredClone(DEFAULT_AGENT_CONFIGS);
       }
@@ -221,12 +236,14 @@ export class AgentConfigStore {
         }
       }
 
-      // Auto-add new default templates not present in saved configs
-      const savedIds = new Set(configs.map((c) => c.id));
-      for (const def of DEFAULT_AGENT_CONFIGS) {
-        if (!savedIds.has(def.id)) {
-          configs.push(structuredClone(def));
-          migrated = true;
+      // Auto-add new default templates only when migration version is behind
+      if (storedVersion < CURRENT_MIGRATION_VERSION) {
+        const savedIds = new Set(configs.map((c) => c.id));
+        for (const def of DEFAULT_AGENT_CONFIGS) {
+          if (!savedIds.has(def.id)) {
+            configs.push(structuredClone(def));
+            migrated = true;
+          }
         }
       }
 
@@ -250,7 +267,8 @@ export class AgentConfigStore {
     const dir = path.dirname(filePath);
     fs.mkdirSync(dir, { recursive: true });
     const tmpFile = filePath + ".tmp";
-    fs.writeFileSync(tmpFile, JSON.stringify(configs, null, 2) + os.EOL);
+    const payload = { configs, _meta: { migrationVersion: CURRENT_MIGRATION_VERSION } };
+    fs.writeFileSync(tmpFile, JSON.stringify(payload, null, 2) + os.EOL);
     fs.renameSync(tmpFile, filePath);
   }
 

--- a/src/core/agent-config-store.ts
+++ b/src/core/agent-config-store.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { AgentConfig, AgentId, AgentRole, AgentRuntimeKind } from "../shared/types.ts";
+import { hasActiveChannelWatchTriggers, type AgentConfig, type AgentId, type AgentRole, type AgentRuntimeKind } from "../shared/types.ts";
 import { permissionProfile } from "./agent-profiles.ts";
 
 export type { AgentConfig };
@@ -176,6 +176,29 @@ export function validateAgentConfigs(configs: AgentConfig[]): string[] {
         }
       }
     }
+  }
+
+  // Cross-validation: only coordinator-role agents may have active channel-watch triggers
+  const agentsWithActiveTriggers: AgentConfig[] = [];
+  for (const c of configs) {
+    if (c && hasActiveChannelWatchTriggers(c.triggers)) {
+      agentsWithActiveTriggers.push(c);
+      if (c.role !== "coordinator") {
+        errors.push(
+          `Agent "${c.id}" has active channel watch triggers but its role is "${c.role}". ` +
+            "Only coordinator-role agents can act as supervisor. Change the role to coordinator or disable the triggers.",
+        );
+      }
+    }
+  }
+
+  // Cross-validation: at most one supervisor (agent with active triggers) per conversation
+  if (agentsWithActiveTriggers.length > 1) {
+    errors.push(
+      `Only one supervisor is allowed per conversation, but ${agentsWithActiveTriggers.length} agents have active channel watch triggers: ` +
+        `${agentsWithActiveTriggers.map((c) => c.id).join(", ")}. ` +
+        "Disable triggers on all but one agent.",
+    );
   }
 
   // Cross-validation: supervisor requires at least one other agent enabled

--- a/src/core/agent-config-store.ts
+++ b/src/core/agent-config-store.ts
@@ -163,6 +163,16 @@ export function validateAgentConfigs(configs: AgentConfig[]): string[] {
         if (t.onAgentBlocked !== undefined && typeof t.onAgentBlocked !== "boolean") {
           errors.push(`Agent "${configId}" triggers.onAgentBlocked must be a boolean.`);
         }
+        if (t.maxTriggersPerConversation !== undefined) {
+          if (typeof t.maxTriggersPerConversation !== "number" || t.maxTriggersPerConversation < 1 || t.maxTriggersPerConversation > 100) {
+            errors.push(`Agent "${configId}" triggers.maxTriggersPerConversation must be an integer between 1 and 100.`);
+          }
+        }
+        if (t.debounceMs !== undefined) {
+          if (typeof t.debounceMs !== "number" || t.debounceMs < 0 || t.debounceMs > 60000) {
+            errors.push(`Agent "${configId}" triggers.debounceMs must be a number between 0 and 60000.`);
+          }
+        }
       }
     }
   }

--- a/src/core/agent-context-builder.ts
+++ b/src/core/agent-context-builder.ts
@@ -1,5 +1,9 @@
 import type { AgentId, AgentProfile, WorkspaceRuntimeConfig } from "../shared/types.ts";
 
+export const SUPERVISOR_TOOL_REMINDER =
+  "Remember: you CANNOT read files or use any tools. " +
+  "Only coordinate based on messages already in the conversation history.";
+
 export type AgentHistoryEntry = {
   sender: string;
   content: string;

--- a/src/core/agent-registry.ts
+++ b/src/core/agent-registry.ts
@@ -51,6 +51,10 @@ export class AgentRegistry {
     }
   }
 
+  has(agentId: AgentId): boolean {
+    return this.sessions.has(agentId);
+  }
+
   get(agentId: AgentId): AgentSession {
     const session = this.sessions.get(agentId);
     if (!session) {

--- a/src/core/channel-watch.ts
+++ b/src/core/channel-watch.ts
@@ -1,13 +1,14 @@
 import { hasActiveChannelWatchTriggers, type AgentId, type AgentProfile, type ChatMessage, type ChannelWatchTriggers } from "../shared/types.ts";
 import { SUPERVISOR_TOOL_REMINDER } from "./agent-context-builder.ts";
+import { assignmentPattern } from "./mention-router.ts";
 import type { EventBus } from "./event-bus.ts";
 import type { AgentRegistry } from "./agent-registry.ts";
 import type { RunManager } from "./run-manager.ts";
 import type { MessageStore } from "./message-store.ts";
 
-const ASSIGNMENT_PATTERN = /@([A-Za-z0-9_-]+)\s*(?::|：)/g;
 const MAX_TRIGGERS_PER_CONVERSATION = 5;
 const DEBOUNCE_MS = 2_000;
+const MAX_ROUTE_DEPTH = 10;
 
 type TriggerContext = {
   agentId: AgentId;
@@ -34,6 +35,7 @@ export class ChannelWatchService {
   ) {
     this.knownIds = new Set(profiles.map((p) => p.id));
     this.knownIds.add("user"); // @user: is the task-closure signal
+    this.knownIds.add("all");  // @all: is the broadcast signal
 
     for (const profile of profiles) {
       if (profile.triggers && hasActiveChannelWatchTriggers(profile.triggers)) {
@@ -59,6 +61,8 @@ export class ChannelWatchService {
 
       if (event.type === "message.created") {
         this.onMessageCreated(event.message);
+      } else if (event.type === "message.updated") {
+        this.onMessageUpdated(event.message);
       } else if (event.type === "run.completed" && "agentId" in event) {
         this.onAgentCompleted(event.agentId as AgentId, (event as { resultMessageId: string }).resultMessageId);
       }
@@ -92,18 +96,20 @@ export class ChannelWatchService {
       }
     }
 
-    if (message.routeState === "blocked") {
-      for (const ctx of this.triggerContexts.values()) {
-        if (ctx.triggers.onAgentBlocked) {
-          this.tryTrigger(ctx, message);
-        }
-      }
-      return;
-    }
-
     if (message.kind === "user" && !hasAssignmentMarker(message.content, this.knownIds)) {
       for (const ctx of this.triggerContexts.values()) {
         if (ctx.triggers.onUnassignedMessage) {
+          this.tryTrigger(ctx, message);
+        }
+      }
+    }
+  }
+
+  private onMessageUpdated(message: ChatMessage): void {
+    // Listen for routeState transitions to "blocked" (published via message.updated)
+    if (message.routeState === "blocked") {
+      for (const ctx of this.triggerContexts.values()) {
+        if (ctx.triggers.onAgentBlocked) {
           this.tryTrigger(ctx, message);
         }
       }
@@ -125,6 +131,10 @@ export class ChannelWatchService {
   }
 
   private tryTrigger(ctx: TriggerContext, sourceMessage: ChatMessage): void {
+    // Honour the same route-depth limit as MessageRouter
+    const nextDepth = (sourceMessage.routeDepth ?? 0) + 1;
+    if (nextDepth > MAX_ROUTE_DEPTH) return;
+
     if (!this.isChannelTrulyIdle(ctx.agentId)) return;
 
     if (!this.agentRegistry.has(ctx.agentId)) return;
@@ -154,9 +164,9 @@ export class ChannelWatchService {
 }
 
 function hasAssignmentMarker(content: string, knownIds: ReadonlySet<string>): boolean {
-  ASSIGNMENT_PATTERN.lastIndex = 0;
+  const pattern = new RegExp(assignmentPattern.source, "g");
   let m: RegExpExecArray | null;
-  while ((m = ASSIGNMENT_PATTERN.exec(content)) !== null) {
+  while ((m = pattern.exec(content)) !== null) {
     if (knownIds.has(m[1])) return true;
   }
   return false;

--- a/src/core/channel-watch.ts
+++ b/src/core/channel-watch.ts
@@ -1,5 +1,4 @@
 import { hasActiveChannelWatchTriggers, type AgentId, type AgentProfile, type ChatMessage, type ChannelWatchTriggers } from "../shared/types.ts";
-import { SUPERVISOR_TOOL_REMINDER } from "./agent-context-builder.ts";
 import { assignmentPattern } from "./mention-router.ts";
 import type { EventBus } from "./event-bus.ts";
 import type { AgentRegistry } from "./agent-registry.ts";
@@ -91,14 +90,10 @@ export class ChannelWatchService {
 
   private onMessageCreated(message: ChatMessage): void {
     if (message.kind === "user") {
+      const hasAssignment = hasAssignmentMarker(message.content, this.knownIds);
       for (const ctx of this.triggerContexts.values()) {
         ctx.triggerCount = 0;
-      }
-    }
-
-    if (message.kind === "user" && !hasAssignmentMarker(message.content, this.knownIds)) {
-      for (const ctx of this.triggerContexts.values()) {
-        if (ctx.triggers.onUnassignedMessage) {
+        if (!hasAssignment && ctx.triggers.onUnassignedMessage) {
           this.tryTrigger(ctx, message);
         }
       }
@@ -173,12 +168,9 @@ function hasAssignmentMarker(content: string, knownIds: ReadonlySet<string>): bo
 }
 
 function buildSupervisorPrompt(agentId: AgentId, count: number, isLast: boolean, maxTriggers: number): string {
-  const toolReminder = SUPERVISOR_TOOL_REMINDER + "\n\n";
-
   if (isLast) {
     return (
       `[Supervisor Check #${count}/${maxTriggers} — FINAL]\n\n` +
-      toolReminder +
       `This is your last automatic check for this conversation. ` +
       `If work was already assigned and is in progress, acknowledge it. ` +
       `If the overall task is done, conclude with @user: and a final summary. ` +
@@ -188,7 +180,6 @@ function buildSupervisorPrompt(agentId: AgentId, count: number, isLast: boolean,
 
   return (
     `[Supervisor Check #${count}/${maxTriggers}]\n\n` +
-    toolReminder +
     `Evaluate the current state of the conversation. ` +
     `If the overall task needs more work, assign tasks using @agent: markers. ` +
     `If all work is complete, conclude with @user: and a final summary.`

--- a/src/core/channel-watch.ts
+++ b/src/core/channel-watch.ts
@@ -1,4 +1,5 @@
-import type { AgentId, AgentProfile, ChatMessage, ChannelWatchTriggers } from "../shared/types.ts";
+import { hasActiveChannelWatchTriggers, type AgentId, type AgentProfile, type ChatMessage, type ChannelWatchTriggers } from "../shared/types.ts";
+import { SUPERVISOR_TOOL_REMINDER } from "./agent-context-builder.ts";
 import type { EventBus } from "./event-bus.ts";
 import type { AgentRegistry } from "./agent-registry.ts";
 import type { RunManager } from "./run-manager.ts";
@@ -13,6 +14,8 @@ type TriggerContext = {
   triggers: ChannelWatchTriggers;
   triggerCount: number;
   lastEnqueueTime: number;
+  maxTriggers: number;
+  debounceMs: number;
 };
 
 export class ChannelWatchService {
@@ -33,12 +36,14 @@ export class ChannelWatchService {
     this.knownIds.add("user"); // @user: is the task-closure signal
 
     for (const profile of profiles) {
-      if (profile.triggers && hasAnyTrigger(profile.triggers)) {
+      if (profile.triggers && hasActiveChannelWatchTriggers(profile.triggers)) {
         this.triggerContexts.set(profile.id, {
           agentId: profile.id,
           triggers: profile.triggers,
           triggerCount: 0,
           lastEnqueueTime: 0,
+          maxTriggers: profile.triggers.maxTriggersPerConversation ?? MAX_TRIGGERS_PER_CONVERSATION,
+          debounceMs: profile.triggers.debounceMs ?? DEBOUNCE_MS,
         });
       }
     }
@@ -60,6 +65,11 @@ export class ChannelWatchService {
     });
   }
 
+  // Design note: this method lives on ChannelWatchService rather than RunManager
+  // because it needs AgentRegistry to query per-agent run status — moving it to
+  // RunManager would require expanding AgentRunner's interface with status query
+  // methods, which would bloat that abstraction unnecessarily. The query is
+  // read-only and does not introduce circular dependencies.
   isChannelTrulyIdle(supervisorId: AgentId): boolean {
     for (const agentId of this.agentRegistry.ids()) {
       if (agentId === supervisorId) continue;
@@ -117,24 +127,20 @@ export class ChannelWatchService {
   private tryTrigger(ctx: TriggerContext, sourceMessage: ChatMessage): void {
     if (!this.isChannelTrulyIdle(ctx.agentId)) return;
 
-    let supervisorSession;
-    try {
-      supervisorSession = this.agentRegistry.get(ctx.agentId);
-    } catch {
-      return;
-    }
+    if (!this.agentRegistry.has(ctx.agentId)) return;
+    const supervisorSession = this.agentRegistry.get(ctx.agentId);
     if (supervisorSession.getStatus() !== "idle") return;
 
     const now = Date.now();
-    if (now - ctx.lastEnqueueTime < DEBOUNCE_MS) return;
+    if (now - ctx.lastEnqueueTime < ctx.debounceMs) return;
 
-    if (ctx.triggerCount >= MAX_TRIGGERS_PER_CONVERSATION) return;
+    if (ctx.triggerCount >= ctx.maxTriggers) return;
 
     ctx.triggerCount += 1;
     ctx.lastEnqueueTime = now;
 
-    const isLast = ctx.triggerCount >= MAX_TRIGGERS_PER_CONVERSATION;
-    const prompt = buildSupervisorPrompt(ctx.agentId, ctx.triggerCount, isLast);
+    const isLast = ctx.triggerCount >= ctx.maxTriggers;
+    const prompt = buildSupervisorPrompt(ctx.agentId, ctx.triggerCount, isLast, ctx.maxTriggers);
 
     const syntheticSource: ChatMessage = {
       id: `trigger_${ctx.agentId}_${Date.now()}_${ctx.triggerCount}`,
@@ -147,10 +153,6 @@ export class ChannelWatchService {
   }
 }
 
-function hasAnyTrigger(triggers: ChannelWatchTriggers): boolean {
-  return triggers.onUnassignedMessage === true || triggers.onAgentBlocked === true;
-}
-
 function hasAssignmentMarker(content: string, knownIds: ReadonlySet<string>): boolean {
   ASSIGNMENT_PATTERN.lastIndex = 0;
   let m: RegExpExecArray | null;
@@ -160,14 +162,12 @@ function hasAssignmentMarker(content: string, knownIds: ReadonlySet<string>): bo
   return false;
 }
 
-function buildSupervisorPrompt(agentId: AgentId, count: number, isLast: boolean): string {
-  const toolReminder =
-    "Remember: you CANNOT read files or use any tools. " +
-    "Only coordinate based on messages already in the conversation history.\n\n";
+function buildSupervisorPrompt(agentId: AgentId, count: number, isLast: boolean, maxTriggers: number): string {
+  const toolReminder = SUPERVISOR_TOOL_REMINDER + "\n\n";
 
   if (isLast) {
     return (
-      `[Supervisor Check #${count}/${MAX_TRIGGERS_PER_CONVERSATION} — FINAL]\n\n` +
+      `[Supervisor Check #${count}/${maxTriggers} — FINAL]\n\n` +
       toolReminder +
       `This is your last automatic check for this conversation. ` +
       `If work was already assigned and is in progress, acknowledge it. ` +
@@ -177,7 +177,7 @@ function buildSupervisorPrompt(agentId: AgentId, count: number, isLast: boolean)
   }
 
   return (
-    `[Supervisor Check #${count}/${MAX_TRIGGERS_PER_CONVERSATION}]\n\n` +
+    `[Supervisor Check #${count}/${maxTriggers}]\n\n` +
     toolReminder +
     `Evaluate the current state of the conversation. ` +
     `If the overall task needs more work, assign tasks using @agent: markers. ` +

--- a/src/core/mention-router.ts
+++ b/src/core/mention-router.ts
@@ -12,7 +12,7 @@ type AssignmentMarker = {
   end: number;
 };
 
-const assignmentPattern = /@([A-Za-z0-9_-]+)\s*(?::|：)/g;
+export const assignmentPattern = /@([A-Za-z0-9_-]+)\s*(?::|：)/g;
 
 export function routeMention(
   content: string,

--- a/src/server/conversation-context.ts
+++ b/src/server/conversation-context.ts
@@ -85,7 +85,9 @@ export class ConversationContext {
       },
     });
 
-    const hasActiveSupervisor = profiles.some((p) => hasActiveChannelWatchTriggers(p.triggers));
+    const hasActiveSupervisor = profiles.some(
+      (p) => p.role === "coordinator" && hasActiveChannelWatchTriggers(p.triggers),
+    );
 
     this.messageRouter = new MessageRouter({
       availableAgents: agentIds,
@@ -100,7 +102,10 @@ export class ConversationContext {
         self.runManager.enqueue(agentId, prompt, sourceMessage);
       },
       markMessageRouted: (messageId, routeState) => {
-        self.messages.markRouteState(messageId, routeState);
+        const updated = self.messages.markRouteState(messageId, routeState);
+        if (updated) {
+          eventBus.publish({ type: "message.updated", conversationId, message: updated });
+        }
       },
     });
 
@@ -147,7 +152,9 @@ export class ConversationContext {
       },
     });
 
-    const newHasSupervisor = profiles.some((p) => hasActiveChannelWatchTriggers(p.triggers));
+    const newHasSupervisor = profiles.some(
+      (p) => p.role === "coordinator" && hasActiveChannelWatchTriggers(p.triggers),
+    );
 
     const newMessageRouter = new MessageRouter({
       availableAgents: agentIds,
@@ -162,7 +169,10 @@ export class ConversationContext {
         newRunManager.enqueue(agentId, prompt, sourceMessage);
       },
       markMessageRouted: (messageId, routeState) => {
-        self.messages.markRouteState(messageId, routeState);
+        const updated = self.messages.markRouteState(messageId, routeState);
+        if (updated) {
+          eventBus.publish({ type: "message.updated", conversationId, message: updated });
+        }
       },
     });
 

--- a/src/server/conversation-context.ts
+++ b/src/server/conversation-context.ts
@@ -11,7 +11,7 @@ import { TerminalTranscriptStore } from "../core/terminal-transcript-store.ts";
 import { WorkspaceStore } from "../core/workspace-store.ts";
 import { MessageRouter } from "../core/message-router.ts";
 import { ChannelWatchService } from "../core/channel-watch.ts";
-import type { AgentId, AgentProfile, WorkspaceRuntimeConfig } from "../shared/types.ts";
+import { hasActiveChannelWatchTriggers, type AgentId, type AgentProfile, type WorkspaceRuntimeConfig } from "../shared/types.ts";
 import { DEFAULT_WORKSPACE_CONFIG } from "../shared/types.ts";
 
 const MAX_ROUTE_DEPTH = 10;
@@ -85,9 +85,7 @@ export class ConversationContext {
       },
     });
 
-    const hasActiveSupervisor = profiles.some(
-      (p) => p.triggers && (p.triggers.onUnassignedMessage || p.triggers.onAgentBlocked),
-    );
+    const hasActiveSupervisor = profiles.some((p) => hasActiveChannelWatchTriggers(p.triggers));
 
     this.messageRouter = new MessageRouter({
       availableAgents: agentIds,
@@ -149,9 +147,7 @@ export class ConversationContext {
       },
     });
 
-    const newHasSupervisor = profiles.some(
-      (p) => p.triggers && (p.triggers.onUnassignedMessage || p.triggers.onAgentBlocked),
-    );
+    const newHasSupervisor = profiles.some((p) => hasActiveChannelWatchTriggers(p.triggers));
 
     const newMessageRouter = new MessageRouter({
       availableAgents: agentIds,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -387,6 +387,7 @@ function currentAgentStates() {
       label: config.name,
       runtime: config.runtime,
       role: config.role,
+      triggers: config.triggers,
       status: "idle" as const,
       selected: index === 0,
       runtimeAvailable: runtimeAvailable(config.runtime),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -63,6 +63,7 @@ export type AgentState = {
   runtime: AgentRuntimeKind;
   status: AgentStatus;
   role: AgentRole;
+  triggers?: ChannelWatchTriggers;
   selected?: boolean;
   runtimeAvailable?: boolean;
 };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -16,7 +16,15 @@ export type AgentRuntimeKind = "claude-code" | "codex" | "codebuddy";
 export type ChannelWatchTriggers = {
   onUnassignedMessage?: boolean;
   onAgentBlocked?: boolean;
+  /** Maximum automatic triggers per conversation (default 5). */
+  maxTriggersPerConversation?: number;
+  /** Minimum milliseconds between consecutive triggers (default 2000). */
+  debounceMs?: number;
 };
+
+export function hasActiveChannelWatchTriggers(triggers?: ChannelWatchTriggers): boolean {
+  return triggers?.onUnassignedMessage === true || triggers?.onAgentBlocked === true;
+}
 
 export type AgentConfigUi = {
   label?: string;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -151,7 +151,7 @@ export function App() {
   const agentsById = useMemo(() => new Map(state.agents.map((agent) => [agent.id, agent])), [state.agents]);
   const agentIds = useMemo(() => state.agents.map((agent) => agent.id), [state.agents]);
   const hasEnabledAgent = agentIds.length > 0;
-  const hasCoordinator = useMemo(() => state.agents.some((agent) => agent.role === "coordinator"), [state.agents]);
+  const hasCoordinator = useMemo(() => state.agents.some((agent) => agent.role === "coordinator" && hasActiveChannelWatchTriggers(agent.triggers)), [state.agents]);
   const scrollKey = useMemo(
     () =>
       state.messages

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -2,7 +2,7 @@ import { CSSProperties, FormEvent, KeyboardEvent, useEffect, useLayoutEffect, us
 import { renderMarkdown } from "./markdown-renderer.ts";
 import { permissionProfile } from "../core/agent-profiles.ts";
 import { runtimeKindToCliKey, runtimeMeta } from "../core/runtime-meta.ts";
-import type { AgentActivityEvent, AgentConfig, AgentId, AgentRole, AgentRuntimeKind, AgentState, AppState, ChatMessage, Conversation, ConversationInfo, PermissionProfile, RunningSummary, RuntimeEvent, Workspace } from "../shared/types.ts";
+import { hasActiveChannelWatchTriggers, type AgentActivityEvent, type AgentConfig, type AgentId, type AgentRole, type AgentRuntimeKind, type AgentState, type AppState, type ChatMessage, type Conversation, type ConversationInfo, type PermissionProfile, type RunningSummary, type RuntimeEvent, type Workspace } from "../shared/types.ts";
 
 const initialState: AppState = {
   workspace: { id: "", name: "", path: "" },
@@ -1470,7 +1470,7 @@ function AgentManagerPanel({ onClose, onSaved, runtimeAvailability }: { onClose:
                       <span className="configCardName">{config.name || config.id}</span>
                       <span className="configCardPill configCardRole">{config.role}</span>
                       <span className="configCardPill configCardRuntime">{config.runtime}</span>
-                      {config.triggers && config.role === "coordinator" ? <span className="configCardPill supervisorBadge">👁 监督</span> : null}
+                      {hasActiveChannelWatchTriggers(config.triggers) && config.role === "coordinator" ? <span className="configCardPill supervisorBadge">👁 监督</span> : null}
                     </div>
                     <div className="configCardActions">
                       <button type="button" className="removeBtn" onClick={(e) => { e.stopPropagation(); removeConfig(i); }} title="删除">&times;</button>
@@ -1500,7 +1500,17 @@ function AgentManagerPanel({ onClose, onSaved, runtimeAvailability }: { onClose:
                           <span className="pillLabel">Role <span className="fieldHint" title="决定默认权限和行为。pm = 规划，architect = 设计，developer = 编码，tester = 测试，general = 自定义，coordinator = 纯协调/监督。">?</span></span>
                           <div className="pillOptions">
                             {ROLES.map((r) => (
-                              <button key={r} type="button" className={`pillBtn ${config.role === r ? "pillActive" : ""}`} onClick={() => updateConfig(i, { role: r, permissionProfile: permissionProfile(r) })}>{r}</button>
+                              <button
+                                key={r}
+                                type="button"
+                                className={`pillBtn ${config.role === r ? "pillActive" : ""}`}
+                                onClick={() => {
+                                  if (config.role === r) return;
+                                  updateConfig(i, { role: r, permissionProfile: permissionProfile(r) });
+                                }}
+                              >
+                                {r}
+                              </button>
                             ))}
                           </div>
                         </div>
@@ -1533,7 +1543,7 @@ function AgentManagerPanel({ onClose, onSaved, runtimeAvailability }: { onClose:
                             })}
                           </div>
                         </div>
-                        {config.triggers && config.role === "coordinator" ? <SupervisorBanner /> : null}
+                        {hasActiveChannelWatchTriggers(config.triggers) && config.role === "coordinator" ? <SupervisorBanner maxTriggers={config.triggers?.maxTriggersPerConversation ?? 5} hasUnassigned={config.triggers?.onUnassignedMessage === true} hasBlocked={config.triggers?.onAgentBlocked === true} /> : null}
                         <div className="fieldWithHint fieldFullWidth">
                           <textarea placeholder="System prompt" value={config.systemPrompt} onChange={(e) => updateConfig(i, { systemPrompt: e.target.value })} rows={3} />
                           <span className="fieldHint fieldHintTop" title="每次运行时发送给智能体的指令。定义其角色、专业能力和行为约束。">?</span>
@@ -1557,16 +1567,20 @@ function AgentManagerPanel({ onClose, onSaved, runtimeAvailability }: { onClose:
   );
 }
 
-function SupervisorBanner() {
+function SupervisorBanner({ maxTriggers, hasUnassigned, hasBlocked }: { maxTriggers: number; hasUnassigned: boolean; hasBlocked: boolean }) {
   return (
     <div className="supervisorBanner">
       <p><span aria-hidden="true">🔍</span> <strong>会话监督已启用</strong></p>
       <p>此智能体会在以下情况自动介入：</p>
       <ul>
-        <li><span aria-hidden="true">⚡</span> <strong>消息未分配</strong> — 消息中没有 @agent: 标记时，自动分析需求并分配任务</li>
-        <li><span aria-hidden="true">⚡</span> <strong>路由阻塞</strong> — 其他智能体的消息被路由拒绝时，介入兜底处理</li>
+        {hasUnassigned ? (
+          <li><span aria-hidden="true">⚡</span> <strong>消息未分配</strong> — 消息中没有 @agent: 标记时，自动分析需求并分配任务</li>
+        ) : null}
+        {hasBlocked ? (
+          <li><span aria-hidden="true">⚡</span> <strong>路由阻塞</strong> — 其他智能体的消息被路由拒绝时，介入兜底处理</li>
+        ) : null}
       </ul>
-      <p>⏱ 单轮对话最多自动触发 5 次，或在任务闭环后自动停止。关闭 enabled 开关可暂停监督。</p>
+      <p>⏱ 单轮对话最多自动触发 {maxTriggers} 次，或在任务闭环后自动停止。关闭 enabled 开关可暂停监督。</p>
     </div>
   );
 }

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -2466,20 +2466,20 @@ button:active:not(:disabled) {
 }
 
 .supervisorBadge {
-  border: 1px solid #c4c4e8;
-  color: #4a4496;
-  background: #f0f0fa;
+  border: 1px solid var(--accent-border);
+  color: var(--accent);
+  background: var(--accent-subtle);
 }
 
 .supervisorBanner {
   margin: 8px 0 12px;
   padding: 12px 14px;
-  border-left: 3px solid #c4c4e8;
-  background: #f0f0fa;
+  border-left: 3px solid var(--accent-border);
+  background: var(--accent-subtle);
   border-radius: var(--radius-md);
   font-size: 12px;
   line-height: 1.6;
-  color: #4a4496;
+  color: var(--accent);
 }
 
 .supervisorBanner p {
@@ -2501,7 +2501,7 @@ button:active:not(:disabled) {
 }
 
 .supervisorBanner strong {
-  color: #3a3380;
+  color: var(--accent-hover);
 }
 
 .configCardActions {

--- a/tests/agent-config-store.test.ts
+++ b/tests/agent-config-store.test.ts
@@ -45,8 +45,8 @@ test("save then load round-trips configs", () => {
     ];
     store.save("ws1", configs);
     const loaded = store.load("ws1");
-    // auto-migration adds missing default templates (5) to the 1 custom → 6 total
-    assert.equal(loaded.length, 6);
+    // save() persists with current migration version, so load() skips auto-add
+    assert.equal(loaded.length, 1);
     assert.equal(loaded[0].id, "custom");
     assert.equal(loaded[0].name, "Custom Agent");
   } finally {
@@ -378,13 +378,14 @@ test("save persists permissionProfile in agents.json on disk", () => {
     store.save("ws1", configs);
     const filePath = path.join(dir, "workspaces", "ws1", "agents.json");
     const raw = JSON.parse(fs.readFileSync(filePath, "utf8"));
-    assert.ok(raw[0].permissionProfile, "file should contain permissionProfile");
-    assert.equal(raw[0].permissionProfile.canReadFiles, true);
-    assert.equal(raw[0].permissionProfile.canWriteFiles, false);
-    assert.equal(raw[0].permissionProfile.canRunCommands, true);
-    assert.equal(raw[0].permissionProfile.canInstallDependencies, false);
-    assert.equal(raw[0].permissionProfile.canGitCommit, false);
-    assert.deepEqual(raw[0].permissionProfile.allowedDirectories, ["."]);
+    const savedConfigs = raw.configs as AgentConfig[];
+    assert.ok(savedConfigs[0].permissionProfile, "file should contain permissionProfile");
+    assert.equal(savedConfigs[0].permissionProfile.canReadFiles, true);
+    assert.equal(savedConfigs[0].permissionProfile.canWriteFiles, false);
+    assert.equal(savedConfigs[0].permissionProfile.canRunCommands, true);
+    assert.equal(savedConfigs[0].permissionProfile.canInstallDependencies, false);
+    assert.equal(savedConfigs[0].permissionProfile.canGitCommit, false);
+    assert.deepEqual(savedConfigs[0].permissionProfile.allowedDirectories, ["."]);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -425,7 +426,7 @@ test("reset outputs configs with permissionProfile", () => {
     // Check file on disk too
     const filePath = path.join(dir, "workspaces", "ws1", "agents.json");
     const raw = JSON.parse(fs.readFileSync(filePath, "utf8"));
-    for (const entry of raw) {
+    for (const entry of (raw.configs as AgentConfig[])) {
       assert.ok(entry.permissionProfile, `${entry.id} on disk should have permissionProfile`);
     }
   } finally {

--- a/tests/agent-config-store.test.ts
+++ b/tests/agent-config-store.test.ts
@@ -537,10 +537,11 @@ test("rejects triggers with non-boolean onAgentBlocked", () => {
 test("accepts valid triggers with both flags set", () => {
   const configs: AgentConfig[] = [
     {
-      id: "a", name: "A", role: "general", runtime: "claude-code",
+      id: "a", name: "A", role: "coordinator", runtime: "claude-code",
       systemPrompt: "do stuff", enabled: true,
       triggers: { onUnassignedMessage: true, onAgentBlocked: false },
     },
+    { id: "b", name: "B", role: "developer", runtime: "claude-code", systemPrompt: "dev", enabled: true },
   ];
   const errors = validateAgentConfigs(configs);
   assert.deepEqual(errors, []);
@@ -649,6 +650,55 @@ test("rejects supervisor enabled alone (single config)", () => {
 test("accepts supervisor disabled when alone", () => {
   const configs: AgentConfig[] = [
     { id: "supervisor", name: "Supervisor", role: "coordinator", runtime: "claude-code", systemPrompt: "supervise", enabled: false },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.deepEqual(errors, []);
+});
+
+// --- Single supervisor enforcement ---
+
+test("rejects multiple agents with active channel watch triggers", () => {
+  const configs: AgentConfig[] = [
+    { id: "supervisor", name: "Supervisor", role: "coordinator", runtime: "claude-code", systemPrompt: "supervise", enabled: true,
+      triggers: { onUnassignedMessage: true },
+    },
+    { id: "watcher", name: "Watcher", role: "coordinator", runtime: "claude-code", systemPrompt: "watch", enabled: true,
+      triggers: { onAgentBlocked: true },
+    },
+    { id: "dev", name: "Dev", role: "developer", runtime: "claude-code", systemPrompt: "dev", enabled: true },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("Only one supervisor")), `Expected single-supervisor error, got: ${JSON.stringify(errors)}`);
+});
+
+test("accepts at most one agent with active triggers", () => {
+  const configs: AgentConfig[] = [
+    { id: "supervisor", name: "Supervisor", role: "coordinator", runtime: "claude-code", systemPrompt: "supervise", enabled: true,
+      triggers: { onUnassignedMessage: true, onAgentBlocked: true },
+    },
+    { id: "dev", name: "Dev", role: "developer", runtime: "claude-code", systemPrompt: "dev", enabled: true },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.deepEqual(errors, []);
+});
+
+test("rejects non-coordinator agent with active triggers", () => {
+  const configs: AgentConfig[] = [
+    { id: "watcher", name: "Watcher", role: "general", runtime: "claude-code", systemPrompt: "watch", enabled: true,
+      triggers: { onUnassignedMessage: true },
+    },
+    { id: "dev", name: "Dev", role: "developer", runtime: "claude-code", systemPrompt: "dev", enabled: true },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("role is") && e.includes("coordinator")), `Expected non-coordinator triggers error, got: ${JSON.stringify(errors)}`);
+});
+
+test("accepts non-coordinator with inactive triggers (both false)", () => {
+  const configs: AgentConfig[] = [
+    { id: "a", name: "A", role: "general", runtime: "claude-code", systemPrompt: "do stuff", enabled: true,
+      triggers: { onUnassignedMessage: false, onAgentBlocked: false },
+    },
+    { id: "b", name: "B", role: "developer", runtime: "claude-code", systemPrompt: "dev", enabled: true },
   ];
   const errors = validateAgentConfigs(configs);
   assert.deepEqual(errors, []);

--- a/tests/agent-config-store.test.ts
+++ b/tests/agent-config-store.test.ts
@@ -483,6 +483,176 @@ test("coordinator permissionProfile with empty allowedDirectories is valid", () 
   assert.deepEqual(errors, []);
 });
 
+// --- Triggers validation tests ---
+
+test("rejects triggers as a non-object (string)", () => {
+  const configs: AgentConfig[] = [
+    {
+      id: "a", name: "A", role: "general", runtime: "claude-code",
+      systemPrompt: "do stuff", enabled: true,
+      triggers: "bad" as unknown as AgentConfig["triggers"],
+    },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("triggers") && e.includes("object")), `Expected a triggers object error, got: ${JSON.stringify(errors)}`);
+});
+
+test("rejects triggers as an array", () => {
+  const configs: AgentConfig[] = [
+    {
+      id: "a", name: "A", role: "general", runtime: "claude-code",
+      systemPrompt: "do stuff", enabled: true,
+      triggers: [] as unknown as AgentConfig["triggers"],
+    },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("triggers") && e.includes("object")), `Expected a triggers object error for array, got: ${JSON.stringify(errors)}`);
+});
+
+test("rejects triggers with non-boolean onUnassignedMessage", () => {
+  const configs: AgentConfig[] = [
+    {
+      id: "a", name: "A", role: "general", runtime: "claude-code",
+      systemPrompt: "do stuff", enabled: true,
+      triggers: { onUnassignedMessage: "yes" as unknown as boolean },
+    },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("onUnassignedMessage") && e.includes("boolean")), `Expected onUnassignedMessage boolean error, got: ${JSON.stringify(errors)}`);
+});
+
+test("rejects triggers with non-boolean onAgentBlocked", () => {
+  const configs: AgentConfig[] = [
+    {
+      id: "a", name: "A", role: "general", runtime: "claude-code",
+      systemPrompt: "do stuff", enabled: true,
+      triggers: { onAgentBlocked: "no" as unknown as boolean },
+    },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("onAgentBlocked") && e.includes("boolean")), `Expected onAgentBlocked boolean error, got: ${JSON.stringify(errors)}`);
+});
+
+test("accepts valid triggers with both flags set", () => {
+  const configs: AgentConfig[] = [
+    {
+      id: "a", name: "A", role: "general", runtime: "claude-code",
+      systemPrompt: "do stuff", enabled: true,
+      triggers: { onUnassignedMessage: true, onAgentBlocked: false },
+    },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.deepEqual(errors, []);
+});
+
+test("accepts triggers with undefined values (omitted flags)", () => {
+  const configs: AgentConfig[] = [
+    {
+      id: "a", name: "A", role: "general", runtime: "claude-code",
+      systemPrompt: "do stuff", enabled: true,
+      triggers: {},
+    },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.deepEqual(errors, []);
+});
+
+test("rejects triggers.maxTriggersPerConversation when non-number", () => {
+  const configs: AgentConfig[] = [
+    {
+      id: "a", name: "A", role: "coordinator", runtime: "claude-code",
+      systemPrompt: "do stuff", enabled: true,
+      triggers: { maxTriggersPerConversation: "five" as unknown as number },
+    },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("maxTriggersPerConversation")), `Expected maxTriggersPerConversation error, got: ${JSON.stringify(errors)}`);
+});
+
+test("rejects triggers.maxTriggersPerConversation when out of range", () => {
+  const configs: AgentConfig[] = [
+    {
+      id: "a", name: "A", role: "coordinator", runtime: "claude-code",
+      systemPrompt: "do stuff", enabled: true,
+      triggers: { maxTriggersPerConversation: 200 },
+    },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("maxTriggersPerConversation")), `Expected maxTriggersPerConversation range error, got: ${JSON.stringify(errors)}`);
+});
+
+test("rejects triggers.debounceMs when non-number", () => {
+  const configs: AgentConfig[] = [
+    {
+      id: "a", name: "A", role: "coordinator", runtime: "claude-code",
+      systemPrompt: "do stuff", enabled: true,
+      triggers: { debounceMs: "fast" as unknown as number },
+    },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("debounceMs")), `Expected debounceMs error, got: ${JSON.stringify(errors)}`);
+});
+
+test("rejects triggers.debounceMs when out of range", () => {
+  const configs: AgentConfig[] = [
+    {
+      id: "a", name: "A", role: "coordinator", runtime: "claude-code",
+      systemPrompt: "do stuff", enabled: true,
+      triggers: { debounceMs: 120_000 },
+    },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("debounceMs")), `Expected debounceMs range error, got: ${JSON.stringify(errors)}`);
+});
+
+test("accepts triggers with valid maxTriggersPerConversation and debounceMs", () => {
+  const configs: AgentConfig[] = [
+    {
+      id: "a", name: "A", role: "coordinator", runtime: "claude-code",
+      systemPrompt: "do stuff", enabled: true,
+      triggers: { maxTriggersPerConversation: 10, debounceMs: 5000 },
+    },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.deepEqual(errors, []);
+});
+
+// --- Cross-validation tests ---
+
+test("rejects supervisor enabled with no other agents enabled", () => {
+  const configs: AgentConfig[] = [
+    { id: "supervisor", name: "Supervisor", role: "coordinator", runtime: "claude-code", systemPrompt: "supervise", enabled: true },
+    { id: "dev", name: "Dev", role: "developer", runtime: "claude-code", systemPrompt: "dev", enabled: false },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("Supervisor cannot be enabled")), `Expected supervisor cross-validation error, got: ${JSON.stringify(errors)}`);
+});
+
+test("accepts supervisor enabled when at least one other agent is enabled", () => {
+  const configs: AgentConfig[] = [
+    { id: "supervisor", name: "Supervisor", role: "coordinator", runtime: "claude-code", systemPrompt: "supervise", enabled: true },
+    { id: "dev", name: "Dev", role: "developer", runtime: "claude-code", systemPrompt: "dev", enabled: true },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.deepEqual(errors, []);
+});
+
+test("rejects supervisor enabled alone (single config)", () => {
+  const configs: AgentConfig[] = [
+    { id: "supervisor", name: "Supervisor", role: "coordinator", runtime: "claude-code", systemPrompt: "supervise", enabled: true },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.ok(errors.some((e) => e.includes("Supervisor cannot be enabled")), `Expected supervisor-alone error, got: ${JSON.stringify(errors)}`);
+});
+
+test("accepts supervisor disabled when alone", () => {
+  const configs: AgentConfig[] = [
+    { id: "supervisor", name: "Supervisor", role: "coordinator", runtime: "claude-code", systemPrompt: "supervise", enabled: false },
+  ];
+  const errors = validateAgentConfigs(configs);
+  assert.deepEqual(errors, []);
+});
+
 test("validate does not require permissionProfile for each config", () => {
   // permissionProfile is optional in AgentConfig by design
   const configs: AgentConfig[] = [

--- a/tests/channel-watch.test.ts
+++ b/tests/channel-watch.test.ts
@@ -94,6 +94,7 @@ function createMocks(opts?: {
 
   const agentRegistry = {
     ids: () => Object.keys(opts?.agentStatuses ?? {}),
+    has: (id: string) => id in (opts?.agentStatuses ?? {}),
     get: (id: string) => {
       const status = opts?.agentStatuses?.[id];
       if (status === undefined) throw new Error(`Unknown agent: ${id}`);

--- a/tests/channel-watch.test.ts
+++ b/tests/channel-watch.test.ts
@@ -810,7 +810,7 @@ test("blocked message triggers supervisor via onAgentBlocked", async () => {
   );
 
   eventBus.publish({
-    type: "message.created",
+    type: "message.updated",
     conversationId: "conv-1",
     message: createBlockedMessage("dev"),
   });

--- a/tests/channel-watch.test.ts
+++ b/tests/channel-watch.test.ts
@@ -40,14 +40,14 @@ function makeSupervisorProfile(id = "supervisor"): AgentProfile {
   return {
     id,
     name: "Supervisor",
-    role: "general",
+    role: "coordinator",
     runtime: "claude-code",
     cwd: "/tmp",
     systemPrompt: "You are a supervisor.",
     permissionProfile: {
-      canReadFiles: true,
+      canReadFiles: false,
       canWriteFiles: false,
-      canRunCommands: true,
+      canRunCommands: false,
       canInstallDependencies: false,
       canGitCommit: false,
       allowedDirectories: [],
@@ -193,8 +193,6 @@ test("run.completed without @agent: triggers supervisor when channel idle", asyn
   assert.equal(enqueueCalls.length, 1);
   assert.equal(enqueueCalls[0].agentId, "supervisor");
   assert.ok(enqueueCalls[0].prompt.includes("Supervisor Check"));
-  assert.ok(enqueueCalls[0].prompt.includes("you CANNOT read files"), "trigger prompt should include tool reminder");
-  assert.ok(enqueueCalls[0].prompt.includes("conversation history"), "trigger prompt should reference conversation history");
 
   service.dispose();
 });

--- a/tests/message-router.test.ts
+++ b/tests/message-router.test.ts
@@ -29,7 +29,7 @@ function createAgentMessage(agentId: AgentId, content: string, overrides?: Parti
   };
 }
 
-function createRouter(options?: Partial<{ availableAgents: readonly AgentId[]; maxRouteDepth: number }>) {
+function createRouter(options?: Partial<{ availableAgents: readonly AgentId[]; maxRouteDepth: number; hasActiveSupervisor: boolean }>) {
   const systemMessages: Array<{ content: string; parentMessageId?: string }> = [];
   const agentRuns: Array<{ agentId: AgentId; prompt: string; source: ChatMessage }> = [];
   const routeStates: Array<{ id: string; state: MessageRouteState }> = [];
@@ -37,6 +37,7 @@ function createRouter(options?: Partial<{ availableAgents: readonly AgentId[]; m
   const router = new MessageRouter({
     availableAgents: options?.availableAgents ?? agents,
     maxRouteDepth: options?.maxRouteDepth ?? 10,
+    hasActiveSupervisor: options?.hasActiveSupervisor,
     createSystemMessage(content: string, parentMessageId?: string) {
       systemMessages.push({ content, parentMessageId });
       return createUserMessage(content, { kind: "system" });
@@ -253,4 +254,35 @@ test("empty assignment does not start agent run", () => {
   assert.equal(systemMessages.length, 1);
   assert.ok(systemMessages[0].content.includes("task content"));
   assert.equal(routeStates[0]?.state, "blocked");
+});
+
+// --- hasActiveSupervisor behavior ---
+
+test("plain mention with supervisor active is silently ignored (no system message)", () => {
+  const { router, systemMessages, agentRuns, routeStates } = createRouter({ hasActiveSupervisor: true });
+  router.process(createUserMessage("hello world"));
+
+  assert.equal(agentRuns.length, 0);
+  assert.equal(systemMessages.length, 0);
+  assert.equal(routeStates[0]?.state, "ignored");
+});
+
+test("plain mention WITHOUT supervisor creates system hint message", () => {
+  const { router, systemMessages, agentRuns, routeStates } = createRouter({ hasActiveSupervisor: false });
+  router.process(createUserMessage("hello world"));
+
+  assert.equal(agentRuns.length, 0);
+  assert.equal(systemMessages.length, 1);
+  assert.ok(systemMessages[0].content.includes("@agent1:"));
+  assert.equal(routeStates[0]?.state, "ignored");
+});
+
+test("plain mention without hasActiveSupervisor option creates system hint", () => {
+  // When the option is omitted (undefined/falsy), behavior should match hasActiveSupervisor: false
+  const { router, systemMessages, agentRuns, routeStates } = createRouter();
+  router.process(createUserMessage("no assignment here"));
+
+  assert.equal(agentRuns.length, 0);
+  assert.equal(systemMessages.length, 1);
+  assert.equal(routeStates[0]?.state, "ignored");
 });


### PR DESCRIPTION
﻿Closes #29

## Changes

- Add channel watch triggers and ChannelWatchService (phase 1)
- Propagate triggers in configsToProfiles, add supervisor default, validate triggers field
- Prevent supervisor self-trigger loop
- Add supervisor badge and banner UI
- Auto-add missing default templates on load
- Suppress routing hint when supervisor active, tighten supervisor permissions
- Add coordinator role with four-layer constraint defense
- Update supervisor prompts with @user: protocol
- Show coordinator role in agent config UI
- Gate SupervisorBanner on coordinator role
- Extract shared supervisor constraints and triggers utils

🤖 Generated with [Claude Code](https://claude.com/claude-code)
