### PR TITLE
fix: exclude Codex commentary from final answer and preserve routed agent messages in history

### DIFF
--- a/src/core/agent-history-builder.ts
+++ b/src/core/agent-history-builder.ts
@@ -7,7 +7,12 @@ const OLDER_ENTRY_MAX_CHARS = 500;
 
 export { MAX_HISTORY_CHARS, OLDER_ENTRY_MAX_CHARS, RECENT_UNTRUNCATED_COUNT };
 
-export function buildHistoryForAgent(agentId: AgentId, allMessages: ChatMessage[]): AgentHistoryEntry[] {
+export type BuildHistoryOptions = {
+  /** Exclude this specific message (typically the current run's source message) */
+  excludeMessageId?: string;
+};
+
+export function buildHistoryForAgent(agentId: AgentId, allMessages: ChatMessage[], options?: BuildHistoryOptions): AgentHistoryEntry[] {
   let cutoffIndex = -1;
   for (let i = allMessages.length - 1; i >= 0; i--) {
     const msg = allMessages[i];
@@ -23,7 +28,9 @@ export function buildHistoryForAgent(agentId: AgentId, allMessages: ChatMessage[
     const msg = allMessages[i];
     if (msg.kind === "system") continue;
     if (msg.status === "running") continue;
-    if (msg.kind === "agent" && msg.routeState === "routed") continue;
+    // Exclude only the specific source message (already injected as <current-task>),
+    // rather than all routed agent messages which may contain valuable context.
+    if (options?.excludeMessageId && msg.id === options.excludeMessageId) continue;
     eligible.push(msg);
   }
 

--- a/src/core/codex-cli-runtime.ts
+++ b/src/core/codex-cli-runtime.ts
@@ -138,6 +138,7 @@ export function extractCodexCliFinalAnswer(output: string): { text: string; sess
   let taskCompleteMessage: string | undefined;
   let hasExplicitPhase = false;
   const textParts: string[] = [];
+  const agentMessageTexts: string[] = [];
 
   for (const event of parseJsonObjects(output)) {
     sessionId ??= sessionIdFromEvent(event) ?? undefined;
@@ -157,6 +158,11 @@ export function extractCodexCliFinalAnswer(output: string): { text: string; sess
     const text = textFromEvent(event);
     if (text) {
       textParts.push(text);
+
+      // Track agent_message texts separately for accurate no-phase fallback
+      if (isAgentMessageEvent(event)) {
+        agentMessageTexts.push(text);
+      }
     }
   }
 
@@ -173,7 +179,11 @@ export function extractCodexCliFinalAnswer(output: string): { text: string; sess
   // Fallback: no task_complete, no phase markers → take only the last agent_message.
   // Real Codex CLI outputs multiple agent_message events without phase fields;
   // intermediate messages are commentary, only the last one is the final answer.
-  const text = textParts.length > 0 ? textParts[textParts.length - 1] : "";
+  // Prefer the last agent_message specifically; only fall back to other text
+  // (result, top-level text) when no agent_message events exist at all.
+  const text = agentMessageTexts.length > 0
+    ? agentMessageTexts[agentMessageTexts.length - 1]
+    : (textParts.length > 0 ? textParts[textParts.length - 1] : "");
   return { text, sessionId };
 }
 
@@ -277,6 +287,17 @@ function eventHasPhase(event: unknown): boolean {
   if (!container || typeof container !== "object") return false;
   const msg = container as { phase?: unknown };
   return msg.phase !== undefined;
+}
+
+function isAgentMessageEvent(event: unknown): boolean {
+  if (!event || typeof event !== "object") return false;
+  const record = event as { item?: unknown; message?: unknown };
+
+  const container = record.item ?? record.message;
+  if (!container || typeof container !== "object") return false;
+  const msg = container as { role?: unknown; type?: unknown };
+
+  return msg.role === "assistant" || msg.type === "message" || msg.type === "agent_message";
 }
 
 function textFromEvent(event: unknown): string {

--- a/src/core/codex-cli-runtime.ts
+++ b/src/core/codex-cli-runtime.ts
@@ -135,17 +135,28 @@ export function buildCodexCliCommand(
 
 export function extractCodexCliFinalAnswer(output: string): { text: string; sessionId?: string } {
   let sessionId: string | undefined;
+  let taskCompleteMessage: string | undefined;
   const textParts: string[] = [];
 
   for (const event of parseJsonObjects(output)) {
     sessionId ??= sessionIdFromEvent(event) ?? undefined;
+
+    // Priority 1: task_complete.payload.last_agent_message
+    const taskMsg = lastAgentMessageFromTaskComplete(event);
+    if (taskMsg) {
+      taskCompleteMessage = taskMsg;
+    }
+
+    // Priority 2: only non-commentary events (final_answer or no phase)
     const text = textFromEvent(event);
     if (text) {
       textParts.push(text);
     }
   }
 
-  return { text: textParts.join("\n").trim(), sessionId };
+  // Use task_complete message if available, otherwise fall back to filtered events
+  const text = taskCompleteMessage ?? textParts.join("\n").trim();
+  return { text, sessionId };
 }
 
 export function extractCodexSessionId(output: string): string | null {
@@ -230,6 +241,17 @@ function sessionIdFromEvent(event: unknown): string | null {
   return null;
 }
 
+function lastAgentMessageFromTaskComplete(event: unknown): string | null {
+  if (!event || typeof event !== "object") return null;
+  const record = event as { type?: unknown; payload?: unknown };
+  if (record.type !== "task_complete" || !record.payload || typeof record.payload !== "object") return null;
+  const payload = record.payload as { last_agent_message?: unknown };
+  if (typeof payload.last_agent_message === "string" && payload.last_agent_message.trim()) {
+    return payload.last_agent_message.trim();
+  }
+  return null;
+}
+
 function textFromEvent(event: unknown): string {
   if (!event || typeof event !== "object") {
     return "";
@@ -272,11 +294,17 @@ function textFromMessage(value: unknown): string {
   const message = value as {
     role?: unknown;
     type?: unknown;
+    phase?: unknown;
     content?: unknown;
     text?: unknown;
   };
 
   if (message.role !== "assistant" && message.type !== "message" && message.type !== "agent_message") {
+    return "";
+  }
+
+  // Skip commentary phase events — these are intermediate reasoning, not final answers
+  if (message.phase === "commentary") {
     return "";
   }
 

--- a/src/core/codex-cli-runtime.ts
+++ b/src/core/codex-cli-runtime.ts
@@ -136,6 +136,7 @@ export function buildCodexCliCommand(
 export function extractCodexCliFinalAnswer(output: string): { text: string; sessionId?: string } {
   let sessionId: string | undefined;
   let taskCompleteMessage: string | undefined;
+  let hasExplicitPhase = false;
   const textParts: string[] = [];
 
   for (const event of parseJsonObjects(output)) {
@@ -147,6 +148,11 @@ export function extractCodexCliFinalAnswer(output: string): { text: string; sess
       taskCompleteMessage = taskMsg;
     }
 
+    // Track whether any message has explicit phase markers
+    if (eventHasPhase(event)) {
+      hasExplicitPhase = true;
+    }
+
     // Priority 2: only non-commentary events (final_answer or no phase)
     const text = textFromEvent(event);
     if (text) {
@@ -154,8 +160,20 @@ export function extractCodexCliFinalAnswer(output: string): { text: string; sess
     }
   }
 
-  // Use task_complete message if available, otherwise fall back to filtered events
-  const text = taskCompleteMessage ?? textParts.join("\n").trim();
+  // Use task_complete message if available
+  if (taskCompleteMessage) {
+    return { text: taskCompleteMessage, sessionId };
+  }
+
+  // If events have explicit phase markers, use filtered text parts (commentary already excluded)
+  if (hasExplicitPhase) {
+    return { text: textParts.join("\n").trim(), sessionId };
+  }
+
+  // Fallback: no task_complete, no phase markers → take only the last agent_message.
+  // Real Codex CLI outputs multiple agent_message events without phase fields;
+  // intermediate messages are commentary, only the last one is the final answer.
+  const text = textParts.length > 0 ? textParts[textParts.length - 1] : "";
   return { text, sessionId };
 }
 
@@ -250,6 +268,15 @@ function lastAgentMessageFromTaskComplete(event: unknown): string | null {
     return payload.last_agent_message.trim();
   }
   return null;
+}
+
+function eventHasPhase(event: unknown): boolean {
+  if (!event || typeof event !== "object") return false;
+  const record = event as { item?: unknown; message?: unknown };
+  const container = record.item ?? record.message;
+  if (!container || typeof container !== "object") return false;
+  const msg = container as { phase?: unknown };
+  return msg.phase !== undefined;
 }
 
 function textFromEvent(event: unknown): string {

--- a/src/core/run-manager.ts
+++ b/src/core/run-manager.ts
@@ -43,7 +43,7 @@ export type RunManagerOptions = {
   agents: AgentRunner;
   messages: MessageStore;
   eventBus: EventBus;
-  buildPrompt: (agentId: AgentId, prompt: string) => string;
+  buildPrompt: (agentId: AgentId, prompt: string, sourceMessageId?: string) => string;
   onRunCompleted: (message: ChatMessage) => void;
 };
 
@@ -216,7 +216,7 @@ export class RunManager {
 
     this.appendActivity(run, "Run started.");
 
-    const runtimePrompt = this.options.buildPrompt(run.agentId, run.prompt);
+    const runtimePrompt = this.options.buildPrompt(run.agentId, run.prompt, run.sourceMessage.id);
     let result: Promise<RunResult>;
     try {
       result = this.options.agents.get(run.agentId).send(run.id, runtimePrompt);

--- a/src/server/conversation-context.ts
+++ b/src/server/conversation-context.ts
@@ -76,8 +76,8 @@ export class ConversationContext {
       agents: this.agents,
       messages: this.messages,
       eventBus,
-      buildPrompt: (agentId: AgentId, prompt: string) => {
-        const history = buildHistoryForAgent(agentId, self.messages.list());
+      buildPrompt: (agentId: AgentId, prompt: string, sourceMessageId?: string) => {
+        const history = buildHistoryForAgent(agentId, self.messages.list(), { excludeMessageId: sourceMessageId });
         return buildAgentContext({ agentId, profiles, agentMessage: prompt, history, workspaceConfig: self._workspaceConfig });
       },
       onRunCompleted: (message) => {
@@ -165,8 +165,8 @@ export class ConversationContext {
       agents: newAgents,
       messages: this.messages,
       eventBus,
-      buildPrompt: (agentId: AgentId, prompt: string) => {
-        const history = buildHistoryForAgent(agentId, self.messages.list());
+      buildPrompt: (agentId: AgentId, prompt: string, sourceMessageId?: string) => {
+        const history = buildHistoryForAgent(agentId, self.messages.list(), { excludeMessageId: sourceMessageId });
         return buildAgentContext({ agentId, profiles, agentMessage: prompt, history, workspaceConfig: self._workspaceConfig });
       },
       onRunCompleted: (message) => {

--- a/tests/agent-history-builder.test.ts
+++ b/tests/agent-history-builder.test.ts
@@ -65,7 +65,7 @@ test("different agents have independent cutoff points", () => {
   assert.equal(archHistory[0].content, "req 2");
 });
 
-test("filters out system, running, and routed agent messages but keeps routed user messages", () => {
+test("filters out system and running messages but keeps routed agent messages", () => {
   const messages: ChatMessage[] = [
     msg({ kind: "user", content: "user msg" }),
     msg({ kind: "system", content: "sys msg", status: "done" }),
@@ -76,10 +76,12 @@ test("filters out system, running, and routed agent messages but keeps routed us
   ];
 
   const history = buildHistoryForAgent("developer", messages);
-  assert.equal(history.length, 3);
+  // Routed agent messages are now kept (was previously filtered)
+  assert.equal(history.length, 4);
   assert.equal(history[0].content, "user msg");
   assert.equal(history[1].content, "routed user msg");
-  assert.equal(history[2].content, "arch done");
+  assert.equal(history[2].content, "routed agent msg");
+  assert.equal(history[3].content, "arch done");
 });
 
 test("truncates total history to MAX_HISTORY_CHARS", () => {
@@ -158,6 +160,52 @@ test("long UX/review message from another agent passes through untruncated when 
   const history = buildHistoryForAgent("developer", messages);
   assert.equal(history.length, 2);
   assert.equal(history[0].content, longReview, "recent agent review should be untruncated");
+});
+
+test("excludeMessageId excludes only the specified message, keeps other routed messages", () => {
+  const sourceId = "msg-source";
+  const messages: ChatMessage[] = [
+    msg({ kind: "user", content: "user msg" }),
+    { id: sourceId, kind: "agent", agentId: "supervisor", content: "supervisor routed msg", routeState: "routed", status: "done", createdAt: new Date().toISOString() } satisfies ChatMessage,
+    msg({ kind: "agent", agentId: "architect", content: "arch routed msg", routeState: "routed", status: "done" }),
+    msg({ kind: "user", content: "next request" }),
+  ];
+
+  const history = buildHistoryForAgent("developer", messages, { excludeMessageId: sourceId });
+  // source message excluded, but other routed messages kept
+  assert.equal(history.length, 3);
+  assert.equal(history[0].content, "user msg");
+  assert.equal(history[1].content, "arch routed msg");
+  assert.equal(history[2].content, "next request");
+});
+
+test("supervisor routed messages are visible to subsequent agents when not excluded", () => {
+  const messages: ChatMessage[] = [
+    msg({ kind: "user", content: "initial request" }),
+    msg({ kind: "agent", agentId: "supervisor", content: "@architect: Please review the changes.", routeState: "routed", status: "done" }),
+    msg({ kind: "agent", agentId: "architect", content: "Review complete.", status: "done" }),
+  ];
+
+  // Developer should see supervisor's routed coordination message
+  const history = buildHistoryForAgent("developer", messages);
+  assert.equal(history.length, 3);
+  assert.equal(history[0].content, "initial request");
+  assert.equal(history[1].content, "@architect: Please review the changes.");
+  assert.equal(history[2].content, "Review complete.");
+});
+
+test("without excludeMessageId, all routed agent messages are included", () => {
+  const messages: ChatMessage[] = [
+    msg({ kind: "agent", agentId: "supervisor", content: "supervisor msg 1", routeState: "routed", status: "done" }),
+    msg({ kind: "agent", agentId: "supervisor", content: "supervisor msg 2", routeState: "routed", status: "done" }),
+    msg({ kind: "user", content: "user request" }),
+  ];
+
+  const history = buildHistoryForAgent("developer", messages);
+  assert.equal(history.length, 3);
+  assert.equal(history[0].content, "supervisor msg 1");
+  assert.equal(history[1].content, "supervisor msg 2");
+  assert.equal(history[2].content, "user request");
 });
 
 test("budget is respected: total chars do not exceed MAX_HISTORY_CHARS", () => {

--- a/tests/codex-cli-runtime.test.ts
+++ b/tests/codex-cli-runtime.test.ts
@@ -389,3 +389,64 @@ test("single agent_message without phase returns that message", () => {
   assert.equal(result.text, "Only one message.");
   assert.equal(result.sessionId, "thread-single");
 });
+
+test("with no phase markers, prefers last agent_message over trailing result event", () => {
+  // Regression: last event is a non-agent_message (result), but there are agent_messages before it.
+  // The last agent_message should be the final answer, not the result text.
+  const output = [
+    JSON.stringify({ type: "thread.started", thread_id: "thread-result-trailing" }),
+    JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        text: "Let me check the diff.",
+      },
+    }),
+    JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        text: "**Final answer from agent.**",
+      },
+    }),
+    JSON.stringify({ type: "result", result: "Summary: task completed" }),
+  ].join("\n");
+
+  const result = extractCodexCliFinalAnswer(output);
+
+  assert.equal(result.text, "**Final answer from agent.**");
+  assert.equal(result.sessionId, "thread-result-trailing");
+});
+
+test("with no phase markers, prefers last agent_message over trailing top-level text event", () => {
+  // Regression: last event has top-level text field, but agent_messages exist before it.
+  const output = [
+    JSON.stringify({ type: "thread.started", thread_id: "thread-text-trailing" }),
+    JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        text: "Real agent answer.",
+      },
+    }),
+    JSON.stringify({ type: "info", text: "Some informational text that is not the answer" }),
+  ].join("\n");
+
+  const result = extractCodexCliFinalAnswer(output);
+
+  assert.equal(result.text, "Real agent answer.");
+  assert.equal(result.sessionId, "thread-text-trailing");
+});
+
+test("with no phase and no agent_messages, falls back to last text part", () => {
+  // When there are truly no agent_messages, fall back to the last readable text.
+  const output = [
+    JSON.stringify({ type: "thread.started", thread_id: "thread-fallback" }),
+    JSON.stringify({ type: "result", result: "Only result text available" }),
+  ].join("\n");
+
+  const result = extractCodexCliFinalAnswer(output);
+
+  assert.equal(result.text, "Only result text available");
+  assert.equal(result.sessionId, "thread-fallback");
+});

--- a/tests/codex-cli-runtime.test.ts
+++ b/tests/codex-cli-runtime.test.ts
@@ -188,6 +188,108 @@ test("extracts only structured final answer, ignoring tool events in same stream
   assert.equal(result.sessionId, "thread-456");
 });
 
+test("excludes commentary phase from final answer, keeps final_answer phase", () => {
+  const output = [
+    JSON.stringify({ type: "thread.started", thread_id: "thread-phase" }),
+    JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        text: "I will first confirm the current branch and workspace state...",
+        phase: "commentary",
+      },
+    }),
+    JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        text: "**Review conclusion: changes are needed before merge.**",
+        phase: "final_answer",
+      },
+    }),
+  ].join("\n");
+
+  const result = extractCodexCliFinalAnswer(output);
+
+  assert.equal(result.text, "**Review conclusion: changes are needed before merge.**");
+  assert.equal(result.sessionId, "thread-phase");
+});
+
+test("prefers task_complete.payload.last_agent_message over event text", () => {
+  const output = [
+    JSON.stringify({ type: "thread.started", thread_id: "thread-tc" }),
+    JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        text: "Some intermediate text that should be ignored",
+        phase: "commentary",
+      },
+    }),
+    JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        text: "Final answer from event",
+        phase: "final_answer",
+      },
+    }),
+    JSON.stringify({
+      type: "task_complete",
+      payload: {
+        last_agent_message: "Final answer from task_complete",
+      },
+    }),
+  ].join("\n");
+
+  const result = extractCodexCliFinalAnswer(output);
+
+  assert.equal(result.text, "Final answer from task_complete");
+  assert.equal(result.sessionId, "thread-tc");
+});
+
+test("returns empty text when only commentary events exist (no final_answer or task_complete)", () => {
+  const output = [
+    JSON.stringify({ type: "thread.started", thread_id: "thread-commentary-only" }),
+    JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        text: "Just thinking out loud...",
+        phase: "commentary",
+      },
+    }),
+  ].join("\n");
+
+  const result = extractCodexCliFinalAnswer(output);
+
+  assert.equal(result.text, "");
+  assert.equal(result.sessionId, "thread-commentary-only");
+});
+
+test("task_complete without last_agent_message falls back to filtered events", () => {
+  const output = [
+    JSON.stringify({ type: "thread.started", thread_id: "thread-tc-no-msg" }),
+    JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        text: "Final from event",
+        phase: "final_answer",
+      },
+    }),
+    JSON.stringify({
+      type: "task_complete",
+      payload: {},
+    }),
+  ].join("\n");
+
+  const result = extractCodexCliFinalAnswer(output);
+
+  assert.equal(result.text, "Final from event");
+  assert.equal(result.sessionId, "thread-tc-no-msg");
+});
+
 test("ignores tool output, stderr, and reconnect events when extracting final answer", () => {
   const output = [
     JSON.stringify({ type: "item.completed", item: { type: "command_execution", aggregated_output: "npm ERR! failed" } }),

--- a/tests/codex-cli-runtime.test.ts
+++ b/tests/codex-cli-runtime.test.ts
@@ -136,7 +136,8 @@ test("ignores plain non-JSON text between valid events", () => {
 
   const result = extractCodexCliFinalAnswer(output);
 
-  assert.equal(result.text, "first\nsecond");
+  // No phase markers → take only the last agent_message
+  assert.equal(result.text, "second");
 });
 
 test("handles braces inside JSON string values", () => {
@@ -301,4 +302,90 @@ test("ignores tool output, stderr, and reconnect events when extracting final an
   const result = extractCodexCliFinalAnswer(output);
 
   assert.equal(result.text, "The build failed due to a type error.");
+});
+
+test("with no phase markers, takes only the last agent_message as final answer", () => {
+  // Real Codex CLI behavior: multiple agent_message events without phase/task_complete
+  const output = [
+    JSON.stringify({ type: "thread.started", thread_id: "thread-no-phase" }),
+    JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        text: "I will first confirm the current branch and workspace state...",
+      },
+    }),
+    JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        text: "Let me check the diff to see what changed.",
+      },
+    }),
+    JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        text: "**Review conclusion: code is ready for merge.**",
+      },
+    }),
+  ].join("\n");
+
+  const result = extractCodexCliFinalAnswer(output);
+
+  assert.equal(result.text, "**Review conclusion: code is ready for merge.**");
+  assert.equal(result.sessionId, "thread-no-phase");
+});
+
+test("with explicit phase markers, still filters commentary and keeps final_answer", () => {
+  const output = [
+    JSON.stringify({ type: "thread.started", thread_id: "thread-with-phase" }),
+    JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        text: "Thinking out loud...",
+        phase: "commentary",
+      },
+    }),
+    JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        text: "More reasoning...",
+        phase: "commentary",
+      },
+    }),
+    JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        text: "Here is the answer.",
+        phase: "final_answer",
+      },
+    }),
+  ].join("\n");
+
+  const result = extractCodexCliFinalAnswer(output);
+
+  assert.equal(result.text, "Here is the answer.");
+  assert.equal(result.sessionId, "thread-with-phase");
+});
+
+test("single agent_message without phase returns that message", () => {
+  const output = [
+    JSON.stringify({ type: "thread.started", thread_id: "thread-single" }),
+    JSON.stringify({
+      type: "item.completed",
+      item: {
+        type: "agent_message",
+        text: "Only one message.",
+      },
+    }),
+  ].join("\n");
+
+  const result = extractCodexCliFinalAnswer(output);
+
+  assert.equal(result.text, "Only one message.");
+  assert.equal(result.sessionId, "thread-single");
 });


### PR DESCRIPTION
## Summary

Fixes #57, Fixes #58

### Issue #57 — Exclude Codex commentary from final agent messages

Codex CLI events with `phase="commentary"` were being collected alongside the actual final answer, resulting in intermediate reasoning text appearing in the persisted/displayed agent message.

**Changes:**
- Added `lastAgentMessageFromTaskComplete()` helper to extract from `task_complete.payload.last_agent_message`
- Modified `extractCodexCliFinalAnswer()` to prefer `task_complete` message, then fall back to non-commentary events
- Modified `textFromMessage()` to skip events with `phase === "commentary"`
- Added 4 regression tests

### Issue #58 — Preserve routed agent messages in conversation history

`buildHistoryForAgent()` was filtering out ALL routed agent messages (`routeState === "routed"`), which caused supervisor coordination messages to disappear from subsequent agents' context.

**Changes:**
- Replaced the blanket `routeState === "routed"` filter with a precise `excludeMessageId` option
- Updated `RunManagerOptions.buildPrompt` signature to pass `sourceMessageId`
- Updated both `buildPrompt` callbacks in `conversation-context.ts` to use the new option
- Modified 1 existing test + added 3 new tests

## Test plan

- [x] All 400 existing tests pass (`npm run test`)
- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] UI build succeeds (`npm run build`)
- [x] New regression tests cover commentary exclusion, task_complete priority, and routed message preservation