### PR TITLE
feat: fix issue #91 - replace hardcoded ID checks with role-based checks

### DIFF
--- a/src/core/agent-config-store.ts
+++ b/src/core/agent-config-store.ts
@@ -16,11 +16,22 @@ export const DEFAULT_AGENT_CONFIGS: AgentConfig[] = [
   {
     id: "pm",
     name: "Product Manager",
-    description: "Clarifies requirements, defines scope and acceptance criteria.",
+    description: "产品负责人：定义产品方向、挑战不合理需求、将模糊想法转化为清晰可执行的产品需求",
     role: "pm",
     runtime: "codex",
     systemPrompt:
-      "You are Orbit's product manager. Clarify requirements, define scope, acceptance criteria, and review whether implementation matches user needs. Do not edit code unless explicitly assigned.",
+      "你是 Orbit 的产品负责人，拥有强烈的产品主人意识。你的角色不是迎合用户请求，而是创造最好的产品。\n\n" +
+      "核心职责：\n" +
+      "- 将模糊想法转化为清晰、可执行的产品需求\n" +
+      "- 主动挑战会损害产品的不合理请求\n" +
+      "- 从产品设计、用户体验和未来路线图角度思考\n" +
+      "- 基于产品价值而非用户需求定义迭代方向\n\n" +
+      "准则：\n" +
+      "- 当请求有缺陷时，解释 WHY 并提出替代方案\n" +
+      "- 关注用户价值而非用户请求——用户可能不知道他们真正需要什么\n" +
+      "- 考虑边缘情况、可扩展性和长期产品健康\n" +
+      "- 输出结构化需求：问题陈述、验收标准、边缘情况、考虑的替代方案\n\n" +
+      "永远不要对所有事情说\"是\"。你的工作是产品判断，而非执行。Do not edit code unless explicitly assigned.",
     enabled: false,
     permissionProfile: permissionProfile("pm"),
   },
@@ -202,13 +213,23 @@ export function validateAgentConfigs(configs: AgentConfig[]): string[] {
     );
   }
 
-  // Cross-validation: supervisor requires at least one other agent enabled
-  const supervisor = configs.find((c) => c && c.id === "supervisor" && c.enabled);
-  if (supervisor) {
-    const othersEnabled = configs.some((c) => c && c.id !== "supervisor" && c.enabled);
+  // Issue #91: Cross-validation: only one coordinator-role agent is allowed
+  const coordinators = configs.filter((c) => c && c.role === "coordinator");
+  if (coordinators.length > 1) {
+    errors.push(
+      `Only one coordinator-role agent is allowed, but found ${coordinators.length}: ` +
+        `${coordinators.map((c) => c.id).join(", ")}. ` +
+        "Keep only one coordinator (supervisor) agent.",
+    );
+  }
+
+  // Cross-validation: coordinator requires at least one other agent enabled
+  const coordinator = configs.find((c) => c && c.role === "coordinator" && c.enabled);
+  if (coordinator) {
+    const othersEnabled = configs.some((c) => c && c.role !== "coordinator" && c.enabled);
     if (!othersEnabled) {
       errors.push(
-        "Supervisor cannot be enabled when no other agents are enabled. " +
+        "Coordinator cannot be enabled when no other agents are enabled. " +
           "Enable at least one working agent (pm, architect, developer, tester) first.",
       );
     }

--- a/src/core/channel-watch.ts
+++ b/src/core/channel-watch.ts
@@ -21,6 +21,7 @@ type TriggerContext = {
 export class ChannelWatchService {
   private readonly triggerContexts: Map<AgentId, TriggerContext> = new Map();
   private readonly knownIds: Set<string>;
+  private readonly agentRoles: Map<AgentId, string>; // Issue #91: Map agentId -> role
   private readonly unsubscribe: () => void;
   private disposed = false;
 
@@ -35,6 +36,9 @@ export class ChannelWatchService {
     this.knownIds = new Set(profiles.map((p) => p.id));
     this.knownIds.add("user"); // @user: is the task-closure signal
     this.knownIds.add("all");  // @all: is the broadcast signal
+
+    // Issue #91: Initialize agentId -> role mapping
+    this.agentRoles = new Map(profiles.map((p) => [p.id, p.role]));
 
     for (const profile of profiles) {
       if (profile.triggers && hasActiveChannelWatchTriggers(profile.triggers)) {
@@ -126,10 +130,12 @@ export class ChannelWatchService {
     // @user: is only a closure signal when the SUPERVISOR says it, not when other agents do.
     // Other agents might mention @user: in their responses (e.g., "I'll let @user: know"),
     // which should NOT suppress supervisor triggers.
+    // Issue #91: Use role-based check instead of hardcoded ID
+    const agentRole = this.agentRoles.get(agentId);
     const hasAssignment = hasAssignmentMarkerExcludingUserForNonSupervisor(
       message.content,
       this.knownIds,
-      agentId,
+      agentRole,
     );
     if (hasAssignment) return;
 
@@ -227,22 +233,24 @@ function hasAssignmentMarker(content: string, knownIds: ReadonlySet<string>): bo
  * responses, it should NOT suppress supervisor triggers. @user: is only a closure
  * signal when the supervisor itself says it.
  *
+ * Issue #91: Use role-based check instead of hardcoded agent ID.
+ *
  * @param content - Message content to check
  * @param knownIds - Set of known agent IDs
- * @param fromAgentId - ID of the agent that sent this message
+ * @param fromAgentRole - Role of the agent that sent this message
  * @returns true if there's an assignment marker that should suppress triggers
  */
 function hasAssignmentMarkerExcludingUserForNonSupervisor(
   content: string,
   knownIds: ReadonlySet<string>,
-  fromAgentId: AgentId,
+  fromAgentRole: string | undefined,
 ): boolean {
   const pattern = new RegExp(assignmentPattern.source, "g");
   let m: RegExpExecArray | null;
   while ((m = pattern.exec(content)) !== null) {
     const mentionedId = m[1];
-    // Skip @user: for non-supervisor agents
-    if (mentionedId === "user" && fromAgentId !== "supervisor") {
+    // Issue #91: Skip @user: for non-coordinator agents (role-based check)
+    if (mentionedId === "user" && fromAgentRole !== "coordinator") {
       continue;
     }
     if (knownIds.has(mentionedId)) return true;

--- a/tests/agent-config-store.test.ts
+++ b/tests/agent-config-store.test.ts
@@ -469,6 +469,7 @@ test("coordinator is a valid role accepted by validation", () => {
     { id: "watcher", name: "Watcher", role: "coordinator", runtime: "claude-code", systemPrompt: "You monitor.", enabled: true,
       permissionProfile: { canReadFiles: false, canWriteFiles: false, canRunCommands: false, canInstallDependencies: false, canGitCommit: false, allowedDirectories: [] },
     },
+    { id: "dev", name: "Dev", role: "general", runtime: "claude-code", systemPrompt: "dev", enabled: true },
   ];
   const errors = validateAgentConfigs(configs);
   assert.deepEqual(errors, []);
@@ -479,6 +480,7 @@ test("coordinator permissionProfile with empty allowedDirectories is valid", () 
     { id: "watcher", name: "Watcher", role: "coordinator", runtime: "claude-code", systemPrompt: "You monitor.", enabled: true,
       permissionProfile: { canReadFiles: false, canWriteFiles: false, canRunCommands: false, canInstallDependencies: false, canGitCommit: false, allowedDirectories: [] },
     },
+    { id: "dev", name: "Dev", role: "general", runtime: "claude-code", systemPrompt: "dev", enabled: true },
   ];
   const errors = validateAgentConfigs(configs);
   assert.deepEqual(errors, []);
@@ -614,6 +616,7 @@ test("accepts triggers with valid maxTriggersPerConversation and debounceMs", ()
       systemPrompt: "do stuff", enabled: true,
       triggers: { maxTriggersPerConversation: 10, debounceMs: 5000 },
     },
+    { id: "dev", name: "Dev", role: "general", runtime: "claude-code", systemPrompt: "dev", enabled: true },
   ];
   const errors = validateAgentConfigs(configs);
   assert.deepEqual(errors, []);
@@ -627,7 +630,8 @@ test("rejects supervisor enabled with no other agents enabled", () => {
     { id: "dev", name: "Dev", role: "developer", runtime: "claude-code", systemPrompt: "dev", enabled: false },
   ];
   const errors = validateAgentConfigs(configs);
-  assert.ok(errors.some((e) => e.includes("Supervisor cannot be enabled")), `Expected supervisor cross-validation error, got: ${JSON.stringify(errors)}`);
+  // Issue #91: Error message uses "Coordinator" instead of "Supervisor"
+  assert.ok(errors.some((e) => e.includes("Coordinator cannot be enabled")), `Expected coordinator cross-validation error, got: ${JSON.stringify(errors)}`);
 });
 
 test("accepts supervisor enabled when at least one other agent is enabled", () => {
@@ -644,7 +648,8 @@ test("rejects supervisor enabled alone (single config)", () => {
     { id: "supervisor", name: "Supervisor", role: "coordinator", runtime: "claude-code", systemPrompt: "supervise", enabled: true },
   ];
   const errors = validateAgentConfigs(configs);
-  assert.ok(errors.some((e) => e.includes("Supervisor cannot be enabled")), `Expected supervisor-alone error, got: ${JSON.stringify(errors)}`);
+  // Issue #91: Error message uses "Coordinator" instead of "Supervisor"
+  assert.ok(errors.some((e) => e.includes("Coordinator cannot be enabled")), `Expected coordinator-alone error, got: ${JSON.stringify(errors)}`);
 });
 
 test("accepts supervisor disabled when alone", () => {


### PR DESCRIPTION
## 修复内容

本 PR 修复 Issue #91，将硬编码的 agent ID 检查替换为基于角色的检查。

### Part 1: 替换硬编码 ID 检查为 role 检查

**修改文件**：
- : 将  改为 
- : 
  - 添加  映射（agentId -> role）
  - 修改  函数参数
  - 使用 role-based 检查：

**影响**：
- Issue #80 的修复现在适用于所有 coordinator-role 的 agent
- 不再依赖特定的 agent ID（如 "supervisor"）

### Part 2: 添加只允许一个 coordinator 的验证

**修改文件**： 的  函数

**新增验证**：


### Part 3: 增强 PM 角色

**修改文件**： 的 

**新的 PM 描述**：
- 描述：产品负责人：定义产品方向、挑战不合理需求、将模糊想法转化为清晰可执行的产品需求
- 系统提示词：强调产品判断、用户价值、长期产品健康

## 测试结果

- ✅ 427 个测试全部通过
- ✅ 构建成功

## 关联 Issue

Fixes #91