### PR TITLE
feat: show runtime setup commands

### DIFF
--- a/src/core/runtime-meta.ts
+++ b/src/core/runtime-meta.ts
@@ -7,18 +7,30 @@ export function runtimeKindToCliKey(runtime: string): string {
   return runtime === "claude-code" ? "claude" : runtime;
 }
 
-/** Shared runtime metadata — labels and install URLs in one place */
-export type RuntimeMeta = { label: string; installUrl: string };
+/** Shared runtime metadata — labels, setup commands, and install URLs in one place */
+export type RuntimeMeta = { label: string; installUrl: string; installCommand: string };
 
 export function runtimeMeta(runtime: string): RuntimeMeta {
   switch (runtime) {
     case "claude-code":
-      return { label: "Claude Code", installUrl: "https://docs.anthropic.com/en/docs/claude-code/quickstart" };
+      return {
+        label: "Claude Code",
+        installUrl: "https://docs.anthropic.com/en/docs/claude-code/quickstart",
+        installCommand: "npm install -g @anthropic-ai/claude-code",
+      };
     case "codex":
-      return { label: "OpenAI Codex", installUrl: "https://developers.openai.com/codex/cli" };
+      return {
+        label: "OpenAI Codex",
+        installUrl: "https://developers.openai.com/codex/cli",
+        installCommand: "npm install -g @openai/codex",
+      };
     case "codebuddy":
-      return { label: "CodeBuddy", installUrl: "https://www.codebuddy.ai/docs/cli/installation" };
+      return {
+        label: "CodeBuddy",
+        installUrl: "https://www.codebuddy.ai/docs/cli/installation",
+        installCommand: "npm install -g @tencent-ai/codebuddy-code",
+      };
     default:
-      return { label: runtime, installUrl: "" };
+      return { label: runtime, installUrl: "", installCommand: "" };
   }
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1657,6 +1657,16 @@ function RuntimeSetupBanner({ agents, isRefreshing, onRefresh }: { agents: Agent
           {agents.map((agent) => agent.label || agent.id).join("、")} 需要安装对应命令行工具。安装完成后点击重新检测即可继续使用。
         </span>
       </div>
+      <div className="runtimeSetupCommands" aria-label="运行环境安装命令">
+        {missingRuntimes.map((runtime) => {
+          const meta = runtimeMeta(runtime);
+          return (
+            <code key={runtime} className="runtimeInstallCommand">
+              {meta.installCommand}
+            </code>
+          );
+        })}
+      </div>
       <div className="runtimeSetupActions">
         {missingRuntimes.map((runtime) => {
           const meta = runtimeMeta(runtime);
@@ -2148,6 +2158,7 @@ function AgentManagerPanel({
                             return (
                               <div className="runtimeInstallHint">
                                 <span>未检测到 {meta.label}。请先安装，并确认终端中可以运行对应命令；安装后点击重新检测即可继续。</span>
+                                <code className="runtimeInstallCommand">{meta.installCommand}</code>
                                 <a href={meta.installUrl} target="_blank" rel="noopener noreferrer" className="runtimeInstallBtn">查看安装指南 ↗</a>
                                 <button type="button" className="runtimeRefreshBtn" onClick={onRefreshRuntimes} disabled={isRefreshingRuntimes}>
                                   {isRefreshingRuntimes ? "检测中..." : "重新检测"}

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -2962,6 +2962,29 @@ button:active:not(:disabled) {
   color: var(--text-primary);
 }
 
+.runtimeSetupCommands {
+  display: flex;
+  flex: 1 1 260px;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 180px;
+}
+
+.runtimeInstallCommand {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
 .runtimeSetupActions {
   display: flex;
   align-items: center;

--- a/tests/runtime-probe.test.ts
+++ b/tests/runtime-probe.test.ts
@@ -82,24 +82,28 @@ test("runtimeMeta returns label and installUrl for claude-code", () => {
   const meta = runtimeMeta("claude-code");
   assert.equal(meta.label, "Claude Code");
   assert.ok(meta.installUrl.includes("anthropic"), "should have anthropic install URL");
+  assert.ok(meta.installCommand.includes("@anthropic-ai/claude-code"), "should include Claude Code install command");
 });
 
 test("runtimeMeta returns label and installUrl for codex", () => {
   const meta = runtimeMeta("codex");
   assert.equal(meta.label, "OpenAI Codex");
   assert.ok(meta.installUrl.includes("openai"), "should have openai install URL");
+  assert.ok(meta.installCommand.includes("@openai/codex"), "should include Codex install command");
 });
 
 test("runtimeMeta returns label and installUrl for codebuddy", () => {
   const meta = runtimeMeta("codebuddy");
   assert.equal(meta.label, "CodeBuddy");
   assert.ok(meta.installUrl.includes("codebuddy"), "should have codebuddy install URL");
+  assert.ok(meta.installCommand.includes("@tencent-ai/codebuddy-code"), "should include CodeBuddy install command");
 });
 
 test("runtimeMeta returns runtime name as label for unknown runtime", () => {
   const meta = runtimeMeta("unknown");
   assert.equal(meta.label, "unknown");
   assert.equal(meta.installUrl, "");
+  assert.equal(meta.installCommand, "");
 });
 
 test("Codex probe always returns runtime: codex even with custom CODEX_CLI_PATH", async () => {


### PR DESCRIPTION
## What changed
- Added per-runtime install commands to shared runtime metadata.
- Displayed those commands in the missing-runtime banner and agent manager install hint.
- Covered the new metadata with runtime probe tests.

Closes #102.

## How verified
- `node --test --import tsx tests/runtime-probe.test.ts`
- `npm run test` (469 tests passed, 0 failed)
- `npm run build`
- Browser smoke: loaded local Orbit at `http://localhost:4317` and confirmed the agent manager renders. This machine reports all configured runtimes available, so the missing-runtime banner was not naturally visible.

## Known limitations / follow-up
- Install commands can drift when vendors change package names, so official docs links remain alongside the commands.
- No auto-install behavior is added.