### PR TITLE
test: guard workspace preset Chinese copy

### DIFF
--- a/tests/workspace-presets.test.ts
+++ b/tests/workspace-presets.test.ts
@@ -19,23 +19,34 @@ test("each preset has required fields", () => {
   }
 });
 
-test("empty preset has no systemPrompt and no rules", () => {
+test("empty preset has readable Chinese copy and no prompt rules", () => {
   const presets = getWorkspacePresets();
   const empty = presets.find((p) => p.id === PRESET_IDS.empty);
   assert.ok(empty, "should have an 'empty' preset");
+  assert.equal(empty.name, "空白工作区");
+  assert.equal(empty.description, "不预设任何提示词和规则");
   assert.equal(empty.systemPrompt, "");
   assert.deepEqual(empty.rules, []);
 });
 
-test("multi-agent-collaboration preset has systemPrompt, rules, and is recommended", () => {
+test("multi-agent-collaboration preset has readable Chinese copy", () => {
   const presets = getWorkspacePresets();
   const mac = presets.find((p) => p.id === PRESET_IDS.multiAgentCollaboration);
   assert.ok(mac, "should have a 'multi-agent-collaboration' preset");
+  assert.equal(mac.name, "多数字员工协作");
+  assert.equal(
+    mac.description,
+    "适用于多数字员工协作开发场景，内置闭环协作流程和中文回复规则",
+  );
   assert.ok(mac.systemPrompt.length > 0, "should have a non-empty systemPrompt");
   assert.ok(mac.rules.length > 0, "should have at least one rule");
   assert.equal(mac.recommended, true, "should be marked recommended");
-  assert.ok(mac.systemPrompt.includes("多数字员工"), "systemPrompt should mention 多数字员工");
-  assert.ok(mac.rules.some((r) => r.includes("中文")), "rules should mention 中文");
+  assert.ok(mac.systemPrompt.includes("多数字员工协作"), "systemPrompt should mention 多数字员工协作");
+  assert.ok(mac.systemPrompt.includes("持续闭环"), "systemPrompt should mention 持续闭环");
+  assert.ok(mac.systemPrompt.includes("架构师"), "systemPrompt should mention 架构师");
+  assert.ok(mac.systemPrompt.includes("开发人员"), "systemPrompt should mention 开发人员");
+  assert.ok(mac.systemPrompt.includes("测试人员"), "systemPrompt should mention 测试人员");
+  assert.deepEqual(mac.rules, ["用户的语言是中文，请使用中文回答用户的问题。"]);
 });
 
 test("preset ids are unique", () => {


### PR DESCRIPTION
## What changed
- Tightened `tests/workspace-presets.test.ts` to assert readable Chinese copy for the empty workspace preset.
- Added explicit readable-copy assertions for the recommended multi-agent collaboration preset name, description, system prompt keywords, and Chinese response rule.
- Left production preset behavior unchanged because the stronger assertions already pass against the current source strings.

Closes #100

## How verified
- `node --test --import tsx tests/workspace-presets.test.ts`
- `npm run test`
- `npm run build`

## Known limitations / follow-up
- This only guards workspace preset copy. README/architecture text may still render incorrectly in some Windows console/codepage views and should be handled separately if source files are confirmed to be corrupted rather than display-only mojibake.