### PR TITLE
feat: show compact agent handoff context

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -197,6 +197,7 @@ export function App() {
   }, [workspaces, state.workspace.id]);
 
   const agentsById = useMemo(() => new Map(state.agents.map((agent) => [agent.id, agent])), [state.agents]);
+  const messagesById = useMemo(() => new Map(state.messages.map((message) => [message.id, message])), [state.messages]);
   const agentIds = useMemo(() => state.agents.map((agent) => agent.id), [state.agents]);
   const hasEnabledAgent = agentIds.length > 0;
   const hasCoordinator = useMemo(() => state.agents.some((agent) => agent.role === "coordinator" && hasActiveChannelWatchTriggers(agent.triggers)), [state.agents]);
@@ -1026,6 +1027,8 @@ export function App() {
                 key={message.id}
                 message={message}
                 agent={message.agentId ? agentsById.get(message.agentId) : undefined}
+                parentMessage={message.parentMessageId ? messagesById.get(message.parentMessageId) : undefined}
+                agentsById={agentsById}
               />
             ))
           )}
@@ -1338,10 +1341,21 @@ function AgentButton(props: { agent: AgentState; selected: boolean; onClick: () 
   );
 }
 
-function MessageRow({ message, agent }: { message: ChatMessage; agent?: AgentState }) {
+function MessageRow({
+  message,
+  agent,
+  parentMessage,
+  agentsById,
+}: {
+  message: ChatMessage;
+  agent?: AgentState;
+  parentMessage?: ChatMessage;
+  agentsById: Map<AgentId, AgentState>;
+}) {
   const author = message.kind === "user" ? "You" : message.kind === "agent" ? message.agentId ?? "agent" : "system";
   const isRunning = message.status === "running";
   const isQueued = message.runStatus === "queued";
+  const handoffSummary = getAgentHandoffSummary(message, parentMessage, agentsById);
   const [cancelling, setCancelling] = useState(false);
 
   async function cancelRun() {
@@ -1394,6 +1408,7 @@ function MessageRow({ message, agent }: { message: ChatMessage; agent?: AgentSta
           {message.runIndex ? <span>run #{message.runIndex}</span> : null}
         </div>
       ) : null}
+      {handoffSummary ? <div className="handoffSummary">{handoffSummary}</div> : null}
       <div className="messageBody">
         {message.activity?.length ? <ActivityList activity={message.activity} status={message.status} /> : null}
         {message.kind === "agent" ? <MarkdownContent content={message.content} /> : <PlainText content={message.content} />}
@@ -2459,6 +2474,59 @@ function formatDuration(ms: number): string {
   const hours = Math.floor(totalMinutes / 60);
   const remainingMinutes = totalMinutes % 60;
   return `${hours}h ${remainingMinutes}m`;
+}
+
+export function getAgentHandoffSummary(
+  message: ChatMessage,
+  parentMessage: ChatMessage | undefined,
+  agentsById: ReadonlyMap<AgentId, Pick<AgentState, "id" | "label">>,
+): string | null {
+  if (message.kind !== "agent" || !message.parentMessageId) {
+    return null;
+  }
+
+  const sourceLabel = getHandoffSourceLabel(parentMessage, message.parentMessageId, agentsById);
+  const originLabel = parentMessage?.kind === "agent"
+    ? "数字员工交接"
+    : parentMessage?.kind === "system"
+      ? "系统触发"
+      : parentMessage?.kind === "user"
+        ? "用户指派"
+        : "上游消息";
+  const parts = [originLabel, `来自 ${sourceLabel}`];
+
+  if (typeof message.routeDepth === "number") {
+    parts.push(`第 ${message.routeDepth} 层`);
+  }
+
+  return parts.join(" · ");
+}
+
+function getHandoffSourceLabel(
+  source: ChatMessage | undefined,
+  fallbackMessageId: string,
+  agentsById: ReadonlyMap<AgentId, Pick<AgentState, "id" | "label">>,
+): string {
+  if (!source) {
+    return `消息 ${formatShortMessageId(fallbackMessageId)}`;
+  }
+
+  if (source.kind === "agent") {
+    const agentId = source.agentId ?? "agent";
+    const label = source.agentId ? agentsById.get(source.agentId)?.label : undefined;
+    return `${label ?? agentId} 的消息 ${formatShortMessageId(source.id)}`;
+  }
+
+  if (source.kind === "system") {
+    return `系统消息 ${formatShortMessageId(source.id)}`;
+  }
+
+  return `用户消息 ${formatShortMessageId(source.id)}`;
+}
+
+function formatShortMessageId(messageId: string): string {
+  const suffix = messageId.includes("_") ? messageId.split("_").at(-1) : messageId.slice(-6);
+  return `#${suffix || messageId}`;
 }
 
 function scrollMessagesToBottom(element: HTMLDivElement | null): void {

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1041,6 +1041,13 @@ button:active:not(:disabled) {
   color: var(--text-muted);
 }
 
+.handoffSummary {
+  margin-bottom: 8px;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 500;
+}
+
 .messageBody {
   overflow-wrap: anywhere;
   color: var(--text-secondary);

--- a/tests/app-message-pagination.test.ts
+++ b/tests/app-message-pagination.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { getWorkspaceCreationAction, mergeOlderMessagesPage } from "../src/ui/App.tsx";
+import { getAgentHandoffSummary, getWorkspaceCreationAction, mergeOlderMessagesPage } from "../src/ui/App.tsx";
 import type { AppState, ChatMessage, MessagePage } from "../src/shared/types.ts";
 
 function message(id: string, content: string): ChatMessage {
@@ -50,4 +50,65 @@ test("mergeOlderMessagesPage prepends older messages and deduplicates current me
 
 test("workspace creation falls back to blank creation when presets are unavailable", () => {
   assert.deepEqual(getWorkspaceCreationAction([]), { kind: "create" });
+});
+
+test("agent handoff summary describes direct user assignments", () => {
+  const source = message("msg_000001", "@developer: implement this");
+  const agentMessage: ChatMessage = {
+    id: "msg_000002",
+    kind: "agent",
+    agentId: "developer",
+    content: "developer is working...",
+    createdAt: "2026-01-01T00:00:02.000Z",
+    parentMessageId: source.id,
+    routeDepth: 1,
+  };
+
+  assert.equal(
+    getAgentHandoffSummary(agentMessage, source, new Map()),
+    "用户指派 · 来自 用户消息 #000001 · 第 1 层",
+  );
+});
+
+test("agent handoff summary describes agent-to-agent handoff without internal route names", () => {
+  const source: ChatMessage = {
+    id: "msg_000010",
+    kind: "agent",
+    agentId: "pm",
+    content: "@developer: build this",
+    createdAt: "2026-01-01T00:00:10.000Z",
+  };
+  const agentMessage: ChatMessage = {
+    id: "msg_000011",
+    kind: "agent",
+    agentId: "developer",
+    content: "developer is working...",
+    createdAt: "2026-01-01T00:00:11.000Z",
+    parentMessageId: source.id,
+    routeDepth: 2,
+  };
+  const agentsById = new Map([["pm", { id: "pm", label: "产品经理" }]]);
+
+  const summary = getAgentHandoffSummary(agentMessage, source, agentsById);
+
+  assert.equal(summary, "数字员工交接 · 来自 产品经理 的消息 #000010 · 第 2 层");
+  assert.ok(!summary?.includes("routeState"));
+  assert.ok(!summary?.includes("parentMessageId"));
+});
+
+test("agent handoff summary falls back when parent message is not loaded", () => {
+  const agentMessage: ChatMessage = {
+    id: "msg_000011",
+    kind: "agent",
+    agentId: "developer",
+    content: "developer is working...",
+    createdAt: "2026-01-01T00:00:11.000Z",
+    parentMessageId: "msg_000010",
+    routeDepth: 2,
+  };
+
+  assert.equal(
+    getAgentHandoffSummary(agentMessage, undefined, new Map()),
+    "上游消息 · 来自 消息 #000010 · 第 2 层",
+  );
 });


### PR DESCRIPTION
﻿## What changed
- Adds a compact handoff summary line to agent message cards using existing `parentMessageId` and `routeDepth` metadata.
- Summaries distinguish user assignments, 数字员工 handoffs, system-triggered runs, and unloaded parent-message fallbacks without exposing internal field names.
- Adds focused unit coverage for direct assignment, agent-to-agent handoff, and missing-parent fallback.

## How verified
- `node --test --import tsx tests/app-message-pagination.test.ts`
- `npm run test` (472 assertions passed)
- `npm run build`
- Browser plugin smoke validation was attempted against `http://127.0.0.1:4318`, but the Browser runtime blocked the localhost page with its URL policy and showed a crash page. I did not use an alternate browser surface to bypass that policy.

## Known limitations / follow-up
- This is the compact message-level slice for #101. It does not build the broader task progress tracker from #93.
- If a parent message is not loaded in the current page, the UI shows a generic upstream message id fallback instead of guessing the true origin.

Closes #101.
