### PR TITLE
fix: enforce Codex runtime permission profiles

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -187,11 +187,15 @@ Codex uses the user's normal Codex CLI home. Orbit does not create per-agent `CO
 
 ## CLI Runtimes
 
-Orbit runs each backend through a runtime adapter. Codex uses:
+Orbit runs each backend through a runtime adapter. Codex maps each agent's permission profile to its native sandbox:
 
 ```text
-codex exec --json --cd <cwd> --sandbox danger-full-access --dangerously-bypass-approvals-and-sandbox -
+no write access        -> codex exec --json --cd <cwd> --sandbox read-only -
+restricted write      -> codex exec --json --cd <cwd> --sandbox workspace-write [--add-dir <dir>] -
+all permissions       -> codex exec --json --cd <cwd> --sandbox danger-full-access --dangerously-bypass-approvals-and-sandbox -
 ```
+
+Resumed Codex sessions receive the same sandbox arguments before the `resume` subcommand. Codex sandbox modes do not express every Orbit permission independently, so install and git-commit restrictions remain in the private agent context until they can be enforced with stable native policy controls.
 
 Claude Code uses:
 

--- a/src/core/codex-cli-runtime.ts
+++ b/src/core/codex-cli-runtime.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import type { AgentId } from "../shared/types.ts";
+import type { AgentId, PermissionProfile } from "../shared/types.ts";
 import type { AgentRuntime, AgentRuntimeRunHandle } from "./agent-runtime.ts";
 import { interruptProcessTree } from "./claude-cli-runtime.ts";
 import { extractReadableText } from "./ansi-text-extractor.ts";
@@ -13,41 +13,46 @@ export type CodexCliRunOptions = {
   agentId: AgentId;
   cwd: string;
   prompt: string;
-  permissionProfile?: unknown;
+  permissionProfile: PermissionProfile;
   resumeSessionId?: string;
   env?: NodeJS.ProcessEnv;
   onOutput?: (text: string) => void;
   imagePaths?: string[];
 };
 
-export function buildCodexCliArgs(options: { cwd: string; resumeSessionId?: string; imagePaths?: string[] }): string[] {
-  if (options.resumeSessionId) {
-    const args = [
-      "exec",
-      "resume",
-      "--json",
-      "--dangerously-bypass-approvals-and-sandbox",
-      options.resumeSessionId,
-      "-",
-    ];
-    if (options.imagePaths?.length) {
-      for (const imgPath of options.imagePaths) {
-        args.push("--image", imgPath);
-      }
-    }
-    return args;
-  }
-
+export function buildCodexCliArgs(options: {
+  cwd: string;
+  permissionProfile: PermissionProfile;
+  resumeSessionId?: string;
+  imagePaths?: string[];
+}): string[] {
+  const fullyTrusted = isFullyTrusted(options.permissionProfile);
+  const sandbox = fullyTrusted
+    ? "danger-full-access"
+    : options.permissionProfile.canWriteFiles ? "workspace-write" : "read-only";
   const args = [
     "exec",
     "--json",
     "--cd",
     options.cwd,
     "--sandbox",
-    "danger-full-access",
-    "--dangerously-bypass-approvals-and-sandbox",
-    "-",
+    sandbox,
   ];
+
+  if (fullyTrusted) {
+    args.push("--dangerously-bypass-approvals-and-sandbox");
+  } else if (sandbox === "workspace-write") {
+    for (const directory of options.permissionProfile.allowedDirectories) {
+      args.push("--add-dir", directory);
+    }
+  }
+
+  if (options.resumeSessionId) {
+    args.push("resume", options.resumeSessionId, "-");
+  } else {
+    args.push("-");
+  }
+
   if (options.imagePaths?.length) {
     for (const imgPath of options.imagePaths) {
       args.push("--image", imgPath);
@@ -58,7 +63,12 @@ export function buildCodexCliArgs(options: { cwd: string; resumeSessionId?: stri
 
 export function runCodexCli(options: CodexCliRunOptions): AgentRuntimeRunHandle {
   const command = buildCodexCliCommand(
-    { cwd: options.cwd, resumeSessionId: options.resumeSessionId, imagePaths: options.imagePaths },
+    {
+      cwd: options.cwd,
+      permissionProfile: options.permissionProfile,
+      resumeSessionId: options.resumeSessionId,
+      imagePaths: options.imagePaths,
+    },
     options.env ?? process.env,
   );
   const env = createCodexEnv(options.agentId, options.env ?? process.env);
@@ -146,11 +156,24 @@ export function runCodexCli(options: CodexCliRunOptions): AgentRuntimeRunHandle 
 }
 
 export function buildCodexCliCommand(
-  options: { cwd: string; resumeSessionId?: string; imagePaths?: string[] },
+  options: {
+    cwd: string;
+    permissionProfile: PermissionProfile;
+    resumeSessionId?: string;
+    imagePaths?: string[];
+  },
   env: NodeJS.ProcessEnv = process.env,
 ): { file: string; args: string[] } {
   const args = buildCodexCliArgs(options);
   return { file: resolveCodexCommand(env), args };
+}
+
+function isFullyTrusted(profile: PermissionProfile): boolean {
+  return profile.canReadFiles &&
+    profile.canWriteFiles &&
+    profile.canRunCommands &&
+    profile.canInstallDependencies &&
+    profile.canGitCommit;
 }
 
 export function extractCodexCliFinalAnswer(output: string): { text: string; sessionId?: string } {

--- a/tests/codex-cli-runtime.test.ts
+++ b/tests/codex-cli-runtime.test.ts
@@ -9,33 +9,86 @@ import {
   extractCodexSessionId,
   resolveCodexCommand,
 } from "../src/core/codex-cli-runtime.ts";
+import type { PermissionProfile } from "../src/shared/types.ts";
 
-test("builds non-interactive Codex exec args without resume", () => {
-  assert.deepEqual(buildCodexCliArgs({ cwd: "D:/workspace" }), [
+const readOnlyProfile: PermissionProfile = {
+  canReadFiles: true,
+  canWriteFiles: false,
+  canRunCommands: true,
+  canInstallDependencies: false,
+  canGitCommit: false,
+  allowedDirectories: ["."],
+};
+
+const workspaceWriteProfile: PermissionProfile = {
+  ...readOnlyProfile,
+  canWriteFiles: true,
+  allowedDirectories: [".", "D:/shared"],
+};
+
+const fullAccessProfile: PermissionProfile = {
+  canReadFiles: true,
+  canWriteFiles: true,
+  canRunCommands: true,
+  canInstallDependencies: true,
+  canGitCommit: true,
+  allowedDirectories: ["."],
+};
+
+test("uses a read-only sandbox without bypass for non-writing agents", () => {
+  assert.deepEqual(buildCodexCliArgs({ cwd: "D:/workspace", permissionProfile: readOnlyProfile }), [
     "exec",
     "--json",
     "--cd",
     "D:/workspace",
     "--sandbox",
-    "danger-full-access",
-    "--dangerously-bypass-approvals-and-sandbox",
+    "read-only",
     "-",
   ]);
 });
 
-test("builds Codex resume args with session id", () => {
-  assert.deepEqual(buildCodexCliArgs({ cwd: "D:/workspace", resumeSessionId: "sess-abc" }), [
+test("uses the same read-only sandbox when resuming a session", () => {
+  assert.deepEqual(buildCodexCliArgs({ cwd: "D:/workspace", permissionProfile: readOnlyProfile, resumeSessionId: "sess-abc" }), [
     "exec",
-    "resume",
     "--json",
-    "--dangerously-bypass-approvals-and-sandbox",
+    "--cd",
+    "D:/workspace",
+    "--sandbox",
+    "read-only",
+    "resume",
     "sess-abc",
     "-",
   ]);
 });
 
+test("maps writable directories into a workspace-write sandbox", () => {
+  assert.deepEqual(buildCodexCliArgs({ cwd: "D:/workspace", permissionProfile: workspaceWriteProfile }), [
+    "exec",
+    "--json",
+    "--cd",
+    "D:/workspace",
+    "--sandbox",
+    "workspace-write",
+    "--add-dir",
+    ".",
+    "--add-dir",
+    "D:/shared",
+    "-",
+  ]);
+});
+
+test("only fully trusted profiles bypass approvals and sandboxing", () => {
+  const args = buildCodexCliArgs({ cwd: "D:/workspace", permissionProfile: fullAccessProfile });
+
+  assert.ok(args.includes("danger-full-access"));
+  assert.ok(args.includes("--dangerously-bypass-approvals-and-sandbox"));
+});
+
 test("builds a spawnable Codex command", () => {
-  const command = buildCodexCliCommand({ cwd: "D:/workspace" }, { ORBIT_CODEX_PATH: "C:/codex/bin/codex.exe" });
+  const command = buildCodexCliCommand(
+    { cwd: "D:/workspace", permissionProfile: readOnlyProfile },
+    { ORBIT_CODEX_PATH: "C:/codex/bin/codex.exe" },
+  );
 
   assert.equal(command.file, "C:/codex/bin/codex.exe");
   assert.ok(command.args.includes("exec"));


### PR DESCRIPTION
## What changed
- maps Codex agents without write access to the native `read-only` sandbox
- maps restricted writers to `workspace-write` and forwards configured writable directories with `--add-dir`
- reserves `danger-full-access` and approval bypass for profiles with every Orbit permission enabled
- applies the same sandbox arguments to resumed sessions and documents the remaining policy boundary

## Why
Orbit previously passed every Codex run through `danger-full-access` with approval and sandbox bypass, even when the agent's permission profile denied writes or commands. This made the UI configuration advisory rather than runtime-enforced.

## How verified
- `node --test --import tsx tests/codex-cli-runtime.test.ts` (30/30 passed)
- `npm run test` (471 tests passed)
- `npm run build`
- `codex exec --json --cd . --sandbox read-only resume --help` with Codex CLI 0.131.0

## Known limitations / follow-up
- This is the first Codex runtime slice of #72 and does not close the issue.
- Codex sandbox modes cannot independently enforce every Orbit flag. In particular, install and git-commit restrictions remain in the private agent context until stable native policy controls are integrated.
- Claude Code native permission and system-prompt mapping remains follow-up work in #72.

Refs #72.