### PR TITLE
fix: run every test in default verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "dev": "tsx src/server/index.ts",
     "build": "tsc --noEmit && vite build && bun build src/standalone-entry.ts --compile --bytecode --minify --sourcemap=none --outfile=dist/bin/orbit",
     "build:all": "tsc --noEmit && vite build && node scripts/build-standalone.mjs --all",
-    "test": "node --test --import tsx tests/mention-router.test.ts tests/message-store.test.ts tests/message-router.test.ts tests/ansi-text-extractor.test.ts tests/terminal-transcript-store.test.ts tests/history-retention.test.ts tests/app-message-pagination.test.ts tests/claude-output-detector.test.ts tests/claude-cli-runtime.test.ts tests/codex-cli-runtime.test.ts tests/codebuddy-cli-runtime.test.ts tests/agent-profiles.test.ts tests/agent-registry.test.ts tests/agent-context-builder.test.ts tests/agent-history-builder.test.ts tests/run-manager.test.ts tests/session-store.test.ts tests/agent-session.test.ts tests/workspace-store.test.ts tests/conversation-store.test.ts tests/markdown-renderer.test.ts tests/agent-config-store.test.ts tests/workspace-config-store.test.ts tests/workspace-agent-presets.test.ts tests/runtime-probe.test.ts tests/port-recovery.test.ts tests/package-manifest.test.ts tests/channel-watch.test.ts tests/interrupt-message.test.ts tests/license.test.ts tests/workspace-presets.test.ts tests/preset-match.test.ts",
-    "test:glob": "node --test --import tsx tests/*.test.ts",
+    "test": "node scripts/run-tests.mjs",
+    "test:glob": "npm run test",
     "prepublishOnly": "npm run test && npm run build"
   },
   "dependencies": {

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,0 +1,26 @@
+import { readdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const testsDirectory = join(repositoryRoot, "tests");
+const testFiles = readdirSync(testsDirectory, { withFileTypes: true })
+  .filter((entry) => entry.isFile() && entry.name.endsWith(".test.ts"))
+  .map((entry) => relative(repositoryRoot, join(testsDirectory, entry.name)))
+  .sort();
+
+if (testFiles.length === 0) {
+  throw new Error("No test files found in tests/*.test.ts");
+}
+
+const result = spawnSync(process.execPath, ["--test", "--import", "tsx", ...testFiles], {
+  cwd: repositoryRoot,
+  stdio: "inherit",
+});
+
+if (result.error) {
+  throw result.error;
+}
+
+process.exitCode = result.status ?? 1;

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -30,8 +30,9 @@ test("package has build script using Bun compile", () => {
   assert.match(manifest.scripts?.build ?? "", /--sourcemap=none/);
 });
 
-test("default test script includes preset matching coverage", () => {
+test("default test script uses complete cross-platform discovery", () => {
   const manifest = readPackageJson();
 
-  assert.match(manifest.scripts?.test ?? "", /tests\/preset-match\.test\.ts/);
+  assert.equal(manifest.scripts?.test, "node scripts/run-tests.mjs");
+  assert.equal(manifest.scripts?.["test:glob"], "npm run test");
 });


### PR DESCRIPTION
## What changed
- Replace the hand-maintained default test-file list with a dependency-free Node launcher that discovers and deterministically sorts every top-level `tests/*.test.ts` file.
- Make `test:glob` delegate to the same cross-platform command instead of relying on shell glob expansion, which fails on Windows.
- Add a package-manifest regression assertion that prevents the default verification command from returning to a partial explicit list.

## Why
The repository currently has 40 top-level test files, but `npm run test` referenced only 32. The missing suites covered attachment security, agent configuration sync/copy, conversation ordering, draft limits/deletion, file magic validation, and transcript settings. A green local or CI result therefore did not represent the full test suite.

## How verified
- Red: `node --test --import tsx tests/package-manifest.test.ts` failed against the old explicit script as expected.
- Green: `node --test --import tsx tests/package-manifest.test.ts` passed (3/3).
- `npm run test` passed: 40 files discovered, 522 tests passed, 0 failed.
- `npm run build` passed: TypeScript, Vite UI, and Bun standalone executable.
- `git diff --check` passed.

## Known limitations / follow-up
- Discovery is intentionally limited to top-level `tests/*.test.ts`; recursive test directories are not part of the current repository convention.
- `npm install` reported 1 low and 1 high audit finding. Dependency upgrades are unrelated to this scoped verification fix and were not included.

Closes #108.