### PR TITLE
fix: start next queued run when a running run is cancelled (T-1)

### DIFF
--- a/src/core/run-manager.ts
+++ b/src/core/run-manager.ts
@@ -195,6 +195,14 @@ export class RunManager {
       runId: run.id,
       resultMessageId: updated.id,
     });
+
+    // A running run was interrupted, freeing the agent's slot — start the next
+    // queued run so the queue doesn't stall (and FIFO is preserved via shift).
+    // Late settlement of the killed run is no-op: complete()/fail() early-return
+    // on status === "cancelled", so they won't touch the newly-active run.
+    if (phase === "during execution") {
+      this.startNext(run.agentId);
+    }
   }
 
   /** Interrupt the current auto-collaboration chain without killing running CLI processes.

--- a/tests/run-manager.test.ts
+++ b/tests/run-manager.test.ts
@@ -639,6 +639,58 @@ test("cancel a running run triggers interrupt and succeeds", async () => {
   assert.ok(msg?.activity?.some((a) => "text" in a && a.text === "Interrupted by user during execution."));
 });
 
+test("cancelling a running run starts the next queued run (no stall, FIFO preserved)", async () => {
+  const messages = new MessageStore();
+  const eventBus = new EventBus();
+  const first = deferred();   // R1, interrupted
+  const second = deferred();  // R2, should start after R1 is cancelled
+  const pending = [first, second];
+  const calls: Array<{ runId: string; prompt: string }> = [];
+
+  const manager = new RunManager({
+    conversationId: "test-conv",
+    messages,
+    eventBus,
+    agents: {
+      get() {
+        return {
+          send(runId: string, prompt: string) {
+            calls.push({ runId, prompt });
+            return pending.shift()?.promise ?? Promise.reject(new Error("unexpected run"));
+          },
+          interrupt() { return true; },
+        };
+      },
+    },
+    buildPrompt(_agentId, prompt) { return prompt; },
+    onRunCompleted() {},
+  });
+
+  const source = createSourceMessage();
+  const r1 = manager.enqueue("developer", "R1", source);   // running
+  const r2 = manager.enqueue("developer", "R2", source);   // queued behind r1
+  assert.equal(r2.status, "queued");
+
+  // Interrupt the running R1 — R2 must start instead of stalling forever.
+  manager.cancel(r1.id);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.deepEqual(calls.map((c) => c.prompt), ["R1", "R2"], "R2 should start after R1 is cancelled");
+  assert.equal(r2.status, "running", "R2 should now be running");
+
+  // The killed R1 process may settle late; it must not disturb the now-running R2.
+  first.reject(new Error("killed"));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(r2.status, "running", "late settlement of cancelled R1 must not stop R2");
+
+  // FIFO: a new R3 enqueued after must queue behind R2, not jump ahead of it.
+  const r3 = manager.enqueue("developer", "R3", source);
+  assert.equal(r3.status, "queued", "R3 must queue behind the running R2 (FIFO preserved)");
+
+  second.resolve({ content: "R2 done" });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
 test("cancel a non-existent run returns not_found error", async () => {
   const messages = new MessageStore();
   const eventBus = new EventBus();


### PR DESCRIPTION
Fixes **T-1** from the code review: cancelling a *running* run stalled the per-agent queue and broke FIFO.

## Bug
`markCancelled(run, "during execution")` deleted the agent's active slot but never called `startNext`; `complete()`/`fail()` early-return on `status === "cancelled"`. So when a running run was interrupted while queued runs waited behind it:
- the next run stayed `queued` forever (agent showed idle, `hasQueuedRuns()` stayed `true`), and
- a later task enqueued for that agent started immediately and **jumped ahead** of the stuck queued run (FIFO break).

Reproduced via the UI 运行卡片「打断」button (`cancelRun()` → `POST /api/runs/:id/cancel`).

## Fix (1 line of logic)
Call `this.startNext(run.agentId)` at the end of `markCancelled` **only for the `during execution` phase** (queued-run cancellation is unchanged — the active run is still running). Safe because we just freed the slot; the killed run's late settlement is a no-op thanks to the existing `cancelled`-status guards in `complete()`/`fail()`.

## Test (failing → passing)
New test `cancelling a running run starts the next queued run (no stall, FIFO preserved)`:
- enqueue R1 (running) + R2 (queued) for one agent → interrupt R1 → assert R2 starts (`send` called for R2), R2 is `running`;
- reject R1's late-settling promise → assert R2 still `running`;
- enqueue R3 → assert R3 is `queued` behind R2 (FIFO preserved).

Existing cancel/interrupt tests remain green (queued-run cancel, running-run cancel with empty queue, `interruptCurrentChain`).

## Verification
- `npm run test` → **529 pass / 0 fail** (+1 new test; branched from latest `main`, so pre-#112 baseline).
- `npm run build` → tsc + Vite + Bun compile all green.

Branched from `main` per coordinator (independent of PR #112 — different region of `run-manager.ts`; at most a light rebase if #112 lands first). Ready for architect review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)