### PR TITLE
fix: surface CLI failure clues instead of generic transcript fallback (T-2)

### DIFF
--- a/src/core/run-manager.ts
+++ b/src/core/run-manager.ts
@@ -739,32 +739,57 @@ function stripRawJsonNoise(value: string): string {
     return value;
   }
 
-  const parsedMessages = parseJsonObjects(value)
-    .map((event) => {
-      const record = event as {
-        type?: unknown;
-        message?: { content?: unknown };
-        error?: unknown;
-        result?: unknown;
-        item?: { type?: unknown; exit_code?: unknown; status?: unknown; aggregated_output?: unknown };
-      };
+  const structured: string[] = [];
+  const assistantText: string[] = [];
 
-      if (typeof record.error === "string") return record.error;
-      if (typeof record.message === "string") return record.message;
-      if (typeof record.result === "string") return record.result;
-      if (record.item?.type === "command_execution" && record.item.status === "failed") {
-        const output = typeof record.item.aggregated_output === "string" ? record.item.aggregated_output : "";
-        return output || `Command failed${typeof record.item.exit_code === "number" ? ` with exit ${record.item.exit_code}` : ""}`;
+  for (const event of parseJsonObjects(value)) {
+    const record = event as {
+      type?: unknown;
+      message?: unknown;
+      error?: unknown;
+      result?: unknown;
+      item?: { type?: unknown; exit_code?: unknown; status?: unknown; aggregated_output?: unknown };
+    };
+
+    if (typeof record.error === "string" && record.error.trim()) {
+      structured.push(record.error);
+    }
+    if (typeof record.message === "string" && record.message.trim()) {
+      structured.push(record.message);
+    }
+    if (typeof record.result === "string" && record.result.trim()) {
+      structured.push(record.result);
+    }
+    if (record.item?.type === "command_execution" && record.item.status === "failed") {
+      const output = typeof record.item.aggregated_output === "string" ? record.item.aggregated_output : "";
+      structured.push(output || `Command failed${typeof record.item.exit_code === "number" ? ` with exit ${record.item.exit_code}` : ""}`);
+    }
+
+    // Surface assistant text the CLI streamed before crashing. When a run dies
+    // mid-flight there is often no result/error event — this partial answer is
+    // usually the most useful clue, and must not be silently discarded.
+    if (record.type === "assistant" && typeof record.message === "object" && record.message !== null) {
+      const content = (record.message as { content?: unknown }).content;
+      if (Array.isArray(content)) {
+        for (const part of content as Array<{ type?: unknown; text?: unknown }>) {
+          if (part?.type === "text" && typeof part.text === "string" && part.text.trim()) {
+            assistantText.push(part.text);
+          }
+        }
       }
-      return "";
-    })
-    .filter(Boolean);
-
-  if (parsedMessages.length > 0) {
-    return parsedMessages.join(" ");
+    }
   }
 
-  return "Runtime failed. Check the transcript for details.";
+  if (structured.length > 0) {
+    return structured.join(" ");
+  }
+  if (assistantText.length > 0) {
+    return assistantText.join(" ");
+  }
+
+  // Nothing extractable: be specific that the CLI produced no final result
+  // rather than showing a bare generic apology that hides the failure.
+  return "运行异常终止：未收到数字员工的最终结果，请查看运行日志了解详情。";
 }
 
 function findLastToolName(activities: AgentActivityEvent[]): string {

--- a/tests/run-manager.test.ts
+++ b/tests/run-manager.test.ts
@@ -829,6 +829,83 @@ test("run failures store a concise error instead of raw stream output", async ()
   assert.ok(lastActivity?.type === "status" && lastActivity.text.length < 2_100);
 });
 
+test("CLI crash that streamed assistant text surfaces that text, not the generic fallback", async () => {
+  const messages = new MessageStore();
+  const eventBus = new EventBus();
+  const failure = deferred();
+
+  const manager = new RunManager({
+    conversationId: "test-conv",
+    messages,
+    eventBus,
+    agents: {
+      get() {
+        return { send() { return failure.promise; }, interrupt() { return true; } };
+      },
+    },
+    buildPrompt(_agentId, prompt) { return prompt; },
+    onRunCompleted() {},
+  });
+
+  const run = manager.enqueue("developer", "first", createSourceMessage());
+  // Non-zero exit with incomplete stream-json: an assistant text event was
+  // streamed, but there is no result/error event to extract.
+  const partial = JSON.stringify({
+    type: "assistant",
+    message: { content: [{ type: "text", text: "I was halfway through editing src/app.ts when the process died." }] },
+  });
+  failure.reject(new Error(partial));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const failed = messages.get(run.resultMessageId);
+  assert.equal(failed?.status, "error");
+  assert.ok(
+    failed?.content.includes("I was halfway through editing src/app.ts"),
+    `expected the streamed assistant text in the failure content, got: ${failed?.content}`,
+  );
+  assert.ok(
+    !failed?.content.includes("Runtime failed. Check the transcript"),
+    `expected not to fall back to the generic message, got: ${failed?.content}`,
+  );
+});
+
+test("CLI crash with no extractable signal gives a specific clue, not the generic fallback", async () => {
+  const messages = new MessageStore();
+  const eventBus = new EventBus();
+  const failure = deferred();
+
+  const manager = new RunManager({
+    conversationId: "test-conv",
+    messages,
+    eventBus,
+    agents: {
+      get() {
+        return { send() { return failure.promise; }, interrupt() { return true; } };
+      },
+    },
+    buildPrompt(_agentId, prompt) { return prompt; },
+    onRunCompleted() {},
+  });
+
+  const run = manager.enqueue("developer", "first", createSourceMessage());
+  // Non-zero exit with stream-json that carries no error/result/assistant signal.
+  const noise = JSON.stringify({ type: "system", subtype: "hook_started", hook_id: "x".repeat(200) });
+  failure.reject(new Error(noise));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const failed = messages.get(run.resultMessageId);
+  assert.equal(failed?.status, "error");
+  assert.ok(
+    !failed?.content.includes("Runtime failed. Check the transcript"),
+    `expected not to fall back to the generic message, got: ${failed?.content}`,
+  );
+  assert.ok(
+    /运行异常终止|未收到.*最终结果/.test(failed?.content ?? ""),
+    `expected a specific no-result clue, got: ${failed?.content}`,
+  );
+  assert.ok(!failed?.content.includes("hook_id"), "raw JSON fields should not leak into content");
+});
+
 test("interruptCurrentChain cancels all queued runs", async () => {
   const messages = new MessageStore();
   const eventBus = new EventBus();


### PR DESCRIPTION
Fixes **T-2** (last item from the code review): when a CLI crashed mid-run, the real failure cause was swallowed into the generic \"Runtime failed. Check the transcript for details.\" and the user had to dig through the transcript.

## Bug
On non-zero exit the runtimes reject with `stderr || stdout || "<Kind> CLI exited with code N"`. When stderr was empty and stdout was incomplete stream-json (an assistant text event streamed but **no** `result`/`error`/`message`-string event), `stripRawJsonNoise` (`run-manager.ts`) extracted nothing and returned the bare generic fallback — silently discarding the partial answer the user actually needed.

## Fix (`run-manager.ts` `stripRawJsonNoise`)
Priority: **structured error/result/command-failure** → **streamed assistant text** → **specific no-result message**.
- New: extract assistant text (text parts of `type:"assistant"` `message.content`), so a mid-run crash surfaces the partial answer instead of dropping it.
- New: when nothing is extractable, state specifically that the CLI produced no final result (product-term Chinese, no `run`/`supervisor` codewords — aligned with PR #112's convention) instead of the generic apology.
- Unchanged: stderr and plain-text errors still pass through verbatim; exit-code-only fallback still works. Also tightened extraction to ignore whitespace-only fields.

Scope is `stripRawJsonNoise` only — a different region of `run-manager.ts` than #112 (copy strings) and #113 (`markCancelled` tail), so merges cleanly (at most a light rebase).

## Tests (failing → passing)
- CLI crash with streamed assistant text → failure content contains that text, not the generic fallback.
- CLI crash with pure-noise stream-json → a specific no-result clue, not the generic fallback; no raw JSON fields leak.
- Existing \"run failures store a concise error instead of raw stream output\" stays green.

## Verification
- `npm run test` → **530 pass / 0 fail** (+2 new; branched from latest `main`).
- `npm run build` → tsc + Vite + Bun compile all green.

Ready for architect review; then tester. This closes out the review (I-1, I-2, T-1, T-2 all addressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)