### PR TITLE
ci: automate private GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,171 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify tag and main ancestry
+        shell: bash
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            node scripts/verify-release-tag.mjs "$GITHUB_REF_NAME"
+            git fetch origin main:refs/remotes/origin/main
+            tag_commit="$(git rev-list -n 1 "$GITHUB_REF_NAME")"
+            git merge-base --is-ancestor "$tag_commit" origin/main || {
+              echo "Release tag must point to a commit contained in origin/main." >&2
+              exit 1
+            }
+          else
+            package_version="$(node -p "require('./package.json').version")"
+            node scripts/verify-release-tag.mjs "v${package_version}"
+          fi
+
+      - name: Run tests
+        run: npm run test
+
+  build:
+    name: Build ${{ matrix.asset }}
+    needs: verify
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: windows
+            asset: windows-x64
+            binary: orbit.exe
+            archive: zip
+          - platform: linux
+            asset: linux-x64
+            binary: orbit
+            archive: tar.gz
+          - platform: macos
+            asset: macos-x64
+            binary: orbit
+            archive: tar.gz
+          - platform: macosArm
+            asset: macos-arm64
+            binary: orbit
+            archive: tar.gz
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build UI and standalone binary
+        shell: bash
+        run: |
+          npx tsc --noEmit
+          npx vite build
+          node scripts/build-standalone.mjs --platform=${{ matrix.platform }}
+
+      - name: Package release asset
+        shell: bash
+        env:
+          ASSET: ${{ matrix.asset }}
+          BINARY: ${{ matrix.binary }}
+          ARCHIVE: ${{ matrix.archive }}
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          package="orbit-${version}-${ASSET}"
+          mkdir -p "release/${package}/dist/bin"
+          cp "dist/bin/${BINARY}" "release/${package}/dist/bin/${BINARY}"
+          cp -R dist/ui "release/${package}/dist/ui"
+          if [[ "${BINARY}" != *.exe ]]; then
+            chmod +x "release/${package}/dist/bin/${BINARY}"
+          fi
+          if [[ "${ARCHIVE}" == "zip" ]]; then
+            (cd release && zip -qr "${package}.zip" "${package}")
+          else
+            tar -C release -czf "release/${package}.tar.gz" "${package}"
+          fi
+          rm -rf "release/${package}"
+
+      - name: Upload packaged asset
+        uses: actions/upload-artifact@v4
+        with:
+          name: orbit-${{ matrix.asset }}
+          path: release/*
+          if-no-files-found: error
+          retention-days: 7
+
+  release:
+    name: Publish private GitHub Release
+    needs: build
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download packaged assets
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          merge-multiple: true
+
+      - name: Generate checksums
+        shell: bash
+        run: |
+          cd release-assets
+          sha256sum orbit-* > SHA256SUMS.txt
+
+      - name: Create or update release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" release-assets/* --clobber --repo "$GITHUB_REPOSITORY"
+          else
+            gh release create "$GITHUB_REF_NAME" release-assets/* \
+              --verify-tag \
+              --title "Orbit $GITHUB_REF_NAME" \
+              --generate-notes \
+              --repo "$GITHUB_REPOSITORY"
+          fi

--- a/docs/standalone-build.md
+++ b/docs/standalone-build.md
@@ -1,6 +1,6 @@
-# npm 包安装
+# 构建与私有发布
 
-Orbit 通过 npm 包分发，内嵌 Bun 编译的独立可执行文件。
+Orbit 通过私有 GitHub Release 分发，发布包包含 Bun 编译的独立可执行文件和 UI 静态资源。
 
 ## 发布前构建
 
@@ -12,7 +12,7 @@ npm run build
 - `dist/bin/orbit.exe`（Windows）或 `dist/bin/orbit`（Linux/macOS）— 字节码编译的可执行文件
 - `dist/ui/` — UI 静态资源
 
-## 打包与安装
+## 本地 npm 打包验证
 
 ```powershell
 # 打包为 tgz
@@ -24,26 +24,55 @@ npm install -g .\orbit-<version>.tgz
 
 版本号由 `package.json` 的 `version` 字段决定。
 
-## 发布到 npm
+## GitHub Release 自动发布
+
+仓库通过 `.github/workflows/release.yml` 响应语义化版本 tag，例如 `v0.9.5`：
+
+1. 校验 tag 与 `package.json` 版本一致，且 tag 指向 `main` 已包含的提交。
+2. 运行完整测试。
+3. 构建 Windows x64、Linux x64、macOS x64 和 macOS ARM64 独立包。
+4. 为每个平台打包可执行文件与 `ui/` 静态资源，并生成 SHA-256 校验文件。
+5. 创建 GitHub Release 并上传所有附件；失败的测试或构建不会创建 Release。
+
+发布步骤：
 
 ```powershell
-npm publish
+git checkout main
+git pull --ff-only origin main
+git tag -a v0.9.5 -m "Orbit v0.9.5"
+git push origin v0.9.5
 ```
 
-`prepublishOnly` 钩子会自动运行测试和构建。
+tag 必须在版本修改和发布工作流合并到 `main` 后再推送。私有仓库的 Release 与附件仍受仓库读取权限保护；只有获授权并登录 GitHub 的用户可以访问。发布给用户的二进制仍应视为可被复制或分析的分发物。
 
-## 用户安装
+首次使用或修改构建流程后，可以先在 GitHub Actions 页面手动运行 **Release** 工作流。手动运行只验证和生成临时 Actions artifacts，不会创建 Release；确认四个平台均构建成功后再推送正式 tag。
+
+## 使用 Release 附件
+
+下载与操作系统匹配的附件并解压，保持 `dist/bin` 与 `dist/ui` 的相对目录不变：
+
+```text
+orbit-<version>-<platform>/
+└── dist/
+    ├── bin/
+    │   └── orbit.exe 或 orbit
+    └── ui/
+```
+
+Windows 启动：
 
 ```powershell
-npm install -g .\orbit-<version>.tgz
+.\dist\bin\orbit.exe
 ```
 
-除非已经把当前项目发布到会覆盖该包名的私有 npm 源，否则不要让用户直接对公开
-npm 源执行 `npm install -g orbit`。公开 npm 上的 `orbit` 是另一个同名项目，
-在较新的 Node 版本下可能会因为 `uuid/v1` 报
-`ERR_PACKAGE_PATH_NOT_EXPORTED`。
+Linux / macOS 启动：
 
-`postinstall` 脚本会自动检测平台，将匹配的二进制文件复制到 `bin/` 目录。
+```bash
+chmod +x ./dist/bin/orbit
+./dist/bin/orbit
+```
+
+不要从公开 npm 源安装 `orbit`：公开 npm 上的同名包与本项目无关。
 
 ## 环境变量
 

--- a/scripts/verify-release-tag.mjs
+++ b/scripts/verify-release-tag.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const tag = process.argv[2] ?? process.env.GITHUB_REF_NAME ?? "";
+const packageJson = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
+const expectedTag = `v${packageJson.version}`;
+
+if (!/^v\d+\.\d+\.\d+$/.test(tag)) {
+  console.error(`Invalid release tag "${tag}". Expected v<major>.<minor>.<patch>.`);
+  process.exit(1);
+}
+
+if (tag !== expectedTag) {
+  console.error(`Release tag ${tag} does not match package.json version ${packageJson.version}. Expected ${expectedTag}.`);
+  process.exit(1);
+}
+
+console.log(`Release tag ${tag} matches package.json version ${packageJson.version}.`);

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { spawnSync } from "node:child_process";
+
+const root = path.resolve(import.meta.dirname, "..");
+const workflow = fs.readFileSync(path.join(root, ".github/workflows/release.yml"), "utf8");
+const packageJson = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8")) as { version: string };
+
+test("release workflow only starts from semantic version tags", () => {
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /tags:\s*\n\s*- "v\*\.\*\.\*"/);
+  assert.match(workflow, /node scripts\/verify-release-tag\.mjs/);
+  assert.match(workflow, /git fetch origin main:refs\/remotes\/origin\/main/);
+  assert.match(workflow, /git rev-list -n 1 "\$GITHUB_REF_NAME"/);
+  assert.match(workflow, /git merge-base --is-ancestor "\$tag_commit" origin\/main/);
+});
+
+test("release workflow verifies, builds every supported target, then publishes", () => {
+  assert.match(workflow, /platform: windows/);
+  assert.match(workflow, /platform: linux/);
+  assert.match(workflow, /platform: macos\s/);
+  assert.match(workflow, /platform: macosArm/);
+  assert.match(workflow, /needs: verify/);
+  assert.match(workflow, /needs: build/);
+  assert.match(workflow, /if: github\.event_name == 'push'/);
+  assert.match(workflow, /contents: write/);
+  assert.match(workflow, /gh release create/);
+  assert.match(workflow, /SHA256SUMS\.txt/);
+  assert.match(workflow, /release\/\$\{package\}\/dist\/bin/);
+  assert.match(workflow, /release\/\$\{package\}\/dist\/ui/);
+});
+
+test("release tag verifier accepts the package version and rejects mismatches", () => {
+  const verifier = path.join(root, "scripts/verify-release-tag.mjs");
+  const valid = spawnSync(process.execPath, [verifier, `v${packageJson.version}`], { encoding: "utf8" });
+  assert.equal(valid.status, 0, valid.stderr);
+
+  const invalid = spawnSync(process.execPath, [verifier, "v999.0.0"], { encoding: "utf8" });
+  assert.notEqual(invalid.status, 0);
+  assert.match(invalid.stderr, /does not match package\.json version/);
+});


### PR DESCRIPTION
## What changed

- add a tag-driven GitHub Actions workflow for private GitHub Releases
- verify the tag matches `package.json` and points to a commit contained in `main`
- run tests, build Windows x64, Linux x64, macOS x64, and macOS ARM64 archives, and generate SHA-256 checksums
- add a manual dry-run mode that builds artifacts without creating a Release
- update the standalone distribution guide and remove the `npm publish` instructions

## Verification

- `npm run test` — 569 tests passed
- `npm run build` — passed
- `node --test --import tsx tests/release-workflow.test.ts` — 3 tests passed
- `git diff --check` — passed
- local Windows standalone target build — passed

## Known limitation / release procedure

A local Linux cross-target build on Windows could not download/extract Bun's `bun-linux-x64-v1.3.14` target package. After this PR is merged, manually run the **Release** workflow on `main` and confirm all four hosted builds pass before creating and pushing `v0.9.5`. No tag or Release is created by this PR.