### PR TITLE
fix: build release binaries on native runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,19 +59,27 @@ jobs:
   build:
     name: Package ${{ matrix.asset }}
     needs: verify
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: windows
             asset: windows-x64
+            runner: windows-latest
+            binary: orbit.exe
           - platform: linux
             asset: linux-x64
+            runner: ubuntu-latest
+            binary: orbit
           - platform: macos
             asset: macos-x64
+            runner: macos-15-intel
+            binary: orbit
           - platform: macosArm
             asset: macos-arm64
+            runner: macos-15
+            binary: orbit
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -93,19 +101,36 @@ jobs:
       - name: Build UI and standalone binary
         shell: bash
         run: |
+          rm -rf dist
           npx tsc --noEmit
           npx vite build
           node scripts/build-standalone.mjs --platform=${{ matrix.platform }}
+
+      - name: Smoke test standalone binary
+        shell: bash
+        run: '"./dist/bin/${{ matrix.binary }}" --machine-id'
 
       - name: Create npm installation package
         shell: bash
         env:
           ASSET: ${{ matrix.asset }}
+          BINARY: ${{ matrix.binary }}
         run: |
           version="$(node -p "require('./package.json').version")"
           mkdir -p release
           packed="$(npm pack --pack-destination release --silent)"
-          mv "release/${packed}" "release/orbit-${version}-${ASSET}.tgz"
+          package_path="release/orbit-${version}-${ASSET}.tgz"
+          mv "release/${packed}" "${package_path}"
+          while IFS= read -r entry; do
+            case "${entry}" in
+              package/package.json|package/README.md|package/README.zh-CN.md|package/install.cjs|package/bin/orbit.js|package/dist/bin/"${BINARY}"|package/dist/ui/*)
+                ;;
+              *)
+                echo "Unexpected file in release package: ${entry}" >&2
+                exit 1
+                ;;
+            esac
+          done < <(tar -tzf "${package_path}")
 
       - name: Upload packaged asset
         uses: actions/upload-artifact@v4

--- a/docs/standalone-build.md
+++ b/docs/standalone-build.md
@@ -30,8 +30,8 @@ npm install -g .\orbit-<version>.tgz
 
 1. 校验 tag 与 `package.json` 版本一致，且 tag 指向 `main` 已包含的提交。
 2. 运行完整测试。
-3. 构建 Windows x64、Linux x64、macOS x64 和 macOS ARM64 可执行文件。
-4. 为每个平台生成可通过 npm 安装的 `.tgz` 附件，并生成 SHA-256 校验文件。
+3. 在对应操作系统的原生 GitHub runner 上构建 Windows x64、Linux x64、macOS x64 和 macOS ARM64 可执行文件，并实际启动进行冒烟测试。
+4. 为每个平台生成可通过 npm 安装的 `.tgz` 附件，校验包内不包含源码、测试、source map 或其他构建残留，并生成 SHA-256 校验文件。
 5. 创建 GitHub Release 并上传所有附件；失败的测试或构建不会创建 Release。
 
 发布步骤：

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -22,6 +22,17 @@ test("release workflow verifies, creates an npm package for every supported targ
   assert.match(workflow, /platform: linux/);
   assert.match(workflow, /platform: macos\s/);
   assert.match(workflow, /platform: macosArm/);
+  assert.match(workflow, /runner: windows-latest/);
+  assert.match(workflow, /runner: ubuntu-latest/);
+  assert.match(workflow, /runner: macos-15-intel/);
+  assert.match(workflow, /runner: macos-15/);
+  assert.match(workflow, /runs-on: \$\{\{ matrix\.runner \}\}/);
+  assert.match(workflow, /Smoke test standalone binary/);
+  assert.match(workflow, /\.\/dist\/bin\/\$\{\{ matrix\.binary \}\}.*--machine-id/);
+  assert.match(workflow, /rm -rf dist/);
+  assert.match(workflow, /Unexpected file in release package/);
+  assert.match(workflow, /package\/dist\/bin\/"\$\{BINARY\}"/);
+  assert.match(workflow, /package\/dist\/ui\/\*/);
   assert.match(workflow, /needs: verify/);
   assert.match(workflow, /needs: build/);
   assert.match(workflow, /if: github\.event_name == 'push'/);


### PR DESCRIPTION
## What changed

- build each Release executable on a native GitHub runner instead of cross-compiling every target on Ubuntu
- run each generated executable with `--machine-id` before packaging
- clean `dist/` before each build
- enforce a strict npm package content allowlist so source, tests, source maps, and stale build output cannot be published
- document native builds and package-content verification

## Root cause

The Windows executable produced by Bun 1.3.14 on Ubuntu installed successfully but crashed immediately with a segmentation fault. The same code compiled natively on Windows runs correctly.

## Verification

- `npm run test` — 569 tests passed
- `npm run build` — passed
- native local Windows executable `--machine-id` — passed
- `node --test --import tsx tests/release-workflow.test.ts` — 3 tests passed
- `git diff --check` — passed

The private `v0.9.5` Release has been moved back to draft. After this PR's four-platform dry run passes and the PR is merged, the existing draft Release and tag will be deleted and `v0.9.5` will be recreated from the new `main` commit.