### PR TITLE
fix: exclude source maps from release packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "postinstall": "node install.cjs",
     "dev": "tsx src/server/index.ts",
-    "build": "tsc --noEmit && vite build && bun build src/standalone-entry.ts --compile --bytecode --minify --sourcemap=none --outfile=dist/bin/orbit",
+    "build": "tsc --noEmit && vite build && node scripts/build-standalone.mjs",
     "build:all": "tsc --noEmit && vite build && node scripts/build-standalone.mjs --all",
     "test": "node scripts/run-tests.mjs",
     "test:glob": "npm run test",

--- a/scripts/build-standalone.mjs
+++ b/scripts/build-standalone.mjs
@@ -92,6 +92,14 @@ function buildStandalone(platformKey) {
     throw new Error(`Bun build failed for ${platformKey}`);
   }
 
+  // Bun compile can leave an entry-point source map next to the executable
+  // even when --sourcemap=none is set. Release packages must never include it.
+  for (const filename of fs.readdirSync(outDir)) {
+    if (filename.endsWith(".map")) {
+      fs.rmSync(path.join(outDir, filename));
+    }
+  }
+
   console.log(`✅ Built: ${outfile}`);
 
   const stats = fs.statSync(outfile);

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -18,16 +18,16 @@ test("npm package publishes only the CLI launcher and built artifacts", () => {
   assert.deepEqual(manifest.files, ["bin/", "dist/", "install.cjs"]);
 });
 
-test("package has build script using Bun compile", () => {
+test("package build delegates to the protected standalone builder", () => {
   const manifest = readPackageJson();
+  const standaloneBuilder = fs.readFileSync("scripts/build-standalone.mjs", "utf8");
 
   assert.equal(manifest.engines?.node, ">=20");
-  assert.ok(manifest.scripts?.build, "build script exists");
-  assert.match(manifest.scripts?.build ?? "", /bun build/);
-  assert.match(manifest.scripts?.build ?? "", /--compile/);
-  assert.match(manifest.scripts?.build ?? "", /--bytecode/);
-  assert.match(manifest.scripts?.build ?? "", /--minify/);
-  assert.match(manifest.scripts?.build ?? "", /--sourcemap=none/);
+  assert.match(manifest.scripts?.build ?? "", /node scripts\/build-standalone\.mjs/);
+  assert.match(standaloneBuilder, /"--compile"/);
+  assert.match(standaloneBuilder, /"--bytecode"/);
+  assert.match(standaloneBuilder, /"--minify"/);
+  assert.match(standaloneBuilder, /"--sourcemap=none"/);
 });
 
 test("default test script uses complete cross-platform discovery", () => {

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -6,6 +6,7 @@ import { spawnSync } from "node:child_process";
 
 const root = path.resolve(import.meta.dirname, "..");
 const workflow = fs.readFileSync(path.join(root, ".github/workflows/release.yml"), "utf8");
+const standaloneBuilder = fs.readFileSync(path.join(root, "scripts/build-standalone.mjs"), "utf8");
 const packageJson = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8")) as { version: string };
 
 test("release workflow only starts from semantic version tags", () => {
@@ -53,4 +54,9 @@ test("release tag verifier accepts the package version and rejects mismatches", 
   const invalid = spawnSync(process.execPath, [verifier, "v999.0.0"], { encoding: "utf8" });
   assert.notEqual(invalid.status, 0);
   assert.match(invalid.stderr, /does not match package\.json version/);
+});
+
+test("standalone builds remove generated source maps before packaging", () => {
+  assert.match(standaloneBuilder, /filename\.endsWith\("\.map"\)/);
+  assert.match(standaloneBuilder, /fs\.rmSync\(path\.join\(outDir, filename\)\)/);
 });


### PR DESCRIPTION
## What changed

- remove Bun-generated `dist/bin/*.map` files immediately after standalone compilation
- route the normal `npm run build` command through the same protected standalone builder used by Release
- keep the strict Release package allowlist unchanged so unexpected files still block publishing
- update tests for the protected build path and source-map removal

## Root cause

Bun 1.3.14 leaves `standalone-entry.js.map` beside compiled executables even with `--sourcemap=none`. The new package-content gate correctly rejected this file because it can expose backend source structure.

## Verification

- `npm run test` — 570 tests passed
- `npm run build` — passed
- verified `dist/bin` contains no `.map` after build
- native Windows executable `--machine-id` — passed
- `git diff --check` — passed

The current private `v0.9.5` Release remains a draft and will be deleted with its tag before recreating the release after this PR is merged and the four-platform dry run passes.