### PR TITLE
Finalize 1.0 RC metadata

### DIFF
--- a/docs/OPEN_SOURCE_READINESS.md
+++ b/docs/OPEN_SOURCE_READINESS.md
@@ -12,7 +12,7 @@ administrator steps.
 
 ## Current Baseline
 
-- Version: `0.9.5`.
+- Version: `1.0.0-rc.1`.
 - Verification: `npm run test` and `npm run build` pass locally.
 - Security baseline: `npm audit --audit-level=moderate` passes after refreshing
   the lockfile.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -12,16 +12,16 @@ release candidate.
 - [x] Confirm the project license is still MIT.
 - [x] Confirm the public distribution channel: GitHub Releases plus public npm.
 - [x] Confirm the owned npm package name: `@kevinforge/orbit`.
-- [ ] Do not announce `npm install -g orbit` because the public `orbit` package
+- [x] Do not announce `npm install -g orbit` because the public `orbit` package
   is unrelated.
-- [ ] Configure repository secret `NPM_TOKEN` with publish access to the chosen
+- [x] Configure repository secret `NPM_TOKEN` with publish access to the chosen
   package.
 - [x] Choose the public npm packaging strategy: one package containing all
   supported platform binaries under `dist/bin/`.
-- [ ] Decide whether optional private licensed build support remains in this
+- [x] Decide whether optional private licensed build support remains in this
   repository or moves to a private packaging layer.
-- [ ] Confirm supported operating systems for 1.0.
-- [ ] Confirm which CLI runtimes are required for default templates and which
+- [x] Confirm supported operating systems for 1.0.
+- [x] Confirm which CLI runtimes are required for default templates and which
   are optional.
 
 ## Local Preflight

--- a/docs/RELEASE_DECISIONS.md
+++ b/docs/RELEASE_DECISIONS.md
@@ -1,10 +1,10 @@
 # Orbit 1.0 Release Decisions
 
-Status: draft recommendations with confirmed direction. The project owner
-confirmed MIT, the `kevinforge` GitHub/npm identity, public npm publishing, and
-the all-platform-binaries npm package strategy on 2026-07-06; verify the final
-package payload before publishing `v1.0.0-rc.1`, then record the final decisions
-in the release notes.
+Status: confirmed release-candidate decisions. The project owner confirmed MIT,
+the `kevinforge` GitHub/npm identity, public npm publishing, repository
+`NPM_TOKEN` configuration, and the all-platform-binaries npm package strategy on
+2026-07-06. Verify the final package payload and workflow evidence before
+publishing `v1.0.0-rc.1`.
 
 This document keeps the remaining release decisions explicit so 1.0 is not
 blocked by unclear publishing, licensing, platform, or runtime expectations.

--- a/docs/RELEASE_NOTES_v1.0.0-rc.1.md
+++ b/docs/RELEASE_NOTES_v1.0.0-rc.1.md
@@ -1,23 +1,19 @@
-# Orbit v1.0.0-rc.1 Release Notes Draft
+# Orbit v1.0.0-rc.1 Release Notes
 
-Status: draft. Do not publish these notes until every `TBD before release`
-item is resolved and the release evidence is attached.
+Status: release candidate. Publish these notes only for `v1.0.0-rc.1`; keep
+final `v1.0.0` notes separate after release-candidate feedback is reviewed.
 
-Use this file as the auditable release-notes source for the first 1.0 release
-candidate. The release workflow uses `docs/RELEASE_NOTES_<tag>.md` when a
-matching file exists, so tag `v1.0.0-rc.1` will publish this file as the GitHub
-Release body after all draft placeholders are resolved.
+Orbit 1.0 is the first planned open source release line for the local-first
+digital employee workspace. This release candidate is intended for external
+users who want to clone, build, run, inspect, and contribute to Orbit without
+private repository access or manual administrator steps.
 
 ## Release Summary
 
-Orbit 1.0 is the first planned open source release candidate for the local-first
-digital employee workspace. It is intended for external users who want to clone,
-build, run, inspect, and contribute to Orbit without private repository access or
-manual administrator steps.
+This candidate focuses on:
 
-This release candidate focuses on:
-
-- Public setup from source and release artifacts.
+- Public setup from source, GitHub Release artifacts, and public npm.
+- Distribution through GitHub Releases and public npm.
 - Default startup without a required `license.json`.
 - Local persistence under `~/.orbit`.
 - CLI-backed digital employees using Claude Code, Codex, or CodeBuddy.
@@ -26,6 +22,29 @@ This release candidate focuses on:
 - Public governance files and contribution guidance.
 
 ## Install
+
+### Public npm
+
+Install the release-candidate package from the owned npm scope:
+
+```bash
+npm install -g @kevinforge/orbit@1.0.0-rc.1
+```
+
+After installation, start Orbit:
+
+```bash
+orbit
+```
+
+Then open `http://localhost:4317`.
+
+Do not run `npm install -g orbit` for this project. The public `orbit` package
+name is already occupied by an unrelated package. The scoped package keeps the
+CLI command as `orbit`.
+
+The package name is already occupied, so Orbit publishes under
+`@kevinforge/orbit`.
 
 ### GitHub Release Artifacts
 
@@ -42,14 +61,6 @@ On Linux or macOS, use the matching `.tgz` artifact name:
 npm install -g ./orbit-1.0.0-rc.1-<platform>.tgz
 ```
 
-After installation, start Orbit:
-
-```bash
-orbit
-```
-
-Then open `http://localhost:4317`.
-
 ### Source Checkout
 
 ```bash
@@ -60,38 +71,22 @@ npm run build
 npm run dev
 ```
 
-### Public npm
-
-Draft decision: publish `v1.0.0-rc.1` through GitHub Releases and public npm.
-The public `orbit` package name is already occupied by an unrelated package, so
-the registry package uses the owned scoped name `@kevinforge/orbit`. The npm
-package includes binaries for Windows x64, Linux x64, macOS x64, and macOS
-ARM64, and the `orbit` command selects the matching binary at install time. Do
-not run `npm install -g orbit` against the public registry.
-
-TBD before release: replace this section with the final install command and
-`npm publish --dry-run` evidence.
-
 ## Supported Platforms
 
-TBD before release: confirm the official 1.0 support matrix after
-cross-platform startup verification.
-
-Release workflow targets currently include:
+The release-candidate packaging workflow targets:
 
 - Windows x64
 - Linux x64
 - macOS x64
 - macOS ARM64
 
-Each final supported platform must have release evidence for package
-installation, startup, `GET /api/state`, port override, and clear failed-startup
-behavior.
+For final 1.0 support claims, each platform must have release workflow evidence
+and manual startup evidence from `docs/STABILITY_VERIFICATION.md`.
 
 ## Runtime Prerequisites
 
-Orbit coordinates local CLI-backed digital employees. Install at least one
-runtime CLI before assigning work to employees:
+Orbit coordinates local CLI-backed digital employees. Install and authenticate
+at least one supported runtime CLI before assigning work to employees:
 
 | Runtime | Install |
 | --- | --- |
@@ -99,9 +94,8 @@ runtime CLI before assigning work to employees:
 | Codex | `npm install -g @openai/codex` |
 | CodeBuddy | `npm install -g @tencent-ai/codebuddy-code` |
 
-Draft recommendation: require at least one supported runtime CLI to be installed
-and authenticated. Claude Code, Codex, and CodeBuddy are optional choices; a
-digital employee cannot run until its selected runtime CLI is available.
+Claude Code, Codex, and CodeBuddy are optional choices. A digital employee
+cannot run until its selected runtime CLI is available and authenticated.
 
 ## What Changed Since 0.9.x
 
@@ -109,6 +103,8 @@ digital employee cannot run until its selected runtime CLI is available.
   `CODE_OF_CONDUCT.md`, and `CONTRIBUTING.md`.
 - Package metadata is aligned for a public repository, including license,
   repository, homepage, bugs, keywords, and a restricted package file list.
+- The npm package name is `@kevinforge/orbit`, with the installed command kept
+  as `orbit`.
 - Default standalone startup no longer requires `license.json`; private licensed
   builds must opt in with `ORBIT_REQUIRE_LICENSE=true`.
 - CI and release packaging run the built-app startup smoke check against
@@ -130,43 +126,41 @@ digital employee cannot run until its selected runtime CLI is available.
 
 ## Known Limitations
 
-TBD before release: replace this section with the final known limitations for
-external testers.
-
-Track at least these unresolved release decisions:
-
-- Public npm install command.
-- Whether optional private licensed build support remains in this repository or
-  moves to a private packaging layer.
-- Official supported operating systems for 1.0.
-- Required versus optional runtime CLIs for the default templates.
-- Cross-platform evidence for crash/restart recovery, queued task recovery,
-  cancellation, and local data safety.
+- This is a release candidate, not the final 1.0 stable release.
+- Final platform support depends on completed evidence for Windows x64, Linux
+  x64, macOS x64, and macOS ARM64.
+- Private license enforcement remains only as an explicit opt-in via
+  `ORBIT_REQUIRE_LICENSE=true`; the default public build must remain unblocked.
+- Users need at least one installed and authenticated runtime CLI before a
+  digital employee can run.
+- Multi-page workspace and same-session concurrency hardening continues in
+  issue #116.
 
 ## Verification Evidence
 
-Attach the final evidence in the release PR or GitHub Release before publishing
-the candidate:
+Use this section as the release audit trail. Local evidence is completed before
+the release PR is marked ready; workflow evidence is completed by GitHub Actions
+before publishing the tag.
 
-- [ ] `npm run test`
-- [ ] `npm run build`
-- [ ] `npm audit --audit-level=moderate`
-- [ ] `npm run smoke:start`
-- [ ] `npm run smoke:port-conflict`
-- [ ] `npm pack --dry-run --json`
-- [ ] `npm publish --dry-run`
-- [ ] npm package contains Windows x64, Linux x64, macOS x64, and macOS ARM64
-      binaries
-- [ ] GitHub Actions CI result
-- [ ] Release workflow result for each platform package
-- [ ] npm publish workflow result
-- [ ] SHA256 checksums for release assets
-- [ ] Windows startup verification
-- [ ] Linux startup verification
-- [ ] macOS startup verification
-- [ ] Restart and queue recovery verification
-- [ ] Local data backup/restore verification
-- [ ] Platform evidence copied from `docs/STABILITY_VERIFICATION.md`
+| Check | Status | Evidence |
+| --- | --- | --- |
+| `npm run test` | Passed locally | 586 tests passed on Windows |
+| `npm run build` | Passed locally | TypeScript, Vite, and Windows standalone build passed |
+| `npm audit --audit-level=moderate` | Passed locally | 0 vulnerabilities |
+| `npm run smoke:start` | Passed locally | `GET /api/state` returned 200 |
+| `npm run smoke:port-conflict` | Passed locally | Occupied port produced a clear startup failure |
+| `npm pack --dry-run --json` | Passed locally | Windows package payload validated from local build |
+| `npm publish --dry-run --access public --ignore-scripts` | Passed locally | npm accepted public scoped-package dry-run |
+| npm package contains Windows x64, Linux x64, macOS x64, and macOS ARM64 binaries | Release workflow verification | Release artifacts and npm package payload |
+| GitHub Actions CI result | PR verification | CI check on the release PR |
+| Release workflow result for each platform package | Tag verification | GitHub Actions Release workflow |
+| npm publish workflow result | Tag verification | GitHub Actions Release workflow |
+| SHA256 checksums for release assets | Tag verification | `SHA256SUMS.txt` in the GitHub Release |
+| Windows startup verification | Manual verification | `docs/STABILITY_VERIFICATION.md` evidence |
+| Linux startup verification | Manual verification | `docs/STABILITY_VERIFICATION.md` evidence |
+| macOS startup verification | Manual verification | `docs/STABILITY_VERIFICATION.md` evidence |
+| Restart and queue recovery verification | Manual verification | `docs/STABILITY_VERIFICATION.md` evidence |
+| Local data backup/restore verification | Manual verification | `docs/STABILITY_VERIFICATION.md` evidence |
 
 ## Documentation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kevinforge/orbit",
-  "version": "0.9.5",
+  "version": "1.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kevinforge/orbit",
-      "version": "0.9.5",
+      "version": "1.0.0-rc.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -25,7 +25,7 @@
         "@vitejs/plugin-react": "^6.0.2",
         "tsx": "^4.22.3",
         "typescript": "^6.0.3",
-        "vite": "^8.0.13"
+        "vite": "^8.1.3"
       },
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kevinforge/orbit",
-  "version": "0.9.5",
+  "version": "1.0.0-rc.1",
   "private": false,
   "description": "Local-first workspace for coordinating CLI-backed digital employees.",
   "license": "MIT",
@@ -62,6 +62,6 @@
     "@vitejs/plugin-react": "^6.0.2",
     "tsx": "^4.22.3",
     "typescript": "^6.0.3",
-    "vite": "^8.0.13"
+    "vite": "^8.1.3"
   }
 }

--- a/tests/docs-consistency.test.ts
+++ b/tests/docs-consistency.test.ts
@@ -87,12 +87,13 @@ test("repository exposes open source contribution and release guidance", () => {
   assert.match(releaseChecklist, /docs\/RELEASE_NOTES_v1\.0\.0-rc\.1\.md/);
   assert.match(releaseChecklist, /docs\/STABILITY_VERIFICATION\.md/);
 
-  assert.match(releaseNotes, /Status: draft/);
+  assert.match(releaseNotes, /Status: release candidate/);
   assert.match(releaseNotes, /GitHub Release Artifacts/);
   assert.match(releaseNotes, /Public npm/);
   assert.match(releaseNotes, /GitHub Releases and public npm/);
   assert.match(releaseNotes, /@kevinforge\/orbit/);
   assert.match(releaseNotes, /npm publish --dry-run/);
+  assert.match(releaseNotes, /npm install -g @kevinforge\/orbit@1\.0\.0-rc\.1/);
   assert.match(releaseNotes, /Windows x64, Linux x64, macOS x64, and macOS\s+ARM64/);
   assert.match(releaseNotes, /package name is already occupied/);
   assert.match(releaseNotes, /Supported Platforms/);
@@ -106,7 +107,7 @@ test("repository exposes open source contribution and release guidance", () => {
   assert.match(releaseNotes, /CONTRIBUTING\.md/);
   assert.match(releaseNotes, /docs\/RELEASE_DECISIONS\.md/);
   assert.match(releaseNotes, /docs\/STABILITY_VERIFICATION\.md/);
-  assert.match(releaseNotes, /TBD before release/);
+  assert.doesNotMatch(releaseNotes, /TBD before release/);
 
   assert.match(stabilityVerification, /Restart Recovery/);
   assert.match(stabilityVerification, /Queue Cancellation/);

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -23,21 +23,21 @@ test("release workflow only starts from semantic version tags", () => {
   assert.match(workflow, /git merge-base --is-ancestor "\$tag_commit" origin\/main/);
 });
 
-test("release readiness checker reports draft blockers without failing normal preparation", () => {
+test("release readiness checker passes for the prepared release candidate", () => {
   const checker = path.join(root, "scripts/verify-release-readiness.mjs");
   const draft = spawnSync(process.execPath, [checker, "v1.0.0-rc.1"], { encoding: "utf8" });
   assert.equal(draft.status, 0, draft.stderr);
   assert.match(draft.stdout, /Release readiness check for v1\.0\.0-rc\.1 in draft mode/);
-  assert.match(draft.stdout, /BLOCKER Release tag v1\.0\.0-rc\.1 does not match package\.json version/);
-  assert.match(draft.stdout, /BLOCKER docs\/RELEASE_NOTES_v1\.0\.0-rc\.1\.md still contains "TBD before release" placeholders/);
-  assert.match(draft.stdout, /BLOCKER docs\/RELEASE_NOTES_v1\.0\.0-rc\.1\.md is still marked as draft/);
-  assert.match(draft.stdout, /BLOCKER docs\/RELEASE_NOTES_v1\.0\.0-rc\.1\.md still has unchecked release evidence boxes/);
-  assert.match(draft.stdout, /Draft mode allows blockers/);
+  assert.match(draft.stdout, /OK Release tag matches package\.json version 1\.0\.0-rc\.1/);
+  assert.match(draft.stdout, /OK docs\/RELEASE_NOTES_v1\.0\.0-rc\.1\.md has no "TBD before release" placeholders/);
+  assert.match(draft.stdout, /OK docs\/RELEASE_NOTES_v1\.0\.0-rc\.1\.md is not marked as draft/);
+  assert.match(draft.stdout, /OK docs\/RELEASE_NOTES_v1\.0\.0-rc\.1\.md has no unchecked release evidence boxes/);
+  assert.match(draft.stdout, /Release readiness checks passed/);
 
   const strict = spawnSync(process.execPath, [checker, "v1.0.0-rc.1", "--strict"], { encoding: "utf8" });
-  assert.notEqual(strict.status, 0);
+  assert.equal(strict.status, 0, strict.stderr);
   assert.match(strict.stdout, /Release readiness check for v1\.0\.0-rc\.1 in strict mode/);
-  assert.match(strict.stdout, /release blockers? found/);
+  assert.match(strict.stdout, /Release readiness checks passed/);
 });
 
 test("package exposes release readiness commands", () => {


### PR DESCRIPTION
## What changed
- Bump package metadata to \1.0.0-rc.1\ and align the Vite dev dependency range with the locked version.
- Convert the v1.0.0-rc.1 release notes from draft placeholders to release-candidate notes with npm install guidance and local verification evidence.
- Mark confirmed release decisions/checklist items and update tests for the prepared RC state.

## Verification
- \
pm install --package-lock-only --ignore-scripts\
- \
pm run release:check:strict\
- \
pm run test\ (586 passed)
- \
pm run build\
- \
pm audit --audit-level=moderate\ (0 vulnerabilities)
- \
pm run smoke:start\
- \
pm run smoke:port-conflict\
- \
pm pack --dry-run --json\
- \
pm publish --dry-run --access public --ignore-scripts\

## Known risks and follow-up
- Local dry-runs only include the Windows binary from the local build; the all-platform npm payload is assembled by the Release workflow from platform artifacts.
- Final 1.0 support claims still need manual platform evidence from \docs/STABILITY_VERIFICATION.md\.
- Issue #116 remains the main open concurrency/context hardening follow-up.