### PR TITLE
Fix cross-platform port conflict smoke

### DIFF
--- a/scripts/smoke-port-conflict.mjs
+++ b/scripts/smoke-port-conflict.mjs
@@ -75,17 +75,49 @@ function cleanupSmokeHome(homeDir) {
 }
 
 async function occupyPort() {
-  const server = net.createServer();
-  await new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const address = server.address();
+  const primary = net.createServer();
+  await listen(primary, { port: 0, host: "0.0.0.0" });
+  const address = primary.address();
   if (!address || typeof address === "string") {
-    server.close();
+    primary.close();
     throw new Error("Unable to allocate a local port");
   }
-  return { server, port: address.port };
+  const port = address.port;
+  const servers = [primary];
+
+  try {
+    const ipv6 = net.createServer();
+    await listen(ipv6, { port, host: "::", ipv6Only: false });
+    servers.push(ipv6);
+  } catch (error) {
+    if (!isAddressInUseError(error)) {
+      await closeServers(servers);
+      throw error;
+    }
+  }
+
+  return { servers, port };
+}
+
+function listen(server, options) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(options, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+async function closeServers(servers) {
+  await Promise.all(
+    servers.map(
+      (server) =>
+        new Promise((resolve) => {
+          server.close(resolve);
+        }),
+    ),
+  );
 }
 
 async function runOrbitExpectingPortConflict(options, port) {
@@ -143,9 +175,13 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function isAddressInUseError(error) {
+  return error && typeof error === "object" && error.code === "EADDRINUSE";
+}
+
 async function main() {
   const options = parseArgs(process.argv.slice(2));
-  const { server, port } = await occupyPort();
+  const { servers, port } = await occupyPort();
 
   try {
     const result = await runOrbitExpectingPortConflict(options, port);
@@ -157,16 +193,19 @@ async function main() {
     if (result.code === 0) {
       throw new Error(`Orbit exited successfully even though port ${port} was occupied.`);
     }
+    if (result.code === null && result.signal) {
+      throw new Error(`Orbit exited from signal ${result.signal} before reporting port ${port}. Output: ${output}`);
+    }
     if (!output.includes(String(port))) {
-      throw new Error(`Port conflict output did not mention occupied port ${port}. Output: ${output}`);
+      throw new Error(`Port conflict output did not mention occupied port ${port}. Exit code: ${result.code}. Output: ${output}`);
     }
     if (!output.includes("ORBIT_PORT")) {
-      throw new Error(`Port conflict output did not mention ORBIT_PORT recovery. Output: ${output}`);
+      throw new Error(`Port conflict output did not mention ORBIT_PORT recovery. Exit code: ${result.code}. Output: ${output}`);
     }
 
     console.log(`[orbit smoke] occupied port ${port} produced a clear startup failure`);
   } finally {
-    await new Promise((resolve) => server.close(resolve));
+    await closeServers(servers);
   }
 }
 


### PR DESCRIPTION
## What changed
- Update the occupied-port smoke test to bind wildcard IPv4 and, when available, IPv6 addresses instead of only \127.0.0.1\.
- Keep clearer diagnostics when Orbit exits without mentioning the occupied port or \ORBIT_PORT\.

## Why
- The \1.0.0-rc.1\ Release workflow failed before publishing because the packaged Windows and macOS jobs did not consistently see a conflict when the smoke script occupied only \127.0.0.1\.
- Linux passed, but the release gate correctly blocked GitHub Release/npm publishing until all platform package jobs are green.

## Verification
- \
pm run smoke:port-conflict\
- \
pm run test\ (586 passed)
- \
pm run build\
- \
pm run smoke:start\

## Known risks and follow-up
- The existing \1.0.0-rc.1\ tag points at the pre-fix commit. After this merges, move/recreate the tag on the fixed main commit and rerun the Release workflow.