### PR TITLE
Fix Windows port conflict smoke setup

### DIFF
--- a/scripts/smoke-port-conflict.mjs
+++ b/scripts/smoke-port-conflict.mjs
@@ -85,15 +85,18 @@ async function occupyPort() {
   const port = address.port;
   const servers = [primary];
 
+  if (process.platform === "win32") {
+    return { servers, port };
+  }
+
   try {
     const ipv6 = net.createServer();
     await listen(ipv6, { port, host: "::", ipv6Only: false });
     servers.push(ipv6);
   } catch (error) {
-    if (!isAddressInUseError(error)) {
-      await closeServers(servers);
-      throw error;
-    }
+    console.warn(
+      `[orbit smoke] IPv6 wildcard occupancy was unavailable for port ${port}: ${formatError(error)}`,
+    );
   }
 
   return { servers, port };
@@ -175,8 +178,8 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function isAddressInUseError(error) {
-  return error && typeof error === "object" && error.code === "EADDRINUSE";
+function formatError(error) {
+  return error instanceof Error ? error.message : String(error);
 }
 
 async function main() {
@@ -210,6 +213,6 @@ async function main() {
 }
 
 main().catch((error) => {
-  console.error(`[orbit smoke] ${error instanceof Error ? error.message : String(error)}`);
+  console.error(`[orbit smoke] ${formatError(error)}`);
   process.exit(1);
 });


### PR DESCRIPTION
## What changed
- Skip the optional IPv6 wildcard listener setup on Windows in the occupied-port smoke test.
- Keep IPv6 wildcard probing on non-Windows platforms, but treat unavailable IPv6 binding as a warning instead of a setup failure.
- Reuse a shared formatter for top-level smoke errors.

## Why
- The retagged \1.0.0-rc.1\ Release workflow passed Linux and macOS package jobs, but Windows failed before printing smoke diagnostics during the occupied-port setup.
- The Windows runner appears to reject or terminate during the optional IPv6 occupancy path, while IPv4 wildcard occupancy is enough for the Windows packaged binary smoke.

## Verification
- \
pm run smoke:port-conflict\
- \
pm run test\ (586 passed)
- \
pm run build\
- \
pm run smoke:start\

## Known risks and follow-up
- After this merges, move/recreate \1.0.0-rc.1\ on the fixed main commit and rerun the Release workflow.