### PR TITLE
fix: avoid killing release smoke parent process

### DIFF
--- a/src/server/port-recovery.ts
+++ b/src/server/port-recovery.ts
@@ -19,7 +19,11 @@ export async function findPortOwners(port: number, exec: ExecFileLike = execFile
 
 export function isOrbitPortOwner(owner: PortOwner): boolean {
   const command = (owner.command ?? "").toLowerCase();
-  return /\borbit(\.exe)?\b/.test(command) || command.includes("\\orbit\\") || command.includes("/orbit/");
+  const executable = firstCommandToken(command);
+  if (!executable) return false;
+  const normalized = executable.replaceAll("\\", "/");
+  const basename = normalized.slice(normalized.lastIndexOf("/") + 1);
+  return basename === "orbit" || basename === "orbit.exe";
 }
 
 export async function stopPortOwner(owner: PortOwner): Promise<void> {
@@ -90,4 +94,14 @@ function dedupeOwners(owners: PortOwner[]): PortOwner[] {
     seen.add(owner.pid);
     return true;
   });
+}
+
+function firstCommandToken(command: string): string | null {
+  const trimmed = command.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith('"')) {
+    const endQuote = trimmed.indexOf('"', 1);
+    return endQuote === -1 ? trimmed.slice(1) : trimmed.slice(1, endQuote);
+  }
+  return trimmed.split(/\s+/, 1)[0] ?? null;
 }

--- a/tests/port-recovery.test.ts
+++ b/tests/port-recovery.test.ts
@@ -5,9 +5,11 @@ import { findPortOwners, isOrbitPortOwner, localAddressMatchesPort } from "../sr
 
 test("isOrbitPortOwner identifies Orbit commands", () => {
   assert.equal(isOrbitPortOwner({ pid: 1, command: "C:\\Users\\me\\AppData\\Roaming\\npm\\orbit.exe" }), true);
-  assert.equal(isOrbitPortOwner({ pid: 2, command: "bun C:\\repo\\orbit\\src\\server\\index.ts" }), true);
+  assert.equal(isOrbitPortOwner({ pid: 2, command: "\"C:\\Users\\me\\AppData\\Roaming\\npm\\orbit.exe\" --flag" }), true);
   assert.equal(isOrbitPortOwner({ pid: 3, command: "C:\\Program Files\\Other\\server.exe" }), false);
-  assert.equal(isOrbitPortOwner({ pid: 4 }), false);
+  assert.equal(isOrbitPortOwner({ pid: 4, command: "node scripts\\smoke-port-conflict.mjs --binary .\\dist\\bin\\orbit.exe" }), false);
+  assert.equal(isOrbitPortOwner({ pid: 5, command: "bun C:\\repo\\orbit\\src\\server\\index.ts" }), false);
+  assert.equal(isOrbitPortOwner({ pid: 6 }), false);
 });
 
 test("localAddressMatchesPort matches exact port suffix", () => {


### PR DESCRIPTION
## What changed
- Tightened Orbit port-owner detection so automatic port recovery only targets processes whose executable is actually orbit/orbit.exe.
- Added regression coverage for release smoke commands that pass ./dist/bin/orbit.exe as an argument.

## Verification
- node --test --import tsx tests/port-recovery.test.ts
- npm run test
- npm run build
- node scripts/smoke-port-conflict.mjs --binary ./dist/bin/orbit.exe
- npm run release:check:strict

## Notes
- This fixes the Windows release job killing the smoke-test parent process when the command line includes --binary ./dist/bin/orbit.exe.