### PR TITLE
fix: recover supervisor after runtime errors

### DIFF
--- a/src/core/channel-watch.ts
+++ b/src/core/channel-watch.ts
@@ -188,9 +188,11 @@ export class ChannelWatchService {
     const supervisorSession = this.agentRegistry.get(ctx.agentId);
 
     if (options?.relaxIdleCheck) {
-      // User-originated: allow queuing even when busy, only skip unrecoverable states
+      // User-originated: allow queuing even when busy or recovering from a
+      // previous runtime error. AgentSession.send() can move an error-state
+      // session back to running as long as no process is active.
       const status = supervisorSession.getStatus();
-      if (status === "error" || status === "stopped") return;
+      if (status === "stopped") return;
     } else {
       // Agent-completion triggered: supervisor must be idle
       if (supervisorSession.getStatus() !== "idle") return;

--- a/src/core/run-manager.ts
+++ b/src/core/run-manager.ts
@@ -554,7 +554,12 @@ export function classifyTerminalActivities(text: string): AgentActivityEvent[] {
   }
 
   if (/api error|hook error|failed with/i.test(normalized)) {
-    return [{ type: "error", message: "Runtime reported an error. Waiting for final result.", timestamp: new Date().toISOString() }];
+    const upstreamBusy = summarizeUpstreamBusyError(normalized);
+    return [{
+      type: "error",
+      message: upstreamBusy ?? "Runtime reported an error. Waiting for final result.",
+      timestamp: new Date().toISOString(),
+    }];
   }
 
   const toolMatch = /\b(Bash|Edit|Write|Read|Grep|Glob|LS|TodoWrite|MultiEdit|NotebookEdit)\b/i.exec(normalized);
@@ -749,7 +754,24 @@ function summarizeRunError(error: string): string {
     return "Runtime failed without an error message. Check the transcript for details.";
   }
 
+  const upstreamBusy = summarizeUpstreamBusyError(normalized);
+  if (upstreamBusy) {
+    return upstreamBusy;
+  }
+
   return truncateText(stripRawJsonNoise(normalized), MAX_RUN_ERROR_CHARS);
+}
+
+function summarizeUpstreamBusyError(value: string): string | null {
+  if (!/\b(529|overloaded|server_error)\b/i.test(value)) {
+    return null;
+  }
+
+  if (!/api error|server_error|overloaded/i.test(value)) {
+    return null;
+  }
+
+  return "上游模型服务繁忙（529 overloaded）。请稍后重试，或切换到其他可用运行时。";
 }
 
 function stripRawJsonNoise(value: string): string {

--- a/tests/channel-watch.test.ts
+++ b/tests/channel-watch.test.ts
@@ -1098,33 +1098,59 @@ test("unassigned user message enqueues supervisor even when supervisor is runnin
   service.dispose();
 });
 
-test("unassigned user message does NOT enqueue supervisor in error or stopped state", async () => {
-  for (const badStatus of ["error", "stopped"] as AgentStatus[]) {
-    const eventBus = new EventBus();
-    const messages = new MessageStore();
-    const { agentRegistry, runManager, enqueueCalls } = createMocks({
-      agentStatuses: { supervisor: badStatus, dev: "idle" },
-    });
+test("unassigned user message can recover a supervisor after runtime error", async () => {
+  const eventBus = new EventBus();
+  const messages = new MessageStore();
+  const { agentRegistry, runManager, enqueueCalls } = createMocks({
+    agentStatuses: { supervisor: "error", dev: "idle" },
+  });
 
-    const profiles = [makeSupervisorProfile("supervisor"), makePlainAgentProfile("dev")];
-    const service = new ChannelWatchService(
-      "conv-1",
-      agentRegistry as any,
-      runManager as any,
-      messages,
-      eventBus,
-      profiles,
-    );
+  const profiles = [makeSupervisorProfile("supervisor"), makePlainAgentProfile("dev")];
+  const service = new ChannelWatchService(
+    "conv-1",
+    agentRegistry as any,
+    runManager as any,
+    messages,
+    eventBus,
+    profiles,
+  );
 
-    eventBus.publish({
-      type: "message.created",
-      conversationId: "conv-1",
-      message: createUserMessage("Hello?"),
-    });
+  eventBus.publish({
+    type: "message.created",
+    conversationId: "conv-1",
+    message: createUserMessage("Hello?"),
+  });
 
-    assert.equal(enqueueCalls.length, 0, `Expected no enqueue for supervisor status=${badStatus}`);
-    service.dispose();
-  }
+  assert.equal(enqueueCalls.length, 1);
+  assert.equal(enqueueCalls[0].agentId, "supervisor");
+  service.dispose();
+});
+
+test("unassigned user message does NOT enqueue supervisor in stopped state", async () => {
+  const eventBus = new EventBus();
+  const messages = new MessageStore();
+  const { agentRegistry, runManager, enqueueCalls } = createMocks({
+    agentStatuses: { supervisor: "stopped", dev: "idle" },
+  });
+
+  const profiles = [makeSupervisorProfile("supervisor"), makePlainAgentProfile("dev")];
+  const service = new ChannelWatchService(
+    "conv-1",
+    agentRegistry as any,
+    runManager as any,
+    messages,
+    eventBus,
+    profiles,
+  );
+
+  eventBus.publish({
+    type: "message.created",
+    conversationId: "conv-1",
+    message: createUserMessage("Hello?"),
+  });
+
+  assert.equal(enqueueCalls.length, 0);
+  service.dispose();
 });
 
 test("no supervisor configured — unassigned user message does not trigger any enqueue", async () => {

--- a/tests/run-manager.test.ts
+++ b/tests/run-manager.test.ts
@@ -881,6 +881,52 @@ test("run failures store a concise error instead of raw stream output", async ()
   assert.ok(lastActivity?.type === "status" && lastActivity.text.length < 2_100);
 });
 
+test("overloaded runtime failures are summarized without repeated provider noise", async () => {
+  const messages = new MessageStore();
+  const eventBus = new EventBus();
+  const failure = deferred();
+
+  const manager = new RunManager({
+    conversationId: "test-conv",
+    messages,
+    eventBus,
+    agents: {
+      get() {
+        return {
+          send() {
+            return failure.promise;
+          },
+          interrupt() { return true; },
+        };
+      },
+    },
+    buildPrompt(_agentId, prompt) {
+      return prompt;
+    },
+    onRunCompleted() {},
+  });
+
+  const run = manager.enqueue("supervisor", "first", createSourceMessage());
+  const rawError = "overloaded overloaded overloaded server_error API Error: 529 [1305] overloaded";
+  eventBus.publish({
+    type: "terminal.chunk",
+    conversationId: "test-conv",
+    agentId: "supervisor",
+    runId: run.id,
+    text: rawError,
+  });
+  failure.reject(new Error(rawError));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const failed = messages.get(run.resultMessageId);
+  assert.equal(failed?.status, "error");
+  assert.ok(failed?.content.includes("529 overloaded"), `expected concise overloaded summary, got: ${failed?.content}`);
+  assert.equal((failed?.content.match(/overloaded/g) ?? []).length, 1);
+
+  const errorActivity = failed?.activity?.find((activity) => activity.type === "error");
+  assert.ok(errorActivity?.type === "error" && errorActivity.message.includes("529 overloaded"));
+});
+
 test("CLI crash that streamed assistant text surfaces that text, not the generic fallback", async () => {
   const messages = new MessageStore();
   const eventBus = new EventBus();


### PR DESCRIPTION
## Summary

- 

## Verification

- [ ] `npm run test`
- [ ] `npm run build`
- [ ] `npm audit --audit-level=moderate` when dependencies or release readiness changed
- [ ] `npm run smoke:start` when startup, packaging, or release behavior changed
- [ ] `npm run smoke:port-conflict` when startup, packaging, or release behavior changed

## Screenshots

- Required for UI changes, or note why they are not needed.

## Known Risks And Follow-Up

- 
