### PR TITLE
Guard Enter shortcuts against IME composition input

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -85,6 +85,16 @@ function loadApprovalMode(): ApprovalMode {
   }
 }
 
+/**
+ * 判断按键是否发生在输入法组合（IME composition）期间。
+ * macOS 中文输入法组合中按 Enter 是"字母原文上屏"、方向键用于选择候选词，
+ * 这些按键必须交给输入法处理，不能触发发送、选中 @员工 等快捷键。
+ * keyCode 229 兼容旧版 Safari（其组合期 keydown 不带 isComposing）。
+ */
+export function isImeComposition(event: { nativeEvent: { isComposing?: boolean }; keyCode?: number }): boolean {
+  return event.nativeEvent.isComposing === true || event.keyCode === 229;
+}
+
 export function App() {
   const [state, setState] = useState<AppState>(initialState);
   const [activeView, setActiveView] = useState<ActiveView>(loadActiveView);
@@ -905,6 +915,10 @@ export function App() {
   }
 
   function handleComposerKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (isImeComposition(event)) {
+      return;
+    }
+
     if (mentionCandidates.length === 0) {
       return;
     }
@@ -1353,6 +1367,9 @@ export function App() {
                 setCursorIndex(event.target.selectionStart ?? event.target.value.length);
               }}
               onKeyDown={(event) => {
+                if (isImeComposition(event)) {
+                  return;
+                }
                 if (event.key === "Enter" && !event.shiftKey) {
                   event.preventDefault();
                   sendMessage(event as unknown as FormEvent<HTMLFormElement>);
@@ -2554,6 +2571,9 @@ function WorkspaceConfigPanel({ onClose, hasWorkspace, presets }: { onClose: () 
                           onChange={(e) => updateRule(i, e.target.value)}
                           placeholder={`规则 ${i + 1}`}
                           onKeyDown={(e) => {
+                            if (isImeComposition(e)) {
+                              return;
+                            }
                             if (e.key === "Enter") {
                               e.preventDefault();
                               addRule();

--- a/tests/ime-composition-guard.test.ts
+++ b/tests/ime-composition-guard.test.ts
@@ -1,0 +1,51 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { isImeComposition } from "../src/ui/App.tsx";
+
+/**
+ * macOS 中文输入法组合（IME composition）期间按 Enter 是"字母原文上屏"，
+ * 不是发送指令。所有把 Enter 当快捷键的输入框必须先经过组合状态守卫。
+ */
+
+const appSource = fs.readFileSync(
+  path.resolve(import.meta.dirname, "../src/ui/App.tsx"),
+  "utf-8",
+);
+
+describe("IME composition guard", () => {
+  test("isImeComposition detects composition-state keys", () => {
+    // 标准浏览器：组合期 keydown 的 isComposing 为 true
+    assert.equal(isImeComposition({ nativeEvent: { isComposing: true }, keyCode: 13 }), true);
+    // 旧版 Safari：组合期 isComposing 缺失，keyCode 固定为 229
+    assert.equal(isImeComposition({ nativeEvent: { isComposing: false }, keyCode: 229 }), true);
+    // 正常按键不得被拦截
+    assert.equal(isImeComposition({ nativeEvent: { isComposing: false }, keyCode: 13 }), false);
+    assert.equal(isImeComposition({ nativeEvent: { isComposing: undefined }, keyCode: 65 }), false);
+  });
+
+  test("composer Enter-send runs only after the composition guard", () => {
+    const guardIndex = appSource.indexOf("if (isImeComposition(event)) {");
+    const sendIndex = appSource.indexOf("sendMessage(event as unknown as FormEvent<HTMLFormElement>)");
+    assert.ok(guardIndex > 0, "composer onKeyDown must check isImeComposition");
+    assert.ok(sendIndex > guardIndex, "composition guard must precede the Enter-send branch");
+  });
+
+  test("mention menu keys are ignored during composition", () => {
+    const match = appSource.match(/function handleComposerKeyDown\([\s\S]*?\n  \}/);
+    assert.ok(match, "handleComposerKeyDown must exist in App.tsx");
+    assert.ok(
+      match[0].indexOf("isImeComposition") >= 0 && match[0].indexOf("isImeComposition") < match[0].indexOf("ArrowDown"),
+      "composition guard must precede mention candidate navigation",
+    );
+  });
+
+  test("workspace rules Enter handler ignores composition keys", () => {
+    const match = appSource.match(
+      /onKeyDown=\{\(e\) => \{\s*if \(isImeComposition\(e\)\) \{\s*return;\s*\}\s*if \(e\.key === "Enter"\) \{\s*e\.preventDefault\(\);\s*addRule\(\);/,
+    );
+    assert.ok(match, "rules input onKeyDown must guard composition before addRule");
+  });
+});


### PR DESCRIPTION
macOS Chinese IME reports Enter with isComposing=true while committing raw letters, so the composer treated the commit key as send and fired the message immediately. Add a shared isImeComposition guard and apply it before the Enter-send branch, mention menu navigation, and the workspace rules Enter-to-add shortcut. keyCode 229 covers legacy Safari. Add tests for the guard and all three call sites.

## Summary

- 

## Verification

- [ ] `npm run test`
- [ ] `npm run build`
- [ ] `npm audit --audit-level=moderate` when dependencies or release readiness changed
- [ ] `npm run smoke:start` when startup, packaging, or release behavior changed
- [ ] `npm run smoke:port-conflict` when startup, packaging, or release behavior changed

## Screenshots

- Required for UI changes, or note why they are not needed.

## Known Risks And Follow-Up

- 
Closes kevinforge/orbit#148