### PR TITLE
Fix intermittent runtime model discovery

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -107,6 +107,11 @@ model selection through ACP session config options. The flow is:
    distinct runtime and reads `session/new` config options without sending a
    prompt. The temporary connection is destroyed after discovery and does not
    create an Orbit employee session or conversation record.
+- A manual refresh is scoped to the employee id and runtime currently selected
+   in the settings form, so it also works before a runtime change or a newly
+   added employee has been saved. The response carries this target snapshot
+   separately from the persisted agent configs; the UI merges only model state
+   and keeps all unsaved form edits.
 
 1. On connection initialization Orbit declares the `session.configOptions`
    client capability. New, resumed, and restored sessions return the runtime's

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -24,7 +24,7 @@ import { initialAgentConfigsForWorkspacePreset } from "../core/workspace-agent-p
 import { getWorkspacePresets } from "../core/workspace-presets.ts";
 import { migrateChannelLayer } from "../core/migrate-channel-layer.ts";
 import { cleanupHistory } from "../core/history-retention.ts";
-import type { AgentConfigWithModelState, AgentModelProbeState, ApprovalMode, Conversation, ConversationInfo, ElicitationResponse, InteractionMode, MessagePage, PermissionDecision, RunningSummary, WorkspaceInfo } from "../shared/types.ts";
+import type { AgentConfigWithModelState, AgentModelProbeResponse, AgentModelProbeState, ApprovalMode, Conversation, ConversationInfo, ElicitationResponse, InteractionMode, MessagePage, PermissionDecision, RunningSummary, WorkspaceInfo } from "../shared/types.ts";
 import { isInteractionMode } from "../shared/types.ts";
 import { ATTACHMENT_LIMITS } from "../shared/types.ts";
 import { AttachmentStore } from "../core/attachment-store.ts";
@@ -98,22 +98,30 @@ async function probeRuntimes(): Promise<void> {
   }
 }
 
-async function probeConfiguredAgentModels(force = false, runtimeFilter?: AgentConfig["runtime"]): Promise<void> {
+async function probeConfiguredAgentModels(
+  force = false,
+  runtimeFilter?: AgentConfig["runtime"],
+  targetAgentId?: string,
+): Promise<void> {
   if (!activeWorkspaceId) return;
   const workspaceId = activeWorkspaceId;
   const workspace = workspaceStore.get(workspaceId);
   if (!workspace) return;
 
   const existing = agentModelStateStore.load(workspaceId);
-  const targetsByRuntime = new Map<AgentConfig["runtime"], AgentConfig[]>();
-  for (const config of allConfigs) {
-    if (runtimeFilter && config.runtime !== runtimeFilter) continue;
-    const snapshot = existing[config.id];
-    const probeState = modelProbeStates.get(workspaceId)?.get(config.runtime);
-    if (!force && snapshot?.runtimeKind === config.runtime && probeState?.status !== "error") continue;
-    const targets = targetsByRuntime.get(config.runtime) ?? [];
-    targets.push(config);
-    targetsByRuntime.set(config.runtime, targets);
+  const targetsByRuntime = new Map<AgentConfig["runtime"], Array<Pick<AgentConfig, "id" | "runtime">>>();
+  if (runtimeFilter && targetAgentId) {
+    targetsByRuntime.set(runtimeFilter, [{ id: targetAgentId, runtime: runtimeFilter }]);
+  } else {
+    for (const config of allConfigs) {
+      if (runtimeFilter && config.runtime !== runtimeFilter) continue;
+      const snapshot = existing[config.id];
+      const probeState = modelProbeStates.get(workspaceId)?.get(config.runtime);
+      if (!force && snapshot?.runtimeKind === config.runtime && probeState?.status !== "error") continue;
+      const targets = targetsByRuntime.get(config.runtime) ?? [];
+      targets.push(config);
+      targetsByRuntime.set(config.runtime, targets);
+    }
   }
 
   await Promise.all([...targetsByRuntime.entries()].map(async ([runtimeKind, targets]) => {
@@ -877,12 +885,33 @@ const server = http.createServer(async (req, res) => {
     if (req.method === "POST" && url.pathname === "/api/agents/probe-models") {
       const runtimeParam = url.searchParams.get("runtime");
       const runtimeFilter = runtimeParam as AgentConfig["runtime"] | null;
+      const targetAgentId = url.searchParams.get("agentId")?.trim();
       if (runtimeFilter && !defaultAcpRunnerRegistry.get(runtimeFilter)) {
         sendJson(res, 400, { ok: false, message: "未知的运行时。" });
         return;
       }
-      await probeConfiguredAgentModels(url.searchParams.get("force") === "1", runtimeFilter ?? undefined);
-      sendJson(res, 200, activeWorkspaceId ? configsWithModelState(activeWorkspaceId) : allConfigs);
+      if (targetAgentId && (!runtimeFilter || !/^[a-zA-Z0-9_-]{1,128}$/.test(targetAgentId))) {
+        sendJson(res, 400, { ok: false, message: "刷新指定员工模型时需要有效的员工 ID 和运行时。" });
+        return;
+      }
+      await probeConfiguredAgentModels(
+        url.searchParams.get("force") === "1",
+        runtimeFilter ?? undefined,
+        targetAgentId,
+      );
+      const configs = activeWorkspaceId ? configsWithModelState(activeWorkspaceId) : allConfigs;
+      const response: AgentModelProbeResponse = { configs };
+      if (activeWorkspaceId && runtimeFilter && targetAgentId) {
+        const snapshot = agentModelStateStore.get(activeWorkspaceId, targetAgentId);
+        const matchingSnapshot = snapshot?.runtimeKind === runtimeFilter ? snapshot : undefined;
+        response.target = {
+          agentId: targetAgentId,
+          runtimeKind: runtimeFilter,
+          modelState: matchingSnapshot ?? null,
+          modelProbe: modelProbeStateFor(activeWorkspaceId, runtimeFilter, matchingSnapshot),
+        };
+      }
+      sendJson(res, 200, response);
       return;
     }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -185,6 +185,20 @@ export type AgentConfigWithModelState = AgentConfig & {
   modelProbe?: AgentModelProbeState;
 };
 
+/**
+ * 设置页可以在保存员工配置前切换 runtime，因此模型探测结果不能只依附于
+ * 服务端已保存的 AgentConfig。target 单独描述本次实际探测的员工和 runtime。
+ */
+export type AgentModelProbeResponse = {
+  configs: AgentConfigWithModelState[];
+  target?: {
+    agentId: AgentId;
+    runtimeKind: AgentRuntimeKind;
+    modelState: AgentModelStateSnapshot | null;
+    modelProbe: AgentModelProbeState;
+  };
+};
+
 export type AgentStatus = "starting" | "idle" | "running" | "error" | "stopped";
 
 export type AgentState = {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -3,7 +3,7 @@ import { renderMarkdown, LOCAL_PATH_LINK_CLASS } from "./markdown-renderer.ts";
 import { isSafeExternalUrl } from "./url-guard.ts";
 import { AGENT_RUNTIME_PRIORITY, runtimeKindToCliKey, runtimeMeta } from "../core/runtime-meta.ts";
 import { matchPreset } from "../core/workspace-presets.ts";
-import { type AgentActivityEvent, type AgentConfig, type AgentConfigWithModelState, type AgentId, type AgentModelStateSnapshot, type AgentPlanSnapshot, type AgentRuntimeKind, type AgentState, type AgentTeamTemplate, type AppState, type ApprovalMode, type ChatMessage, type Conversation, type ConversationInfo, type DraftAttachmentInfo, type ElicitationContent, type ElicitationFieldSchema, type ElicitationResponse, type InteractionMode, type MessagePage, type PendingElicitation, type PendingPermission, type PermissionDecision, type PersistedProcessTimelineEntry, type RunningSummary, type RuntimeEvent, type Workspace, type WorkspacePreset, ATTACHMENT_LIMITS } from "../shared/types.ts";
+import { type AgentActivityEvent, type AgentConfig, type AgentConfigWithModelState, type AgentId, type AgentModelProbeResponse, type AgentModelStateSnapshot, type AgentPlanSnapshot, type AgentRuntimeKind, type AgentState, type AgentTeamTemplate, type AppState, type ApprovalMode, type ChatMessage, type Conversation, type ConversationInfo, type DraftAttachmentInfo, type ElicitationContent, type ElicitationFieldSchema, type ElicitationResponse, type InteractionMode, type MessagePage, type PendingElicitation, type PendingPermission, type PermissionDecision, type PersistedProcessTimelineEntry, type RunningSummary, type RuntimeEvent, type Workspace, type WorkspacePreset, ATTACHMENT_LIMITS } from "../shared/types.ts";
 import { appendTransientProcessActivity, collapseToolExecutions, type ProcessToolActivity, type ProcessToolExecution } from "../shared/process-activity.ts";
 import { WorkAnalysisPanel } from "./WorkAnalysisPanel.tsx";
 import * as TDesign from "tdesign-react";
@@ -2702,21 +2702,22 @@ function AgentManagerPanel({
       .catch(() => setTeamTemplates([]));
   }, []);
 
-  async function probeModels(force = false, runtime?: AgentRuntimeKind) {
+  async function probeModels(force = false, runtime?: AgentRuntimeKind, agentId?: AgentId) {
     if (isProbingModels) return;
     setIsProbingModels(true);
     try {
       const params = new URLSearchParams();
       if (force) params.set("force", "1");
       if (runtime) params.set("runtime", runtime);
+      if (agentId) params.set("agentId", agentId);
       const query = params.toString();
       const response = await fetch(`/api/agents/probe-models${query ? `?${query}` : ""}`, { method: "POST" });
       if (!response.ok) {
         setError("获取模型列表失败，请稍后重试。");
         return;
       }
-      const probedConfigs = await response.json() as AgentConfigWithModelState[];
-      setConfigs((current) => mergeProbedConfigs(current, probedConfigs));
+      const probeResponse = await response.json() as AgentModelProbeResponse;
+      setConfigs((current) => mergeModelProbeResponse(current, probeResponse));
     } catch {
       setError("获取模型列表失败，请检查本地运行时是否可用。");
     } finally {
@@ -2984,7 +2985,7 @@ function AgentManagerPanel({
                           snapshot={modelSnapshot}
                           probe={modelProbe}
                           onChange={(patch) => updateConfig(i, patch)}
-                          onRefreshModels={() => void probeModels(true, config.runtime)}
+                          onRefreshModels={() => void probeModels(true, config.runtime, config.id)}
                           isRefreshing={isProbingModels}
                         />
                         <div className="fieldWithHint fieldFullWidth">
@@ -3097,6 +3098,24 @@ export function mergeProbedConfigs(
     }),
     ...current.filter((config) => !probedIds.has(config.id)),
   ];
+}
+
+export function mergeModelProbeResponse(
+  current: AgentConfigWithModelState[],
+  response: AgentModelProbeResponse,
+): AgentConfigWithModelState[] {
+  const merged = mergeProbedConfigs(current, response.configs);
+  const target = response.target;
+  if (!target) return merged;
+  return merged.map((config) => (
+    config.id === target.agentId && config.runtime === target.runtimeKind
+      ? {
+          ...config,
+          modelState: target.modelState ?? undefined,
+          modelProbe: target.modelProbe,
+        }
+      : config
+  ));
 }
 
 function MarkdownContent({ content }: { content: string }) {

--- a/tests/app-process-events.test.ts
+++ b/tests/app-process-events.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { applyEvent, buildProcessTimeline, mergeProbedConfigs, upsertMessage } from "../src/ui/App.tsx";
+import { applyEvent, buildProcessTimeline, mergeModelProbeResponse, mergeProbedConfigs, upsertMessage } from "../src/ui/App.tsx";
 import type { AgentActivityEvent, AgentModelStateSnapshot, AgentPlanSnapshot, AppState, ChatMessage } from "../src/shared/types.ts";
 
 const CONVERSATION = "conv1";
@@ -401,4 +401,75 @@ test("model probe responses preserve unsaved local employee configuration", () =
   assert.equal(merged[0]?.model?.preferredModelId, "model-b");
   assert.deepEqual(merged[0]?.modelState, probed.modelState);
   assert.deepEqual(merged[0]?.modelProbe, probed.modelProbe);
+});
+
+test("targeted model probe applies to an unsaved runtime switch", () => {
+  const local = {
+    id: "developer",
+    name: "本地改名",
+    description: "未保存描述",
+    runtime: "codebuddy" as const,
+    systemPrompt: "未保存提示词",
+    enabled: true,
+  };
+  const serverConfig = {
+    ...local,
+    name: "服务端旧名称",
+    runtime: "claude-code" as const,
+  };
+  const modelState: AgentModelStateSnapshot = {
+    agentId: "developer",
+    runtimeKind: "codebuddy",
+    configId: "model",
+    choices: [{ value: "glm-5.3", name: "GLM-5.3" }],
+    currentValue: undefined,
+    currentValueSource: "probe",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+
+  const merged = mergeModelProbeResponse([local], {
+    configs: [serverConfig],
+    target: {
+      agentId: "developer",
+      runtimeKind: "codebuddy",
+      modelState,
+      modelProbe: { runtimeKind: "codebuddy", status: "ready", updatedAt: modelState.updatedAt },
+    },
+  });
+
+  assert.equal(merged[0]?.name, "本地改名");
+  assert.equal(merged[0]?.runtime, "codebuddy");
+  assert.equal(merged[0]?.systemPrompt, "未保存提示词");
+  assert.deepEqual(merged[0]?.modelState, modelState);
+  assert.equal(merged[0]?.modelProbe?.status, "ready");
+});
+
+test("targeted model probe does not overwrite a later runtime switch", () => {
+  const local = {
+    id: "developer",
+    name: "开发",
+    runtime: "codex" as const,
+    systemPrompt: "实现任务",
+    enabled: true,
+  };
+  const merged = mergeModelProbeResponse([local], {
+    configs: [local],
+    target: {
+      agentId: "developer",
+      runtimeKind: "codebuddy",
+      modelState: {
+        agentId: "developer",
+        runtimeKind: "codebuddy",
+        configId: "model",
+        choices: [{ value: "glm-5.3", name: "GLM-5.3" }],
+        currentValue: undefined,
+        currentValueSource: "probe",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+      modelProbe: { runtimeKind: "codebuddy", status: "ready" },
+    },
+  });
+
+  assert.equal(merged[0]?.runtime, "codex");
+  assert.equal(merged[0]?.modelState, undefined);
 });


### PR DESCRIPTION
## 变更

- 模型刷新请求携带当前表单中的员工 ID 与 runtime，支持未保存的运行时切换。
- 服务端按请求目标探测对应 ACP runtime，并单独返回目标员工的模型状态。
- 前端只合并模型探测字段，不覆盖员工名称、提示词、runtime 等未保存配置。
- 增加异步响应隔离，避免旧 runtime 的迟到结果覆盖当前选择。
- 补充模型探测与 UI 状态合并测试，并更新架构说明。

Fixes #151

## 验证

- `npm run test`：603 passed，1 skipped。
- `npx tsc --noEmit`：通过。
- Vite production build：通过。
- `git diff --check`：通过。

## 已知限制

- 完整 `npm run build` 在 standalone 阶段因当前环境缺少 Bun 未完成；TypeScript 与 Vite 构建均已通过。