### PR TITLE
Isolate page conversation context and add configurable supervisor runtime and model

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -107,6 +107,11 @@ model selection through ACP session config options. The flow is:
    distinct runtime and reads `session/new` config options without sending a
    prompt. The temporary connection is destroyed after discovery and does not
    create an Orbit employee session or conversation record.
+- A manual refresh is scoped to the employee id and runtime currently selected
+   in the settings form, so it also works before a runtime change or a newly
+   added employee has been saved. The response carries this target snapshot
+   separately from the persisted agent configs; the UI merges only model state
+   and keeps all unsaved form edits.
 
 1. On connection initialization Orbit declares the `session.configOptions`
    client capability. New, resumed, and restored sessions return the runtime's
@@ -220,10 +225,10 @@ Each project directory gets its own isolated workspace via `src/core/workspace-s
 
 ## Workspace & Conversation Management
 
-The server keeps one active UI pointer while retaining multiple live conversation contexts through `src/server/conversation-context.ts`:
+The server retains multiple live conversation contexts through `src/server/conversation-context.ts`. Each browser page owns its workspace and conversation through URL query parameters; the server's active pointer is retained only as a compatibility fallback for older clients and restart recovery:
 
 - **ConversationContext**: bundles per-conversation runtime state (MessageStore, TerminalTranscriptStore, AgentRegistry, RunManager, MessageRouter).
-- **Context map**: contexts are keyed by workspace and conversation, created lazily, and retained while users switch elsewhere so work can continue in the background.
+- **Context map**: contexts are keyed by workspace and conversation, created lazily, and retained while pages switch elsewhere so work can continue in the background. Core runtime events carry both identifiers, and SSE subscriptions filter by the page scope.
 - **LRU bound**: up to 10 inactive contexts are retained; idle contexts may be evicted, but contexts with running agents are never evicted.
 - **WorkspaceStore CRUD**: list, create, update, delete workspaces. Deleting a workspace removes its live contexts and persisted data.
 - **ConversationStore**: manages conversation metadata per workspace at `conversations/<workspaceId>/conversations.json`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -182,6 +182,39 @@ The final agent prompt is assembled in this order:
 
 Workspace prompts inject optional shared user context across all employees, while each employee retains its own task-specific instruction. They do not define or replace Orbit's three interaction modes. Complex collaboration uses a separate internal supervisor profile, and its persisted runtime session is retained when the conversation switches to another mode.
 
+### Supervisor Configuration
+
+The built-in supervisor used by 复杂协作 is configurable per conversation through
+`ConversationInfo.supervisorConfig`:
+
+```ts
+type SupervisorConfig = {
+  runtime: AgentRuntimeKind;
+  model?: AgentModelPreference;
+};
+```
+
+- **Runtime** — which of Claude Code, Codex, or CodeBuddy runs the supervisor.
+  Changing it cancels the supervisor's queued or running checks and rebuilds its
+  session. Other employees and message history are unaffected.
+- **Model** — a preference recorded with the runtime it was chosen under, so a
+  preference is ignored once the runtime changes (model value ids are not
+  portable across runtimes). Changing only the model does **not** cancel work or
+  rebuild the session; the new preference is applied lazily when the supervisor's
+  next run starts, matching how regular employee preferences behave.
+
+The supervisor keeps its internal id across all conversations, so its model
+snapshot is stored per conversation (`supervisor:<conversation-id>` in
+`agent-model-state.json`) and `agent.model_state` events for it carry a
+`conversationId` so page-scoped SSE delivery filters them correctly.
+
+Configuration is reachable from the collaboration mode menu before or after
+enabling 复杂协作, and is saved through
+`PUT /api/conversations/:id/supervisor-config?workspaceId=...&conversationId=...`.
+Conversations recorded before this field existed keep only `supervisionRuntime`;
+`ConversationStore` maps it to `{ runtime: supervisionRuntime }` on read and new
+writes use `supervisorConfig` only.
+
 `WorkspaceConfigStore` (`src/core/workspace-config-store.ts`) manages load/save with atomic writes and graceful fallback to defaults when the file is missing or corrupted.
 
 ## Channel History

--- a/docs/DATA_DIRECTORY.md
+++ b/docs/DATA_DIRECTORY.md
@@ -55,6 +55,11 @@ runtime-derived state, not user configuration: model preferences chosen in the
 settings UI are stored in `agents.json`, and this cache is rewritten by Orbit
 whenever discovery or a real run reports a fresh snapshot.
 
+The built-in supervisor shares one internal id across every conversation, so
+its entry is keyed `supervisor:<conversation-id>` instead of a bare employee id.
+Events still report `agentId: "supervisor"`, so no conversation can overwrite
+another conversation's supervisor snapshot.
+
 These files can contain project paths, conversation content, uploaded
 attachments, digital employee configuration, ACP session records, runtime
 activity, and terminal output. Treat `~/.orbit` as private user data.

--- a/docs/TERMINOLOGY_AND_ROUTING.md
+++ b/docs/TERMINOLOGY_AND_ROUTING.md
@@ -23,7 +23,9 @@ Use these terms in docs, issues, PRs, screenshots, and user-facing copy.
 - **Supervisor**: the built-in coordinator enabled by 复杂协作. It decomposes
   the goal, schedules digital employees, tracks progress, recovers from
   failures, and drives the task to closure. It is not a user-configured digital
-  employee.
+  employee. Its runtime and model preference are configurable per conversation
+  (see [Supervisor Configuration](#supervisor-configuration)); its display name,
+  system prompt, and triggers are not.
 - **Assignment marker**: an `@display-name:` marker that tells Orbit which
   digital employee should receive work. The name is the configured display name,
   not the internal id.
@@ -51,6 +53,25 @@ never loses context.
 
 These mode rules are built into Orbit and apply to custom teams as well as the
 built-in templates. They do not depend on editable workspace prompts or rules.
+
+## Supervisor Configuration
+
+The supervisor is not a digital employee, but its runtime and model preference
+are user-configurable per conversation and can be changed before or after
+enabling 复杂协作:
+
+- **Runtime** (Claude Code, Codex, CodeBuddy): changing it cancels the
+  supervisor's queued or running checks and rebuilds its session. Other digital
+  employees and message history are unaffected.
+- **Model**: recorded together with the runtime it was chosen under, so it stops
+  applying once the runtime changes. Changing only the model cancels nothing and
+  takes effect on the supervisor's next run.
+
+Switching away from 复杂协作 keeps the configuration and the supervisor's
+resumable session, so returning to the mode restores the previous setup.
+
+Call the supervisor **监工** in user-facing copy. The bare word `supervisor` is
+an internal id and must not appear in UI text.
 
 ## Routing Markers
 

--- a/src/core/agent-model-state-store.ts
+++ b/src/core/agent-model-state-store.ts
@@ -3,6 +3,24 @@ import os from "node:os";
 import path from "node:path";
 
 import type { AgentId, AgentModelStateSnapshot } from "../shared/types.ts";
+import { INTERNAL_SUPERVISOR_ID } from "./agent-profiles.ts";
+
+/**
+ * 监工是内部保留 ID，所有会话共用 agentId "supervisor"。若沿用固定键，一个会话
+ * 探测到的模型列表会覆盖同工作区其他会话的监工快照（issue #153）。
+ * 因此存储层用 `supervisor:<conversationId>` 作为内部组合键，对外仍暴露
+ * agentId "supervisor"，由读写两侧的键转换屏蔽这个差异。
+ */
+const SUPERVISOR_STORAGE_PREFIX = `${INTERNAL_SUPERVISOR_ID}:`;
+
+export function supervisorStorageKey(conversationId: string): string {
+  return `${SUPERVISOR_STORAGE_PREFIX}${conversationId}`;
+}
+
+/** 存储键 → 对外暴露的 agentId。 */
+export function storageKeyAgentId(storageKey: string): AgentId {
+  return storageKey.startsWith(SUPERVISOR_STORAGE_PREFIX) ? INTERNAL_SUPERVISOR_ID : storageKey;
+}
 
 /**
  * 员工模型快照的 workspace 级存储（issue #142）。runtime 每次新建/恢复会话
@@ -42,10 +60,11 @@ export class AgentModelStateStore {
     return this.load(workspaceId)[agentId];
   }
 
-  /** 单员工键级更新：读取现有表、替换该键后整体原子写回。 */
-  update(workspaceId: string, snapshot: AgentModelStateSnapshot): void {
+  /** 单员工键级更新：读取现有表、替换该键后整体原子写回。
+   *  storageKey 用于监工的会话维度隔离（默认即 snapshot.agentId）。 */
+  update(workspaceId: string, snapshot: AgentModelStateSnapshot, storageKey: string = snapshot.agentId): void {
     const states = this.load(workspaceId);
-    states[snapshot.agentId] = snapshot;
+    states[storageKey] = snapshot;
     const filePath = this.statePath(workspaceId);
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     const tmpFile = `${filePath}.tmp`;
@@ -58,10 +77,11 @@ export class AgentModelStateStore {
   }
 }
 
-function isAgentModelStateSnapshot(agentId: string, value: unknown): value is AgentModelStateSnapshot {
+function isAgentModelStateSnapshot(storageKey: string, value: unknown): value is AgentModelStateSnapshot {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const snapshot = value as Record<string, unknown>;
-  if (snapshot.agentId !== agentId) return false;
+  // 监工快照的存储键带会话后缀，而快照内 agentId 仍是内部名 supervisor。
+  if (snapshot.agentId !== storageKeyAgentId(storageKey)) return false;
   if (!isAgentRuntimeKind(snapshot.runtimeKind)) return false;
   if (typeof snapshot.configId !== "string" || typeof snapshot.updatedAt !== "string") return false;
   if (!Array.isArray(snapshot.choices)) return false;

--- a/src/core/agent-profiles.ts
+++ b/src/core/agent-profiles.ts
@@ -1,19 +1,27 @@
-import type { AgentConfig, AgentId, AgentProfile, AgentRuntimeKind } from "../shared/types.ts";
+import type { AgentConfig, AgentId, AgentProfile, AgentRuntimeKind, SupervisorConfig } from "../shared/types.ts";
 
 export type AgentRuntimeOverrides = Partial<Record<AgentId, AgentRuntimeKind>>;
 
 export const INTERNAL_SUPERVISOR_ID = "supervisor";
 
-export function createSupervisorProfile(cwd: string, runtime: AgentRuntimeKind): AgentProfile {
+/**
+ * 监工 profile（issue #153）：运行时与模型偏好来自会话级配置。
+ * 模型偏好沿用普通员工的 runtime 归属门控——value ID 不跨 runtime 通用，
+ * 偏好所属 runtime 与当前 runtime 不一致即不应用。
+ */
+export function createSupervisorProfile(cwd: string, config: SupervisorConfig): AgentProfile {
   return {
     id: INTERNAL_SUPERVISOR_ID,
     name: "监工",
     description: "Coordinates the conversation and moves assigned work toward completion.",
-    runtime,
+    runtime: config.runtime,
     cwd,
     internal: true,
     systemPrompt: "You are Orbit's built-in collaboration supervisor. Monitor the conversation and coordinate enabled digital employees toward task completion. You may only use the conversation history. Never read files, search code, run commands, modify files, or access external resources. Delegate through the exact @employee-name: markers listed in the available employees section and conclude to the user with @user:.",
     triggers: { onUnassignedMessage: true, onAgentBlocked: true, onRunFailed: true },
+    ...(config.model?.runtimeKind === config.runtime && config.model.preferredModelId?.trim()
+      ? { preferredModelId: config.model.preferredModelId.trim() }
+      : {}),
   };
 }
 

--- a/src/core/agent-registry.ts
+++ b/src/core/agent-registry.ts
@@ -89,6 +89,29 @@ export class AgentRegistry {
     this.sessions.get(profile.id)?.start();
   }
 
+  /**
+   * 更新员工的首选模型（issue #153）。只改 profile 与会话内的偏好，
+   * 不重建会话、不取消排队/运行中的任务；偏好在每次运行开始时惰性应用，
+   * 因此新值从该员工的下一次运行开始生效。
+   */
+  updatePreferredModel(agentId: AgentId, preferredModelId?: string): boolean {
+    const session = this.sessions.get(agentId);
+    if (!session) return false;
+    const trimmed = preferredModelId?.trim() || undefined;
+    this.profilesById = this.profilesById.map((profile) => {
+      if (profile.id !== agentId) return profile;
+      const { preferredModelId: _previous, ...rest } = profile;
+      return trimmed ? { ...rest, preferredModelId: trimmed } : rest;
+    });
+    session.setPreferredModelId(trimmed);
+    return true;
+  }
+
+  /** 当前注册员工的 profile（含运行期更新后的偏好）。 */
+  profile(agentId: AgentId): AgentProfile | undefined {
+    return this.profilesById.find((profile) => profile.id === agentId);
+  }
+
   remove(agentId: AgentId): void {
     const session = this.sessions.get(agentId);
     if (!session) return;

--- a/src/core/agent-registry.ts
+++ b/src/core/agent-registry.ts
@@ -16,6 +16,7 @@ export class AgentRegistry {
     private readonly conversationId: string,
     private readonly runtimes: ReadonlyMap<AgentRuntime["kind"], AgentRuntime> = DEFAULT_AGENT_RUNTIMES,
     private readonly modelState?: AgentModelStateBridge,
+    private readonly workspaceId?: string,
   ) {
     this.profilesById = [...profiles];
     for (const profile of profiles) {
@@ -34,6 +35,7 @@ export class AgentRegistry {
       eventBus: this.eventBus,
       sessionStore: this.sessionStore,
       conversationId: this.conversationId,
+      workspaceId: this.workspaceId,
       ...(profile.preferredModelId ? { preferredModelId: profile.preferredModelId } : {}),
       ...(this.modelState ? { modelState: this.modelState } : {}),
     }));

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -10,6 +10,7 @@ import type {
   PendingPermission,
   PermissionDecision,
   RunResult,
+  RuntimeEvent,
 } from "../shared/types.ts";
 import { isAgentRunCancelledError, type AgentRuntime } from "./agent-runtime.ts";
 import { sanitizeAgentVisibleReply } from "./agent-prompt.ts";
@@ -35,6 +36,8 @@ export type AgentSessionOptions = {
   quietWindowMs?: number;
   sessionStore: SessionStore;
   conversationId: string;
+  /** Workspace scope for events; optional for standalone unit-test callers. */
+  workspaceId?: string;
   interactionTimeoutMs?: number;
   preferredModelId?: string;
   modelState?: AgentModelStateBridge;
@@ -73,6 +76,14 @@ export class AgentSession {
   private runCount = 0;
 
   constructor(private readonly options: AgentSessionOptions) {}
+
+  private publish(event: RuntimeEvent): void {
+    this.options.eventBus.publish(
+      this.options.workspaceId && "conversationId" in event
+        ? { ...event, workspaceId: this.options.workspaceId }
+        : event,
+    );
+  }
 
   get id(): AgentId {
     return this.options.id;
@@ -225,7 +236,7 @@ export class AgentSession {
       requestPermission: (request) => this.requestPermission(runId, request),
       requestElicitation: (request) => this.requestElicitation(runId, request),
       onOutput: (text) => {
-        this.options.eventBus.publish({
+        this.publish({
           type: "terminal.chunk",
           conversationId: this.options.conversationId,
           agentId: this.id,
@@ -234,7 +245,7 @@ export class AgentSession {
         });
       },
       onActivity: (activity) => {
-        this.options.eventBus.publish({
+        this.publish({
           type: "runtime.activity",
           conversationId: this.options.conversationId,
           agentId: this.id,
@@ -247,7 +258,7 @@ export class AgentSession {
 
     handle.sessionId.then((sessionId) => {
       if (sessionId && this.activeRun?.runId === runId) {
-        this.options.eventBus.publish({
+        this.publish({
           type: "run.sessionId",
           conversationId: this.options.conversationId,
           agentId: this.id,
@@ -329,12 +340,12 @@ export class AgentSession {
         this.settlePendingPermission(permission.id, pending, "reject", "审批请求已过期，操作未获批准。");
       }, timeoutMs);
       this.pendingPermissionStates.set(permission.id, { permission, resolve, timer });
-      this.options.eventBus.publish({
+      this.publish({
         type: "permission.requested",
         conversationId: this.options.conversationId,
         permission,
       });
-      this.options.eventBus.publish({
+      this.publish({
         type: "runtime.activity",
         conversationId: this.options.conversationId,
         agentId: this.id,
@@ -373,12 +384,12 @@ export class AgentSession {
         this.settlePendingElicitation(id, pending, { action: "cancel" }, "用户输入请求已过期。");
       }, timeoutMs);
       this.pendingElicitationStates.set(id, { elicitation, resolve, timer });
-      this.options.eventBus.publish({
+      this.publish({
         type: "elicitation.requested",
         conversationId: this.options.conversationId,
         elicitation,
       });
-      this.options.eventBus.publish({
+      this.publish({
         type: "runtime.activity",
         conversationId: this.options.conversationId,
         agentId: this.id,
@@ -401,12 +412,12 @@ export class AgentSession {
     this.pendingPermissionStates.delete(requestId);
     clearTimeout(pending.timer);
     pending.resolve(decision);
-    this.options.eventBus.publish({
+    this.publish({
       type: "permission.resolved",
       conversationId: this.options.conversationId,
       requestId: pending.permission.id,
     });
-    this.options.eventBus.publish({
+    this.publish({
       type: "runtime.activity",
       conversationId: this.options.conversationId,
       agentId: this.id,
@@ -442,13 +453,13 @@ export class AgentSession {
     this.pendingElicitationStates.delete(requestId);
     clearTimeout(pending.timer);
     pending.resolve(response);
-    this.options.eventBus.publish({
+    this.publish({
       type: "elicitation.resolved",
       conversationId: this.options.conversationId,
       requestId,
     });
     if (activityText) {
-      this.options.eventBus.publish({
+      this.publish({
         type: "runtime.activity",
         conversationId: this.options.conversationId,
         agentId: this.id,
@@ -489,7 +500,7 @@ export class AgentSession {
     }
 
     this.status = status;
-    this.options.eventBus.publish({
+    this.publish({
       type: "agent.status",
       conversationId: this.options.conversationId,
       agentId: this.id,

--- a/src/core/agent-session.ts
+++ b/src/core/agent-session.ts
@@ -74,8 +74,24 @@ export class AgentSession {
   private readonly pendingElicitationStates = new Map<string, PendingElicitationState>();
   private elicitationCount = 0;
   private runCount = 0;
+  /** 首选模型可在会话运行期间更新（issue #153），下一次运行开始时生效。 */
+  private preferredModelId?: string;
 
-  constructor(private readonly options: AgentSessionOptions) {}
+  constructor(private readonly options: AgentSessionOptions) {
+    this.preferredModelId = options.preferredModelId;
+  }
+
+  /**
+   * 更新首选模型。只改内存中的偏好，不重启会话、不中断当前运行：
+   * 偏好在每次运行开始时惰性应用，因此新值从下一次运行开始生效。
+   */
+  setPreferredModelId(preferredModelId?: string): void {
+    this.preferredModelId = preferredModelId?.trim() || undefined;
+  }
+
+  preferredModel(): string | undefined {
+    return this.preferredModelId;
+  }
 
   private publish(event: RuntimeEvent): void {
     this.options.eventBus.publish(
@@ -228,7 +244,8 @@ export class AgentSession {
       resumeSessionId,
       imagePaths,
       // 模型偏好（issue #142）：每次运行开始时读最近快照并惰性应用。
-      preferredModelId: this.options.preferredModelId,
+      // 读可变字段而非 options，使运行期更新的偏好在下一次运行生效（issue #153）。
+      preferredModelId: this.preferredModelId,
       lastSessionConfig: this.options.modelState?.load(this.id),
       onSessionConfig: this.options.modelState
         ? (snapshot) => this.options.modelState!.update(snapshot)

--- a/src/core/attachment-store.ts
+++ b/src/core/attachment-store.ts
@@ -233,6 +233,12 @@ export class AttachmentStore {
     }
   }
 
+  /** Remove abandoned draft uploads when an entire workspace is deleted. */
+  async deleteWorkspaceDrafts(workspaceId: string): Promise<void> {
+    const draftDir = this.safePath("tmp", "attachments", workspaceId);
+    await fsPromises.rm(draftDir, { recursive: true, force: true });
+  }
+
   // --- Cleanup ---
 
   async cleanupExpiredDrafts(): Promise<number> {

--- a/src/core/channel-watch.ts
+++ b/src/core/channel-watch.ts
@@ -30,6 +30,7 @@ export class ChannelWatchService {
     private readonly messages: MessageStore,
     eventBus: EventBus,
     profiles: readonly AgentProfile[],
+    private readonly workspaceId?: string,
   ) {
     this.knownNames = new Set(profiles.map((p) => p.name.toLocaleLowerCase()));
     this.knownNames.add("user"); // @user: is the task-closure signal
@@ -54,6 +55,7 @@ export class ChannelWatchService {
 
     this.unsubscribe = eventBus.subscribe((event) => {
       if (this.disposed) return;
+      if (this.workspaceId && "workspaceId" in event && event.workspaceId !== undefined && event.workspaceId !== this.workspaceId) return;
       if ("conversationId" in event && event.conversationId !== this.conversationId) return;
 
       if (event.type === "message.created") {

--- a/src/core/conversation-store.ts
+++ b/src/core/conversation-store.ts
@@ -3,7 +3,7 @@ import crypto from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 
-import type { AgentId, AgentRuntimeKind, Conversation, InteractionMode } from "../shared/types.ts";
+import type { AgentId, AgentRuntimeKind, Conversation, InteractionMode, SupervisorConfig } from "../shared/types.ts";
 import { isInteractionMode } from "../shared/types.ts";
 
 type ConversationData = {
@@ -48,7 +48,7 @@ export class ConversationStore {
   update(workspaceId: string, conversationId: string, patch: {
     name?: string;
     interactionMode?: InteractionMode;
-    supervisionRuntime?: AgentRuntimeKind | null;
+    supervisorConfig?: SupervisorConfig | null;
     lastDirectAgentId?: AgentId;
   }): Conversation {
     const data = this.loadData(workspaceId);
@@ -60,8 +60,10 @@ export class ConversationStore {
       ...data.conversations[index]!,
       ...(patch.name !== undefined ? { name: patch.name } : {}),
       ...(patch.interactionMode !== undefined ? { interactionMode: patch.interactionMode } : {}),
-      ...(patch.supervisionRuntime !== undefined
-        ? patch.supervisionRuntime === null ? { supervisionRuntime: undefined } : { supervisionRuntime: patch.supervisionRuntime }
+      ...(patch.supervisorConfig !== undefined
+        ? patch.supervisorConfig === null
+          ? { supervisorConfig: undefined, supervisionRuntime: undefined }
+          : { supervisorConfig: patch.supervisorConfig }
         : {}),
       ...(patch.lastDirectAgentId !== undefined ? { lastDirectAgentId: patch.lastDirectAgentId } : {}),
     };
@@ -130,13 +132,7 @@ export class ConversationStore {
       const parsed = JSON.parse(content) as ConversationData;
       return {
         conversations: Array.isArray(parsed.conversations)
-          ? parsed.conversations.map((conversation) => ({
-              ...conversation,
-              // 无旧格式兼容：非法/缺失的 interactionMode 一律回到默认 direct
-              interactionMode: isInteractionMode(conversation.interactionMode)
-                ? conversation.interactionMode
-                : "direct",
-            }))
+          ? parsed.conversations.map(withNormalizedFields)
           : [],
       };
     } catch {
@@ -152,4 +148,24 @@ export class ConversationStore {
     fs.writeFileSync(tmpFile, JSON.stringify(data, null, 2) + os.EOL);
     fs.renameSync(tmpFile, filePath);
   }
+}
+
+/**
+ * 读取时规范化会话记录：
+ * - 非法/缺失的 interactionMode 一律回到默认 direct（无旧格式兼容）。
+ * - issue #153 之前只保存 supervisionRuntime，读取时映射为
+ *   `supervisorConfig = { runtime: supervisionRuntime }`。不批量迁移数据，
+ *   旧字段原样保留，新写入只使用 supervisorConfig。
+ */
+function withNormalizedFields(conversation: Conversation): Conversation {
+  const legacyRuntime = conversation.supervisionRuntime;
+  return {
+    ...conversation,
+    interactionMode: isInteractionMode(conversation.interactionMode)
+      ? conversation.interactionMode
+      : "direct",
+    ...(conversation.supervisorConfig || !legacyRuntime
+      ? {}
+      : { supervisorConfig: { runtime: legacyRuntime } }),
+  };
 }

--- a/src/core/message-store.ts
+++ b/src/core/message-store.ts
@@ -130,6 +130,23 @@ export class MessageStore {
     return [...this.messages];
   }
 
+  /** Find a client-created user message across the whole durable history. */
+  findByClientMessageId(clientMessageId: string): ChatMessage | null {
+    const loaded = this.messages.find(
+      (message) => message.kind === "user" && message.clientMessageId === clientMessageId,
+    );
+    if (loaded) return loaded;
+    if (!this.filePath) return null;
+
+    for (const shard of this.manifest.shards) {
+      const message = this.readShard(shard.name).find(
+        (candidate) => candidate.kind === "user" && candidate.clientMessageId === clientMessageId,
+      );
+      if (message) return message;
+    }
+    return null;
+  }
+
   get(id: string): ChatMessage | null {
     const loaded = this.messages.find((message) => message.id === id);
     if (loaded) return loaded;

--- a/src/core/run-manager.ts
+++ b/src/core/run-manager.ts
@@ -64,6 +64,8 @@ export type ManagedRun = {
 
 export type RunManagerOptions = {
   conversationId: string;
+  /** Workspace scope for events; optional for standalone unit-test callers. */
+  workspaceId?: string;
   agents: AgentRunner;
   messages: MessageStore;
   eventBus: EventBus;
@@ -86,6 +88,14 @@ export class RunManager {
 
   constructor(private readonly options: RunManagerOptions) {
     this.unsubscribe = this.options.eventBus.subscribe((event) => this.handleRuntimeEvent(event));
+  }
+
+  private publish(event: RuntimeEvent): void {
+    this.options.eventBus.publish(
+      this.options.workspaceId && "conversationId" in event
+        ? { ...event, workspaceId: this.options.workspaceId }
+        : event,
+    );
   }
 
   dispose(): void {
@@ -167,7 +177,7 @@ export class RunManager {
       interactionMode: sourceMessage.interactionMode,
       approvalMode: sourceMessage.approvalMode ?? "ask",
     } satisfies NewChatMessage);
-    this.options.eventBus.publish({ type: "message.created", conversationId: this.options.conversationId, message: agentMessage });
+    this.publish({ type: "message.created", conversationId: this.options.conversationId, message: agentMessage });
 
     const run: ManagedRun = {
       id: runId,
@@ -245,7 +255,7 @@ export class RunManager {
       status: "cancelling",
       runStatus: "cancelling",
     });
-    this.options.eventBus.publish({
+    this.publish({
       type: "message.updated",
       conversationId: this.options.conversationId,
       message: updated,
@@ -282,7 +292,7 @@ export class RunManager {
       completedAt: run.completedAt,
       startedAt: run.startedAt,
     });
-    this.options.eventBus.publish({
+    this.publish({
       type: "message.updated",
       conversationId: this.options.conversationId,
       message: updated,
@@ -290,7 +300,7 @@ export class RunManager {
       // 无结算快照时不携带该字段，客户端保留实时活动、不剔除部分回答。
       ...(run.excludedAnswerGroup !== undefined ? { excludedAnswerGroup: run.excludedAnswerGroup } : {}),
     });
-    this.options.eventBus.publish({
+    this.publish({
       type: "run.cancelled",
       conversationId: this.options.conversationId,
       agentId: run.agentId,
@@ -328,7 +338,7 @@ export class RunManager {
       ...this.settleProcessFields(run),
       completedAt: run.completedAt,
     });
-    this.options.eventBus.publish({
+    this.publish({
       type: "message.updated",
       conversationId: this.options.conversationId,
       message: updated,
@@ -336,7 +346,7 @@ export class RunManager {
       // 无结算快照时不携带该字段，客户端保留实时活动、不剔除部分回答。
       ...(run.excludedAnswerGroup !== undefined ? { excludedAnswerGroup: run.excludedAnswerGroup } : {}),
     });
-    this.options.eventBus.publish({
+    this.publish({
       type: "run.cancelled",
       conversationId: this.options.conversationId,
       agentId: run.agentId,
@@ -484,7 +494,7 @@ export class RunManager {
       sessionId: runResult.sessionId,
       runIndex: runResult.runIndex,
     });
-    this.options.eventBus.publish({
+    this.publish({
       type: "message.updated",
       conversationId: this.options.conversationId,
       message: updated,
@@ -492,7 +502,7 @@ export class RunManager {
       // 无结算快照时不携带该字段，客户端保留实时活动、不剔除部分回答。
       ...(run.excludedAnswerGroup !== undefined ? { excludedAnswerGroup: run.excludedAnswerGroup } : {}),
     });
-    this.options.eventBus.publish({
+    this.publish({
       type: "run.completed",
       conversationId: this.options.conversationId,
       agentId: run.agentId,
@@ -536,7 +546,7 @@ export class RunManager {
       completedAt: run.completedAt,
       startedAt: run.startedAt,
     });
-    this.options.eventBus.publish({
+    this.publish({
       type: "message.updated",
       conversationId: this.options.conversationId,
       message: updated,
@@ -544,7 +554,7 @@ export class RunManager {
       // 无结算快照时不携带该字段，客户端保留实时活动、不剔除部分回答。
       ...(run.excludedAnswerGroup !== undefined ? { excludedAnswerGroup: run.excludedAnswerGroup } : {}),
     });
-    this.options.eventBus.publish({ type: "run.failed", conversationId: this.options.conversationId, agentId: run.agentId, runId: run.id, error: errorSummary, interactionMode: run.interactionMode });
+    this.publish({ type: "run.failed", conversationId: this.options.conversationId, agentId: run.agentId, runId: run.id, error: errorSummary, interactionMode: run.interactionMode });
     this.startNext(run.agentId);
     this.releaseRun(run);
   }
@@ -562,7 +572,7 @@ export class RunManager {
       runStatus: "running",
       startedAt,
     });
-    this.options.eventBus.publish({ type: "message.updated", conversationId: this.options.conversationId, message: updated });
+    this.publish({ type: "message.updated", conversationId: this.options.conversationId, message: updated });
     this.start(next);
   }
 
@@ -591,7 +601,7 @@ export class RunManager {
     } else {
       run.activity = appendTransientProcessActivity(run.activity, boundedActivity);
     }
-    this.options.eventBus.publish({ type: "run.activity", conversationId: this.options.conversationId, agentId: run.agentId, runId: run.id, activity: boundedActivity });
+    this.publish({ type: "run.activity", conversationId: this.options.conversationId, agentId: run.agentId, runId: run.id, activity: boundedActivity });
   }
 
   /** 运行结算时随消息持久化的过程字段。工具/状态活动不落盘，仅在内存与实时流中。 */
@@ -642,6 +652,7 @@ export class RunManager {
 
   private handleRuntimeEvent(event: RuntimeEvent): void {
     // Only process events for our own conversation
+    if (this.options.workspaceId && "workspaceId" in event && event.workspaceId !== undefined && event.workspaceId !== this.options.workspaceId) return;
     if ("conversationId" in event && event.conversationId !== this.options.conversationId) return;
 
     if (event.type === "run.sessionId" && event.runId) {
@@ -650,7 +661,7 @@ export class RunManager {
         const updated = this.options.messages.update(run.resultMessageId, {
           sessionId: event.sessionId,
         });
-        this.options.eventBus.publish({ type: "message.updated", conversationId: this.options.conversationId, message: updated });
+        this.publish({ type: "message.updated", conversationId: this.options.conversationId, message: updated });
       }
       return;
     }

--- a/src/server/conversation-context.ts
+++ b/src/server/conversation-context.ts
@@ -22,6 +22,7 @@ import {
   type PermissionDecision,
   type WorkspaceRuntimeConfig,
   type AgentRuntimeKind,
+  type SupervisorConfig,
 } from "../shared/types.ts";
 import { DEFAULT_WORKSPACE_CONFIG, DEFAULT_GLOBAL_CONFIG } from "../shared/types.ts";
 import { createSupervisorProfile, INTERNAL_SUPERVISOR_ID } from "../core/agent-profiles.ts";
@@ -31,7 +32,7 @@ const MAX_ROUTE_DEPTH = 10;
 
 export type ConversationContextPatch = {
   interactionMode?: InteractionMode;
-  supervisionRuntime?: AgentRuntimeKind | null;
+  supervisorConfig?: SupervisorConfig | null;
   lastDirectAgentId?: AgentId;
 };
 
@@ -45,7 +46,8 @@ export type ConversationContextOptions = {
   workspaceConfig?: WorkspaceRuntimeConfig;
   globalConfig?: GlobalRuntimeConfig;
   interactionMode?: InteractionMode;
-  supervisionRuntime?: AgentRuntimeKind;
+  /** 监工的运行时与模型偏好（issue #153）。旧字段 supervisionRuntime 由存储层映射而来。 */
+  supervisorConfig?: SupervisorConfig;
   lastDirectAgentId?: AgentId;
   /** 会话记录变更回调（如普通对话目标员工变化），由服务层负责持久化。 */
   onConversationPatch?: (patch: ConversationContextPatch) => void;
@@ -66,7 +68,7 @@ export class ConversationContext {
   private _globalConfig: GlobalRuntimeConfig;
   private _interactionMode: InteractionMode;
   private _lastDirectAgentId?: AgentId;
-  private _supervisionRuntime?: AgentRuntimeKind;
+  private _supervisorConfig?: SupervisorConfig;
   private readonly eventBus: EventBus;
   private readonly unsubscribe: () => void;
   private messageMutationTail: Promise<void> = Promise.resolve();
@@ -79,7 +81,7 @@ export class ConversationContext {
     this._globalConfig = options.globalConfig ?? structuredClone(DEFAULT_GLOBAL_CONFIG);
     this._interactionMode = options.interactionMode ?? "direct";
     this._lastDirectAgentId = options.lastDirectAgentId;
-    this._supervisionRuntime = options.supervisionRuntime;
+    this._supervisorConfig = options.supervisorConfig;
     this._profiles = profiles.filter((profile) => !profile.internal);
     this.eventBus = eventBus;
 
@@ -246,39 +248,72 @@ export class ConversationContext {
     return this._lastDirectAgentId;
   }
 
-  supervisionRuntime(): AgentRuntimeKind | undefined {
-    return this._supervisionRuntime;
+  supervisorConfig(): SupervisorConfig | undefined {
+    return this._supervisorConfig;
   }
 
   /**
    * 切换会话交互模式。只影响下一条用户消息：运行中/排队任务及其后续链沿用
    * 各自的模式快照，不因切换而取消或改变行为。
    *
-   * 监工策略：一旦设置过 supervisionRuntime，监工会话保持注册——切换到普通/
-   * 简单协作不删除其持久化 session（再次开启复杂协作时原样恢复），且仍在执行
-   * 的复杂协作链完成时仍可触发监工收尾（由 ChannelWatch 按消息模式快照门控）。
+   * 监工策略：一旦配置过监工，其会话保持注册——切换到普通/简单协作不删除其
+   * 持久化 session（再次开启复杂协作时原样恢复），且仍在执行复杂协作链完成时
+   * 仍可触发监工收尾（由 ChannelWatch 按消息模式快照门控）。
    */
   setInteractionMode(mode: InteractionMode, runtime?: AgentRuntimeKind): void {
     if (mode === "supervised") {
-      const selectedRuntime = runtime ?? this._supervisionRuntime;
+      const selectedRuntime = runtime ?? this._supervisorConfig?.runtime;
       if (!selectedRuntime) throw new Error("A runtime is required to enable supervised collaboration.");
-      // 切换监工 runtime 是对监工自身的重建操作：取消其排队/运行中的检查。
-      if (!this.agents.has(INTERNAL_SUPERVISOR_ID) || this._supervisionRuntime !== selectedRuntime) {
-        this.runManager.cancelAgentRuns(INTERNAL_SUPERVISOR_ID);
-        this.agents.remove(INTERNAL_SUPERVISOR_ID);
-        this.agents.add(createSupervisorProfile(this.cwd(), selectedRuntime));
+      if (!this.agents.has(INTERNAL_SUPERVISOR_ID) || this._supervisorConfig?.runtime !== selectedRuntime) {
+        // 模型偏好按 runtime 归属，跨运行时即失效，重建时不保留。
+        const model = this._supervisorConfig?.model?.runtimeKind === selectedRuntime
+          ? this._supervisorConfig.model
+          : undefined;
+        this.applySupervisorConfig(model ? { runtime: selectedRuntime, model } : { runtime: selectedRuntime });
       }
-      this._supervisionRuntime = selectedRuntime;
     }
-    // direct/collaborative：保留监工注册与 runtime 记录（不取消其运行、不清 session）。
+    // direct/collaborative：保留监工注册与配置（不取消其运行、不清 session）。
     this._interactionMode = mode;
     this.options.onConversationPatch?.({
       interactionMode: mode,
-      ...(mode === "supervised" && this._supervisionRuntime
-        ? { supervisionRuntime: this._supervisionRuntime }
+      ...(mode === "supervised" && this._supervisorConfig
+        ? { supervisorConfig: this._supervisorConfig }
         : {}),
     });
     this.rebuildCoordinationLayer();
+  }
+
+  /**
+   * 更新监工的运行时与模型偏好（issue #153）。
+   *
+   * - 运行时变化：这是对监工自身的重建操作——取消其排队/运行中的检查，移除并
+   *   按新配置重建 session。普通员工与历史消息不受影响。
+   * - 仅模型变化：既不取消任务也不重建会话，只更新会话内的首选模型，
+   *   新偏好从监工的下一次运行开始生效。
+   *
+   * 开关复杂协作只影响下一条消息，因此本方法可在任意模式下调用。
+   */
+  setSupervisorConfig(config: SupervisorConfig): void {
+    if (!this.agents.has(INTERNAL_SUPERVISOR_ID) || this._supervisorConfig?.runtime !== config.runtime) {
+      this.applySupervisorConfig(config);
+    } else {
+      // 仅模型变化：偏好与当前 runtime 不匹配时不应用（value ID 不跨 runtime 通用）。
+      this.agents.updatePreferredModel(
+        INTERNAL_SUPERVISOR_ID,
+        config.model?.runtimeKind === config.runtime ? config.model?.preferredModelId : undefined,
+      );
+      this._supervisorConfig = config;
+    }
+    this.options.onConversationPatch?.({ supervisorConfig: config });
+    this.rebuildCoordinationLayer();
+  }
+
+  /** 重建监工会话：先取消其排队/运行中的检查，再按新配置注册。 */
+  private applySupervisorConfig(config: SupervisorConfig): void {
+    this.runManager.cancelAgentRuns(INTERNAL_SUPERVISOR_ID);
+    this.agents.remove(INTERNAL_SUPERVISOR_ID);
+    this.agents.add(createSupervisorProfile(this.cwd(), config));
+    this._supervisorConfig = config;
   }
 
   private buildRuntimePrompt(
@@ -315,10 +350,10 @@ export class ConversationContext {
 
   private buildActiveProfiles(profiles: readonly AgentProfile[]): AgentProfile[] {
     const normalProfiles = profiles.filter((profile) => !profile.internal);
-    // 监工注册条件是"设置过 supervisionRuntime"而非当前模式：切换到普通/简单协作
+    // 监工注册条件是"配置过监工"而非当前模式：切换到普通/简单协作
     // 后，仍在执行的复杂协作链仍可能需要监工检查，且其 session 需要保持可恢复。
-    if (!this._supervisionRuntime) return [...normalProfiles];
-    return [...normalProfiles, createSupervisorProfile(this.cwdFrom(profiles), this._supervisionRuntime)];
+    if (!this._supervisorConfig) return [...normalProfiles];
+    return [...normalProfiles, createSupervisorProfile(this.cwdFrom(profiles), this._supervisorConfig)];
   }
 
   private cwdFrom(profiles: readonly AgentProfile[]): string {
@@ -326,10 +361,10 @@ export class ConversationContext {
   }
 
   private channelProfiles(profiles = this._profiles): AgentProfile[] {
-    if (!this._supervisionRuntime) return [...profiles];
+    if (!this._supervisorConfig) return [...profiles];
     return profiles.some((profile) => profile.id === INTERNAL_SUPERVISOR_ID)
       ? [...profiles]
-      : [...profiles, createSupervisorProfile(this.cwdFrom(profiles), this._supervisionRuntime)];
+      : [...profiles, createSupervisorProfile(this.cwdFrom(profiles), this._supervisorConfig)];
   }
 
   private rebuildCoordinationLayer(): void {

--- a/src/server/conversation-context.ts
+++ b/src/server/conversation-context.ts
@@ -69,6 +69,7 @@ export class ConversationContext {
   private _supervisionRuntime?: AgentRuntimeKind;
   private readonly eventBus: EventBus;
   private readonly unsubscribe: () => void;
+  private messageMutationTail: Promise<void> = Promise.resolve();
 
   constructor(private options: ConversationContextOptions) {
     const { workspaceId, conversationId, profiles, eventBus, sessionStore, workspaceStore } = options;
@@ -103,6 +104,7 @@ export class ConversationContext {
 
     this.unsubscribe = eventBus.subscribe((event) => {
       // Only process events belonging to this conversation
+      if ("workspaceId" in event && event.workspaceId !== undefined && event.workspaceId !== workspaceId) return;
       if ("conversationId" in event && event.conversationId !== conversationId) return;
       if ((event as { type: string }).type === "terminal.chunk") {
         const e = event as { agentId: string; text: string };
@@ -111,7 +113,7 @@ export class ConversationContext {
     });
 
     const activeProfiles = this.buildActiveProfiles(this._profiles);
-    this.agents = new AgentRegistry(activeProfiles, eventBus, sessionStore, conversationId, undefined, options.modelState);
+    this.agents = new AgentRegistry(activeProfiles, eventBus, sessionStore, conversationId, undefined, options.modelState, workspaceId);
     this.agents.startAll();
 
     const agentIds = this.agents.ids();
@@ -119,6 +121,7 @@ export class ConversationContext {
     const self = this;
     this.runManager = new RunManager({
       conversationId,
+      workspaceId,
       agents: this.agents,
       messages: this.messages,
       eventBus,
@@ -139,11 +142,25 @@ export class ConversationContext {
       this.messages,
       eventBus,
       this.channelProfiles(),
+      workspaceId,
     );
   }
 
   hasRunningAgent(): boolean {
     return this.agents.hasRunningAgent();
+  }
+
+  /** Serialize message intake for this conversation, including async attachment commits. */
+  async withMessageMutation<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.messageMutationTail;
+    let release!: () => void;
+    this.messageMutationTail = new Promise<void>((resolve) => { release = resolve; });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
   }
 
   hasRunningOrQueued(): boolean {
@@ -177,7 +194,7 @@ export class ConversationContext {
 
     const { workspaceId, conversationId, eventBus, sessionStore } = this.options;
     const activeProfiles = this.buildActiveProfiles(profiles);
-    const newAgents = new AgentRegistry(activeProfiles, eventBus, sessionStore, conversationId, undefined, this.options.modelState);
+    const newAgents = new AgentRegistry(activeProfiles, eventBus, sessionStore, conversationId, undefined, this.options.modelState, this.options.workspaceId);
     newAgents.startAll();
 
     this._profiles = profiles.filter((profile) => !profile.internal);
@@ -188,6 +205,7 @@ export class ConversationContext {
 
     const newRunManager = new RunManager({
       conversationId,
+      workspaceId: this.options.workspaceId,
       agents: newAgents,
       messages: this.messages,
       eventBus,
@@ -208,6 +226,7 @@ export class ConversationContext {
       this.messages,
       eventBus,
       this.channelProfiles(activeProfiles),
+      this.options.workspaceId,
     );
 
     // Replace mutable fields via Object.assign (intentional hot-swap)
@@ -324,6 +343,7 @@ export class ConversationContext {
       this.messages,
       this.eventBus,
       profiles,
+      this.options.workspaceId,
     );
   }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -24,7 +24,7 @@ import { initialAgentConfigsForWorkspacePreset } from "../core/workspace-agent-p
 import { getWorkspacePresets } from "../core/workspace-presets.ts";
 import { migrateChannelLayer } from "../core/migrate-channel-layer.ts";
 import { cleanupHistory } from "../core/history-retention.ts";
-import type { AgentConfigWithModelState, AgentModelProbeState, ApprovalMode, Conversation, ConversationInfo, ElicitationResponse, InteractionMode, MessagePage, PermissionDecision, RunningSummary, WorkspaceInfo } from "../shared/types.ts";
+import type { AgentConfigWithModelState, AgentModelProbeResponse, AgentModelProbeState, ApprovalMode, Conversation, ConversationInfo, ElicitationResponse, InteractionMode, MessagePage, PermissionDecision, RunningSummary, WorkspaceInfo } from "../shared/types.ts";
 import { isInteractionMode } from "../shared/types.ts";
 import { ATTACHMENT_LIMITS } from "../shared/types.ts";
 import { AttachmentStore } from "../core/attachment-store.ts";
@@ -98,22 +98,31 @@ async function probeRuntimes(): Promise<void> {
   }
 }
 
-async function probeConfiguredAgentModels(force = false, runtimeFilter?: AgentConfig["runtime"]): Promise<void> {
-  if (!activeWorkspaceId) return;
-  const workspaceId = activeWorkspaceId;
+async function probeConfiguredAgentModels(
+  force = false,
+  runtimeFilter?: AgentConfig["runtime"],
+  targetAgentId?: string,
+  targetWorkspaceId?: string,
+): Promise<void> {
+  const workspaceId = targetWorkspaceId || activeWorkspaceId;
+  if (!workspaceId) return;
   const workspace = workspaceStore.get(workspaceId);
   if (!workspace) return;
 
   const existing = agentModelStateStore.load(workspaceId);
-  const targetsByRuntime = new Map<AgentConfig["runtime"], AgentConfig[]>();
-  for (const config of allConfigs) {
-    if (runtimeFilter && config.runtime !== runtimeFilter) continue;
-    const snapshot = existing[config.id];
-    const probeState = modelProbeStates.get(workspaceId)?.get(config.runtime);
-    if (!force && snapshot?.runtimeKind === config.runtime && probeState?.status !== "error") continue;
-    const targets = targetsByRuntime.get(config.runtime) ?? [];
-    targets.push(config);
-    targetsByRuntime.set(config.runtime, targets);
+  const targetsByRuntime = new Map<AgentConfig["runtime"], Array<Pick<AgentConfig, "id" | "runtime">>>();
+  if (runtimeFilter && targetAgentId) {
+    targetsByRuntime.set(runtimeFilter, [{ id: targetAgentId, runtime: runtimeFilter }]);
+  } else {
+    for (const config of configStore.load(workspaceId)) {
+      if (runtimeFilter && config.runtime !== runtimeFilter) continue;
+      const snapshot = existing[config.id];
+      const probeState = modelProbeStates.get(workspaceId)?.get(config.runtime);
+      if (!force && snapshot?.runtimeKind === config.runtime && probeState?.status !== "error") continue;
+      const targets = targetsByRuntime.get(config.runtime) ?? [];
+      targets.push(config);
+      targetsByRuntime.set(config.runtime, targets);
+    }
   }
 
   await Promise.all([...targetsByRuntime.entries()].map(async ([runtimeKind, targets]) => {
@@ -206,7 +215,7 @@ type AgentModelWithState = NonNullable<AgentConfigWithModelState["modelState"]>;
 
 function configsWithModelState(workspaceId: string): AgentConfigWithModelState[] {
   const modelStates = agentModelStateStore.load(workspaceId);
-  return allConfigs.map((config) => ({
+  return configStore.load(workspaceId).map((config) => ({
     ...config,
     modelState: modelStates[config.id],
     modelProbe: modelProbeStateFor(workspaceId, config.runtime, modelStates[config.id]),
@@ -242,10 +251,24 @@ function runtimeAvailable(runtime: string): boolean {
   return result?.available ?? false;
 }
 
-// Forward all events to SSE clients (single global subscriber)
+// Add the owning workspace at the server boundary so older core components can
+// keep publishing conversation events without knowing transport concerns.
 eventBus.subscribe((event) => {
   if (event.type === "runtime.activity") return;
-  sseHub.publish(event);
+  let scopedEvent = event;
+  if (event.type !== "events.gap" && "conversationId" in event && event.workspaceId === undefined) {
+    const matches = [...contextMap.keys()].filter((key) => key.endsWith(`:${event.conversationId}`));
+    // An unscoped legacy event is safe to infer only when the conversation id
+    // is unique in this process. Otherwise dropping it is safer than leaking
+    // one workspace's activity into another page.
+    if (matches.length === 1) {
+      const key = matches[0]!;
+      scopedEvent = { ...event, workspaceId: key.slice(0, key.length - event.conversationId.length - 1) };
+    } else if (matches.length > 1) {
+      return;
+    }
+  }
+  sseHub.publish(scopedEvent);
   // After agent.status events, push running.updated if summaries changed
   if (event.type === "agent.status") {
     pushRunningSummaries();
@@ -309,6 +332,30 @@ function contextKey(workspaceId: string, conversationId: string): string {
   return `${workspaceId}:${conversationId}`;
 }
 
+type RequestTarget = { workspaceId: string; conversationId: string };
+
+/** Resolve page-owned context. Query parameters are the public API contract;
+ * the active pointers are retained only as a compatibility fallback for old clients. */
+function resolveTarget(url: URL, requireConversation = true): RequestTarget | null {
+  const workspaceId = url.searchParams.get("workspaceId") || activeWorkspaceId;
+  if (!workspaceId || !workspaceStore.get(workspaceId)) return null;
+  const conversationId = url.searchParams.get("conversationId")
+    || (workspaceId === activeWorkspaceId ? activeConversationId : "");
+  if (requireConversation && (!conversationId || !conversationStore.get(workspaceId, conversationId))) return null;
+  return { workspaceId, conversationId };
+}
+
+function contextForTarget(target: RequestTarget | null): ConversationContext | null {
+  if (!target) return null;
+  if (!target.workspaceId || !target.conversationId) return null;
+  if (!workspaceStore.get(target.workspaceId) || !conversationStore.get(target.workspaceId, target.conversationId)) return null;
+  return getOrCreateContext(target.workspaceId, target.conversationId);
+}
+
+function conversationStoreFor(workspaceId: string): ConversationStore {
+  return workspaceId === activeWorkspaceId ? conversationStore : new ConversationStore();
+}
+
 function getOrCreateContext(workspaceId: string, conversationId: string): ConversationContext {
   const key = contextKey(workspaceId, conversationId);
   const existing = contextMap.get(key);
@@ -334,7 +381,7 @@ function evictIfNeeded(): void {
     let evicted = false;
     for (const key of contextLru) {
       const ctx = contextMap.get(key);
-      if (ctx && !ctx.hasRunningAgent()) {
+      if (ctx && !ctx.hasRunningOrQueued()) {
         ctx.dispose();
         contextMap.delete(key);
         const idx = contextLru.indexOf(key);
@@ -377,15 +424,13 @@ function disposeWorkspaceContexts(workspaceId: string): void {
 }
 
 function createContext(workspaceId: string, conversationId: string): ConversationContext {
-  const configs = workspaceId === activeWorkspaceId
-    ? allConfigs
-    : configStore.load(workspaceId);
+  const configs = configStore.load(workspaceId);
   const enabledConfigs = configs.filter((c) => c.enabled);
   const ws = workspaceStore.get(workspaceId);
   const profiles = configsToProfiles(enabledConfigs, ws!.path);
   const sessStore = new SessionStore(workspaceStore.sessionsDir(workspaceId));
   const workspaceConfig = workspaceConfigStore.load(workspaceId);
-  const conversation = conversationStore.get(workspaceId, conversationId);
+  const conversation = conversationStoreFor(workspaceId).get(workspaceId, conversationId);
   return new ConversationContext({
     workspaceId,
     conversationId,
@@ -413,7 +458,6 @@ function createContext(workspaceId: string, conversationId: string): Conversatio
         const updated = store.update(workspaceId, conversationId, patch);
         if (workspaceId === activeWorkspaceId && conversationId === activeConversationId) {
           activeConversation = toActiveConversation(updated);
-          publishContextSwitched();
         }
       } catch {
         // 持久化失败不阻断路由流程；模式仍在本会话上下文中生效
@@ -509,41 +553,20 @@ function switchWorkspace(workspaceId: string): void {
   activeConversation = EMPTY_CONVERSATION;
   saveLastActive(activeWorkspaceId, activeConversationId);
 
-  publishContextSwitched();
 }
 
-function switchConversation(conversationId: string): void {
-  if (conversationId === activeConversationId) return;
-  if (!activeWorkspaceId) throw new Error("No active workspace.");
-  // No running-agent check
-
-  const conv = conversationStore.get(activeWorkspaceId, conversationId);
-  if (!conv) throw new Error(`Conversation not found: ${conversationId}`);
-
-  // Issue #77: Don't touch lastOpenedAt when switching conversations
-  activateConversation(conv, false);
-  publishContextSwitched();
-}
-
-function refreshEnabledAgents(): void {
-  if (!activeWorkspaceId) return;
-  const enabledConfigs = allConfigs.filter((c) => c.enabled);
-  const profiles = configsToProfiles(enabledConfigs, activeWorkspace.path);
+function refreshEnabledAgentsForWorkspace(workspaceId: string, configs: AgentConfig[]): void {
+  const workspace = workspaceStore.get(workspaceId);
+  if (!workspace) return;
+  const enabledConfigs = configs.filter((c) => c.enabled);
+  const profiles = configsToProfiles(enabledConfigs, workspace.path);
 
   // Refresh profiles for ALL contexts in the same workspace, not just the active one
   for (const [key, ctx] of contextMap) {
-    if (key.startsWith(`${activeWorkspaceId}:`)) {
+    if (key.startsWith(`${workspaceId}:`)) {
       ctx.refreshProfiles(profiles);
     }
   }
-}
-
-function publishContextSwitched(): void {
-  sseHub.publish({
-    type: "context.switched",
-    workspace: activeWorkspace,
-    conversation: activeConversation,
-  });
 }
 
 function clearActiveContext(): void {
@@ -555,7 +578,6 @@ function clearActiveContext(): void {
   allConfigs = [];
   sessionStore = null;
   clearLastActive();
-  publishContextSwitched();
 }
 
 function clearActiveConversation(): void {
@@ -563,7 +585,6 @@ function clearActiveConversation(): void {
   activeConversationId = "";
   activeConversation = EMPTY_CONVERSATION;
   saveLastActive(activeWorkspaceId, activeConversationId);
-  publishContextSwitched();
 }
 
 function currentAgentStates() {
@@ -599,18 +620,25 @@ const server = http.createServer(async (req, res) => {
 
     // SSE
     if (req.method === "GET" && url.pathname === "/events") {
-      sseHub.add(res);
+      const lastEventId = Number(req.headers["last-event-id"]);
+      sseHub.add(res, {
+        workspaceId: url.searchParams.get("workspaceId") || undefined,
+        conversationId: url.searchParams.get("conversationId") || undefined,
+      }, Number.isFinite(lastEventId) ? lastEventId : undefined);
       return;
     }
 
     // State
     if (req.method === "GET" && url.pathname === "/api/state") {
-      const ctx = getActiveContext();
+      const target = resolveTarget(url, false);
+      const ctx = target?.conversationId ? contextForTarget(target) : null;
+      const workspace = target ? workspaceStore.get(target.workspaceId) : null;
+      const conversation = target?.conversationId ? conversationStoreFor(target.workspaceId).get(target.workspaceId, target.conversationId) : null;
       const messages = ctx?.messages.list() ?? [];
       sendJson(res, 200, {
-        workspace: activeWorkspace,
-        conversation: activeConversation,
-        agents: currentAgentStates(),
+        workspace: workspace ? { id: workspace.id, name: workspace.name, path: workspace.path } : EMPTY_WORKSPACE,
+        conversation: conversation ? toActiveConversation(conversation) : EMPTY_CONVERSATION,
+        agents: ctx ? ctx.agents.states().map((s) => ({ ...s, runtimeAvailable: runtimeAvailable(s.runtime) })) : (target ? configsWithModelState(target.workspaceId).filter((c) => c.enabled).map((c, i) => ({ id: c.id, label: c.name, runtime: c.runtime, status: "idle" as const, selected: i === 0, runtimeAvailable: runtimeAvailable(c.runtime) })) : currentAgentStates()),
         messages: ctx?.runManager.projectLiveProcessState(messages) ?? messages,
         messageHistory: ctx?.messages.historyState() ?? emptyMessageHistory(),
         terminal: ctx?.transcripts.all() ?? {},
@@ -623,17 +651,18 @@ const server = http.createServer(async (req, res) => {
     }
 
     if (req.method === "GET" && url.pathname === "/api/work-analysis") {
-      if (!activeWorkspaceId) {
+      const workspaceId = url.searchParams.get("workspaceId") || activeWorkspaceId;
+      if (!workspaceId || !workspaceStore.get(workspaceId)) {
         sendJson(res, 409, { ok: false, message: "Create or select a workspace before viewing work analysis." });
         return;
       }
       const requestedDays = Number(url.searchParams.get("days") ?? 30);
       const days = Number.isFinite(requestedDays) ? Math.max(1, Math.min(365, Math.floor(requestedDays))) : 30;
       sendJson(res, 200, buildWorkspaceWorkAnalysis({
-        workspaceId: activeWorkspaceId,
+        workspaceId,
         days,
         workspaceStore,
-        conversationStore,
+        conversationStore: conversationStoreFor(workspaceId),
         agentConfigStore: configStore,
       }));
       return;
@@ -641,7 +670,8 @@ const server = http.createServer(async (req, res) => {
 
     // Messages
     if (req.method === "GET" && url.pathname === "/api/messages") {
-      const ctx = getActiveContext();
+      const target = resolveTarget(url);
+      const ctx = target?.conversationId ? contextForTarget(target) : null;
       if (!ctx) {
         sendJson(res, 200, emptyMessagePage());
         return;
@@ -653,7 +683,7 @@ const server = http.createServer(async (req, res) => {
     }
 
     if (req.method === "POST" && url.pathname === "/api/messages") {
-      await handlePostMessage(req, res);
+      await handlePostMessage(req, res, url);
       return;
     }
 
@@ -667,7 +697,7 @@ const server = http.createServer(async (req, res) => {
         sendJson(res, 400, { ok: false, message: "A valid requestId and decision are required." });
         return;
       }
-      const ctx = getActiveContext();
+      const ctx = contextForTarget(resolveTarget(url));
       if (!ctx?.resolvePermission(requestId, decision)) {
         sendJson(res, 404, { ok: false, message: "Permission request is no longer pending." });
         return;
@@ -684,7 +714,7 @@ const server = http.createServer(async (req, res) => {
         sendJson(res, 400, { ok: false, message: "A valid requestId and elicitation response are required." });
         return;
       }
-      const ctx = getActiveContext();
+      const ctx = contextForTarget(resolveTarget(url));
       if (!ctx?.resolveElicitation(requestId, response)) {
         sendJson(res, 404, { ok: false, message: "Elicitation request is no longer pending." });
         return;
@@ -695,7 +725,7 @@ const server = http.createServer(async (req, res) => {
 
     // Interrupt current auto-collaboration chain
     if (req.method === "POST" && url.pathname === "/api/conversation/interrupt") {
-      const ctx = getActiveContext();
+      const ctx = contextForTarget(resolveTarget(url));
       if (!ctx) {
         sendJson(res, 409, { ok: false, message: "No active conversation." });
         return;
@@ -708,7 +738,8 @@ const server = http.createServer(async (req, res) => {
     // --- Attachment endpoints ---
 
     if (req.method === "POST" && url.pathname === "/api/attachments/drafts") {
-      if (!activeWorkspaceId || !activeConversationId) {
+      const target = resolveTarget(url);
+      if (!target) {
         sendJson(res, 409, { ok: false, message: "No active conversation." });
         return;
       }
@@ -734,7 +765,7 @@ const server = http.createServer(async (req, res) => {
       }
 
       // Issue #88: Check draft count limit before saving
-      const draftCount = await attachmentStore.countDrafts(activeWorkspaceId, activeConversationId);
+      const draftCount = await attachmentStore.countDrafts(target.workspaceId, target.conversationId);
       if (draftCount >= ATTACHMENT_LIMITS.MAX_DRAFTS_PER_CONVERSATION) {
         sendJson(res, 400, {
           ok: false,
@@ -744,8 +775,8 @@ const server = http.createServer(async (req, res) => {
       }
 
       const saved = await attachmentStore.saveDraft({
-        workspaceId: activeWorkspaceId,
-        conversationId: activeConversationId,
+        workspaceId: target.workspaceId,
+        conversationId: target.conversationId,
         data: buffer,
         mimeType,
         filename,
@@ -759,7 +790,7 @@ const server = http.createServer(async (req, res) => {
           mimeType,
           filename,
           size: saved.size,
-          previewUrl: `/api/attachments/drafts/${activeWorkspaceId}/${activeConversationId}/${saved.id}`,
+          previewUrl: `/api/attachments/drafts/${target.workspaceId}/${target.conversationId}/${saved.id}`,
         },
       });
       return;
@@ -838,21 +869,14 @@ const server = http.createServer(async (req, res) => {
         return;
       }
 
-      // Search all active contexts for the run
-      let result: { ok: boolean; reason?: string } = { ok: false, reason: "not_found" };
-      for (const [, ctx] of contextMap) {
-        const candidate = ctx.runManager.cancel(runId);
-        if (candidate.ok) {
-          result = candidate;
-          break;
-        }
-        // Any reason other than "not_found" is definitive — stop searching
-        if (candidate.reason !== "not_found") {
-          result = candidate;
-          break;
-        }
+      // 定向取消：只作用于本页面的会话上下文，不再遍历全部上下文
+      const target = resolveTarget(url);
+      if (!target) {
+        sendJson(res, 409, { ok: false, message: "workspaceId and conversationId are required." });
+        return;
       }
-
+      const ctx = contextForTarget(target);
+      const result: { ok: boolean; reason?: string } = ctx?.runManager.cancel(runId) ?? { ok: false, reason: "not_found" };
       if (!result.ok) {
         if (result.reason === "not_cancellable") {
           sendJson(res, 409, { ok: false, reason: "not_cancellable", message: "This run has already finished and cannot be cancelled." });
@@ -870,19 +894,43 @@ const server = http.createServer(async (req, res) => {
     if (req.method === "GET" && url.pathname === "/api/agents") {
       // 合并 workspace 级模型快照（issue #142）：模型列表/当前值由 runtime 在
       // 运行时写入独立存储，agents.json 只保存用户偏好。
-      sendJson(res, 200, activeWorkspaceId ? configsWithModelState(activeWorkspaceId) : allConfigs);
+      const workspaceId = url.searchParams.get("workspaceId") || activeWorkspaceId;
+      sendJson(res, 200, workspaceId ? configsWithModelState(workspaceId) : allConfigs);
       return;
     }
 
     if (req.method === "POST" && url.pathname === "/api/agents/probe-models") {
       const runtimeParam = url.searchParams.get("runtime");
       const runtimeFilter = runtimeParam as AgentConfig["runtime"] | null;
+      const targetAgentId = url.searchParams.get("agentId")?.trim();
       if (runtimeFilter && !defaultAcpRunnerRegistry.get(runtimeFilter)) {
         sendJson(res, 400, { ok: false, message: "未知的运行时。" });
         return;
       }
-      await probeConfiguredAgentModels(url.searchParams.get("force") === "1", runtimeFilter ?? undefined);
-      sendJson(res, 200, activeWorkspaceId ? configsWithModelState(activeWorkspaceId) : allConfigs);
+      if (targetAgentId && (!runtimeFilter || !/^[a-zA-Z0-9_-]{1,128}$/.test(targetAgentId))) {
+        sendJson(res, 400, { ok: false, message: "刷新指定员工模型时需要有效的员工 ID 和运行时。" });
+        return;
+      }
+      await probeConfiguredAgentModels(
+        url.searchParams.get("force") === "1",
+        runtimeFilter ?? undefined,
+        targetAgentId,
+        url.searchParams.get("workspaceId") || undefined,
+      );
+      const workspaceId = url.searchParams.get("workspaceId") || activeWorkspaceId;
+      const configs = workspaceId ? configsWithModelState(workspaceId) : allConfigs;
+      const response: AgentModelProbeResponse = { configs };
+      if (workspaceId && runtimeFilter && targetAgentId) {
+        const snapshot = agentModelStateStore.get(workspaceId, targetAgentId);
+        const matchingSnapshot = snapshot?.runtimeKind === runtimeFilter ? snapshot : undefined;
+        response.target = {
+          agentId: targetAgentId,
+          runtimeKind: runtimeFilter,
+          modelState: matchingSnapshot ?? null,
+          modelProbe: modelProbeStateFor(workspaceId, runtimeFilter, matchingSnapshot),
+        };
+      }
+      sendJson(res, 200, response);
       return;
     }
 
@@ -892,33 +940,33 @@ const server = http.createServer(async (req, res) => {
     }
 
     if (req.method === "PUT" && url.pathname === "/api/agents") {
-      await handlePutAgents(req, res);
+      await handlePutAgents(req, res, url);
       return;
     }
 
     if (req.method === "POST" && url.pathname === "/api/agents/reset") {
-      if (!activeWorkspaceId) {
+      const workspaceId = url.searchParams.get("workspaceId") || activeWorkspaceId;
+      if (!workspaceId || !workspaceStore.get(workspaceId)) {
         sendJson(res, 409, { ok: false, message: "Create or select a workspace before resetting agents." });
         return;
       }
-      const ctx = getActiveContext();
-      if (ctx?.hasRunningAgent()) {
+      if ([...contextMap].some(([key, value]) => key.startsWith(`${workspaceId}:`) && value.hasRunningOrQueued())) {
         sendJson(res, 409, { ok: false, message: "Cannot reset while an agent is running. Wait for it to finish." });
         return;
       }
-      allConfigs = configStore.reset(activeWorkspaceId);
-      refreshEnabledAgents();
-      sendJson(res, 200, allConfigs);
+      const configs = configStore.reset(workspaceId);
+      refreshEnabledAgentsForWorkspace(workspaceId, configs);
+      sendJson(res, 200, configs);
       return;
     }
 
     if (req.method === "POST" && url.pathname === "/api/agents/apply-team") {
-      if (!activeWorkspaceId) {
+      const workspaceId = url.searchParams.get("workspaceId") || activeWorkspaceId;
+      if (!workspaceId || !workspaceStore.get(workspaceId)) {
         sendJson(res, 409, { ok: false, message: "Create or select a workspace before applying a team." });
         return;
       }
-      const ctx = getActiveContext();
-      if (ctx?.hasRunningAgent()) {
+      if ([...contextMap].some(([key, value]) => key.startsWith(`${workspaceId}:`) && value.hasRunningOrQueued())) {
         sendJson(res, 409, { ok: false, message: "Cannot change the team while an agent is running." });
         return;
       }
@@ -929,10 +977,10 @@ const server = http.createServer(async (req, res) => {
         return;
       }
       // 数字员工尽量使用本地实际可用的不同运行时（按 AGENT_RUNTIME_PRIORITY 轮流分配）。
-      allConfigs = initialAgentConfigsForWorkspacePreset(template.id, getRuntimeAvailabilityArray()) ?? [];
-      configStore.save(activeWorkspaceId, allConfigs);
-      refreshEnabledAgents();
-      sendJson(res, 200, allConfigs);
+      const configs = initialAgentConfigsForWorkspacePreset(template.id, getRuntimeAvailabilityArray()) ?? [];
+      configStore.save(workspaceId, configs);
+      refreshEnabledAgentsForWorkspace(workspaceId, configs);
+      sendJson(res, 200, configs);
       return;
     }
 
@@ -949,16 +997,18 @@ const server = http.createServer(async (req, res) => {
     }
 
     if (req.method === "GET" && url.pathname === "/api/workspace-config") {
-      if (!activeWorkspaceId) {
+      const workspaceId = url.searchParams.get("workspaceId") || activeWorkspaceId;
+      if (!workspaceId || !workspaceStore.get(workspaceId)) {
         sendJson(res, 200, { systemPrompt: "", rules: [] });
         return;
       }
-      sendJson(res, 200, workspaceConfigStore.load(activeWorkspaceId));
+      sendJson(res, 200, workspaceConfigStore.load(workspaceId));
       return;
     }
 
     if (req.method === "PUT" && url.pathname === "/api/workspace-config") {
-      if (!activeWorkspaceId) {
+      const workspaceId = url.searchParams.get("workspaceId") || activeWorkspaceId;
+      if (!workspaceId || !workspaceStore.get(workspaceId)) {
         sendJson(res, 409, { ok: false, message: "Create or select a workspace before saving workspace config." });
         return;
       }
@@ -977,12 +1027,12 @@ const server = http.createServer(async (req, res) => {
         sendJson(res, 400, { ok: false, message: "systemPrompt must be a string." });
         return;
       }
-      workspaceConfigStore.save(activeWorkspaceId, input);
-      const resolved = workspaceConfigStore.load(activeWorkspaceId);
+      workspaceConfigStore.save(workspaceId, input);
+      const resolved = workspaceConfigStore.load(workspaceId);
       // Update all active contexts for this workspace so the next agent run
       // immediately uses the new config.
       for (const [key, ctx] of contextMap) {
-        if (key.startsWith(`${activeWorkspaceId}:`)) {
+        if (key.startsWith(`${workspaceId}:`)) {
           ctx.updateWorkspaceConfig(resolved);
         }
       }
@@ -1120,7 +1170,7 @@ const server = http.createServer(async (req, res) => {
       // Check if ANY context for this workspace has running agents
       let hasRunning = false;
       for (const [key, ctx] of contextMap) {
-        if (key.startsWith(`${wsId}:`) && ctx.hasRunningAgent()) {
+        if (key.startsWith(`${wsId}:`) && ctx.hasRunningOrQueued()) {
           hasRunning = true;
           break;
         }
@@ -1132,6 +1182,7 @@ const server = http.createServer(async (req, res) => {
       try {
         const wasActiveWorkspace = wsId === activeWorkspaceId;
         disposeWorkspaceContexts(wsId);
+        attachmentStore.deleteWorkspaceDrafts(wsId).catch(() => { /* best effort */ });
         workspaceStore.delete(wsId);
         if (wasActiveWorkspace) {
           const nextWorkspace = workspaceStore.list()[0];
@@ -1166,11 +1217,12 @@ const server = http.createServer(async (req, res) => {
     // --- Conversation endpoints ---
 
     if (req.method === "GET" && url.pathname === "/api/conversations") {
-      if (!activeWorkspaceId) {
+      const workspaceId = url.searchParams.get("workspaceId") || activeWorkspaceId;
+      if (!workspaceId || !workspaceStore.get(workspaceId)) {
         sendJson(res, 200, []);
         return;
       }
-      sendJson(res, 200, conversationStore.list(activeWorkspaceId));
+      sendJson(res, 200, conversationStoreFor(workspaceId).list(workspaceId));
       return;
     }
 
@@ -1179,7 +1231,7 @@ const server = http.createServer(async (req, res) => {
       const wsId = parts[3];
       if (!wsId) { sendJson(res, 400, { ok: false, message: "Missing workspace id." }); return; }
       try {
-        const store = wsId === activeWorkspaceId ? conversationStore : new ConversationStore();
+        const store = conversationStoreFor(wsId);
         sendJson(res, 200, store.list(wsId));
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
@@ -1196,13 +1248,12 @@ const server = http.createServer(async (req, res) => {
       }
       const input = (await readJson(req)) as { name?: unknown };
       const name = conversationTitle(typeof input.name === "string" ? input.name : "");
-      // Switch workspace if creating in a different one
-      if (wsId !== activeWorkspaceId) {
-        switchWorkspace(wsId);
+      if (!workspaceStore.get(wsId)) {
+        sendJson(res, 404, { ok: false, message: "Workspace not found." });
+        return;
       }
-      const conv = conversationStore.create(activeWorkspaceId, name);
-      activateConversation(conv);
-      publishContextSwitched();
+      const conv = conversationStoreFor(wsId).create(wsId, name);
+      getOrCreateContext(wsId, conv.id);
       sendJson(res, 200, conv);
       return;
     }
@@ -1211,8 +1262,9 @@ const server = http.createServer(async (req, res) => {
       const parts = url.pathname.split("/");
       const convId = parts[3];
       if (!convId) { sendJson(res, 400, { ok: false, message: "Missing conversation id." }); return; }
-      if (convId !== activeConversationId || !activeWorkspaceId) {
-        sendJson(res, 409, { ok: false, message: "Only the active conversation can change the interaction mode." });
+      const target = resolveTarget(url);
+      if (!target || target.conversationId !== convId) {
+        sendJson(res, 409, { ok: false, message: "workspaceId and conversationId are required." });
         return;
       }
       const input = (await readJson(req)) as { mode?: unknown; runtime?: unknown };
@@ -1221,20 +1273,19 @@ const server = http.createServer(async (req, res) => {
         return;
       }
       const mode = input.mode;
-      const ctx = getActiveContext();
+      const ctx = contextForTarget(target);
       if (!ctx) { sendJson(res, 409, { ok: false, message: "No active conversation context." }); return; }
       try {
-        const current = conversationStore.get(activeWorkspaceId, activeConversationId);
+        const current = conversationStoreFor(target.workspaceId).get(target.workspaceId, convId);
         if (!current) throw new Error("Conversation not found.");
         const runtime = typeof input.runtime === "string" ? input.runtime as import("../shared/types.ts").AgentRuntimeKind : current.supervisionRuntime;
         if (mode === "supervised" && (!runtime || !runtimeAvailable(runtimeKindToCliKey(runtime)))) {
           sendJson(res, 409, { ok: false, message: "Choose an available runtime before enabling supervised collaboration." });
           return;
         }
-        // setInteractionMode 通过 onConversationPatch 持久化并广播 context.switched
+        // setInteractionMode 通过 onConversationPatch 持久化模式与监工运行时
         ctx.setInteractionMode(mode, runtime);
-        const updated = conversationStore.get(activeWorkspaceId, activeConversationId) ?? current;
-        activeConversation = toActiveConversation(updated);
+        const updated = conversationStoreFor(target.workspaceId).get(target.workspaceId, convId) ?? current;
         sendJson(res, 200, { ok: true, conversation: updated });
       } catch (error) {
         sendJson(res, 409, { ok: false, message: error instanceof Error ? error.message : String(error) });
@@ -1251,11 +1302,10 @@ const server = http.createServer(async (req, res) => {
       const input = (await readJson(req)) as { name?: unknown };
       const name = typeof input.name === "string" ? input.name.trim() : undefined;
       try {
-        const store = wsId === activeWorkspaceId ? conversationStore : new ConversationStore();
+        const store = conversationStoreFor(wsId);
         const conv = store.update(wsId, convId, { name });
         if (convId === activeConversationId && wsId === activeWorkspaceId) {
           activeConversation = toActiveConversation(conv);
-          publishContextSwitched();
         }
         sendJson(res, 200, conv);
       } catch (error) {
@@ -1275,7 +1325,7 @@ const server = http.createServer(async (req, res) => {
         return;
       }
       const targetCtx = contextMap.get(contextKey(wsId, convId));
-      if (targetCtx?.hasRunningAgent()) {
+      if (targetCtx?.hasRunningOrQueued()) {
         sendJson(res, 409, { ok: false, message: "Cannot delete a conversation with running agents." });
         return;
       }
@@ -1283,13 +1333,12 @@ const server = http.createServer(async (req, res) => {
         const wasActiveConversation = wsId === activeWorkspaceId && convId === activeConversationId;
         disposeContext(wsId, convId);
         attachmentStore.deleteConversationAttachments(wsId, convId).catch(() => { /* best effort */ });
-        const store = wsId === activeWorkspaceId ? conversationStore : new ConversationStore();
+        const store = conversationStoreFor(wsId);
         store.delete(wsId, convId);
         if (wasActiveConversation) {
           const nextConversation = conversationStore.list(activeWorkspaceId)[0];
           if (nextConversation) {
             activateConversation(nextConversation);
-            publishContextSwitched();
           } else {
             clearActiveConversation();
           }
@@ -1307,12 +1356,12 @@ const server = http.createServer(async (req, res) => {
       const convId = parts[3];
       if (!convId) { sendJson(res, 400, { ok: false, message: "Missing conversation id." }); return; }
       try {
-        const wsId = url.searchParams.get("workspaceId");
-        if (wsId && wsId !== activeWorkspaceId) {
-          switchWorkspace(wsId);
-        }
-        switchConversation(convId);
-        sendJson(res, 200, { ok: true, workspace: activeWorkspace, conversation: activeConversation });
+        const wsId = url.searchParams.get("workspaceId") || activeWorkspaceId;
+        const conversation = wsId ? conversationStoreFor(wsId).get(wsId, convId) : null;
+        const workspace = wsId ? workspaceStore.get(wsId) : null;
+        if (!wsId || !conversation || !workspace) throw new Error("Conversation not found.");
+        getOrCreateContext(wsId, convId);
+        sendJson(res, 200, { ok: true, workspace: { id: workspace.id, name: workspace.name, path: workspace.path }, conversation: toActiveConversation(conversation) });
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         sendJson(res, 409, { ok: false, message: msg });
@@ -1454,11 +1503,12 @@ function wait(ms: number): Promise<void> {
 
 // --- Helpers ---
 
-async function handlePostMessage(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+async function handlePostMessage(req: http.IncomingMessage, res: http.ServerResponse, url: URL): Promise<void> {
   const input = (await readJson(req)) as {
     content?: unknown;
     draftAttachments?: unknown;
     approvalMode?: unknown;
+    clientMessageId?: unknown;
   };
   const content = typeof input.content === "string" ? input.content.trim() : "";
   const approvalMode: ApprovalMode = input.approvalMode === "full-access" ? "full-access" : "ask";
@@ -1468,25 +1518,34 @@ async function handlePostMessage(req: http.IncomingMessage, res: http.ServerResp
     return;
   }
 
-  if (!activeWorkspaceId) {
+  const workspaceId = url.searchParams.get("workspaceId") || activeWorkspaceId;
+  const requestedConversationId = url.searchParams.get("conversationId") || "";
+  if (!workspaceId || !workspaceStore.get(workspaceId)) {
     sendJson(res, 409, { ok: false, message: "Create or select a workspace before sending a message." });
     return;
   }
 
-  let context = getActiveContext();
+  let conversation = requestedConversationId
+    ? conversationStoreFor(workspaceId).get(workspaceId, requestedConversationId)
+    : null;
+  if (requestedConversationId && !conversation) {
+    sendJson(res, 404, { ok: false, message: "Conversation not found." });
+    return;
+  }
+  let context = conversation ? getOrCreateContext(workspaceId, conversation.id) : null;
 
   if (!context) {
-    const conversation = conversationStore.create(activeWorkspaceId, conversationTitle(content));
-    activeConversationId = conversation.id;
-    activeConversation = toActiveConversation(conversation);
-    conversationStore.touchLastOpened(activeWorkspaceId, activeConversationId);
-    context = getOrCreateContext(activeWorkspaceId, activeConversationId);
-    saveLastActive(activeWorkspaceId, activeConversationId);
-    publishContextSwitched();
-  } else if (activeConversation.name === UNTITLED_CONVERSATION_NAME) {
-    const renamed = conversationStore.update(activeWorkspaceId, activeConversationId, { name: conversationTitle(content) });
-    activeConversation = toActiveConversation(renamed);
-    publishContextSwitched();
+    conversation = conversationStoreFor(workspaceId).create(workspaceId, conversationTitle(content));
+    conversationStoreFor(workspaceId).touchLastOpened(workspaceId, conversation.id);
+    context = getOrCreateContext(workspaceId, conversation.id);
+    if (workspaceId === activeWorkspaceId) {
+      activeConversationId = conversation.id;
+      activeConversation = toActiveConversation(conversation);
+      saveLastActive(workspaceId, conversation.id);
+    }
+  } else if (conversation?.name === UNTITLED_CONVERSATION_NAME) {
+    conversation = conversationStoreFor(workspaceId).update(workspaceId, conversation.id, { name: conversationTitle(content) });
+    if (workspaceId === activeWorkspaceId && conversation.id === activeConversationId) activeConversation = toActiveConversation(conversation);
   }
 
   if (!context) {
@@ -1494,42 +1553,54 @@ async function handlePostMessage(req: http.IncomingMessage, res: http.ServerResp
     return;
   }
 
-  // Commit draft attachments if present
-  let attachments: import("../shared/types.ts").MessageAttachment[] | undefined;
+  const clientMessageId = typeof input.clientMessageId === "string" ? input.clientMessageId.trim() : "";
   const draftAttachments = Array.isArray(input.draftAttachments)
     ? input.draftAttachments as Array<{ id: string; mimeType: string; filename: string; size: number }>
     : [];
 
-  if (draftAttachments.length > 0) {
-    // Enforce max files per message
-    if (draftAttachments.length > ATTACHMENT_LIMITS.MAX_FILES_PER_MESSAGE) {
-      sendJson(res, 400, {
-        ok: false,
-        message: `Too many attachments (${draftAttachments.length}). Maximum is ${ATTACHMENT_LIMITS.MAX_FILES_PER_MESSAGE}.`,
-      });
-      return;
+  await context.withMessageMutation(async () => {
+    if (clientMessageId) {
+      const existing = context.messages.findByClientMessageId(clientMessageId);
+      if (existing) {
+        sendJson(res, 200, { ok: true, messageId: existing.id, workspaceId, conversationId: conversation!.id, deduplicated: true });
+        return;
+      }
     }
-    attachments = await attachmentStore.commitDrafts({
-      workspaceId: activeWorkspaceId,
-      conversationId: activeConversationId,
-      draftAttachments,
+
+    // Commit draft attachments if present
+    let attachments: import("../shared/types.ts").MessageAttachment[] | undefined;
+    if (draftAttachments.length > 0) {
+      // Enforce max files per message
+      if (draftAttachments.length > ATTACHMENT_LIMITS.MAX_FILES_PER_MESSAGE) {
+        sendJson(res, 400, {
+          ok: false,
+          message: `Too many attachments (${draftAttachments.length}). Maximum is ${ATTACHMENT_LIMITS.MAX_FILES_PER_MESSAGE}.`,
+        });
+        return;
+      }
+      attachments = await attachmentStore.commitDrafts({
+        workspaceId,
+        conversationId: conversation!.id,
+        draftAttachments,
+      });
+    }
+
+    // 模式快照：每条用户消息在发送时记录当轮 interaction mode，
+    // 后续员工运行、转交、监工检查都继承该值，不读取执行时的全局模式。
+    const userMessage = context.messages.add({
+      kind: "user",
+      ...(clientMessageId ? { clientMessageId } : {}),
+      content,
+      status: "sent",
+      attachments,
+      approvalMode,
+      interactionMode: conversation!.interactionMode ?? "direct",
     });
-  }
+    eventBus.publish({ type: "message.created", workspaceId, conversationId: conversation!.id, message: userMessage });
+    context.messageRouter.process(userMessage);
 
-  // 模式快照：每条用户消息在发送时记录当轮 interaction mode，
-  // 后续员工运行、转交、监工检查都继承该值，不读取执行时的全局模式。
-  const userMessage = context.messages.add({
-    kind: "user",
-    content,
-    status: "sent",
-    attachments,
-    approvalMode,
-    interactionMode: activeConversation.interactionMode ?? "direct",
+    sendJson(res, 200, { ok: true, messageId: userMessage.id, workspaceId, conversationId: conversation!.id });
   });
-  eventBus.publish({ type: "message.created", conversationId: activeConversationId, message: userMessage });
-  context.messageRouter.process(userMessage);
-
-  sendJson(res, 200, { ok: true, messageId: userMessage.id });
 }
 
 const MAX_BODY_SIZE = 10 * 1024 * 1024; // 10MB
@@ -1692,13 +1763,13 @@ async function pickDirectory(): Promise<string> {
   }
 }
 
-async function handlePutAgents(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
-  if (!activeWorkspaceId) {
+async function handlePutAgents(req: http.IncomingMessage, res: http.ServerResponse, url: URL): Promise<void> {
+  const workspaceId = url.searchParams.get("workspaceId") || activeWorkspaceId;
+  if (!workspaceId || !workspaceStore.get(workspaceId)) {
     sendJson(res, 409, { ok: false, message: "Create or select a workspace before saving agents." });
     return;
   }
-  const ctx = getActiveContext();
-  if (ctx?.hasRunningAgent()) {
+  if ([...contextMap].some(([key, ctx]) => key.startsWith(`${workspaceId}:`) && ctx.hasRunningOrQueued())) {
     sendJson(res, 409, { ok: false, message: "Cannot save while an agent is running. Wait for it to finish." });
     return;
   }
@@ -1716,10 +1787,11 @@ async function handlePutAgents(req: http.IncomingMessage, res: http.ServerRespon
   }
 
   // modelState 是 GET 响应合并的运行时快照，保存前剥离，避免污染 agents.json。
-  allConfigs = input.map(({ modelState: _modelState, modelProbe: _modelProbe, ...config }) => config);
-  configStore.save(activeWorkspaceId, allConfigs);
-  refreshEnabledAgents();
-  sendJson(res, 200, configsWithModelState(activeWorkspaceId));
+  const configs = input.map(({ modelState: _modelState, modelProbe: _modelProbe, ...config }) => config);
+  configStore.save(workspaceId, configs);
+  refreshEnabledAgentsForWorkspace(workspaceId, configs);
+  if (workspaceId === activeWorkspaceId) allConfigs = configs;
+  sendJson(res, 200, configsWithModelState(workspaceId));
 }
 
 function shutdown(): void {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,11 +5,11 @@ import path from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
-import { configsToProfiles } from "../core/agent-profiles.ts";
+import { configsToProfiles, INTERNAL_SUPERVISOR_ID } from "../core/agent-profiles.ts";
 import { disposeAcpConnectionPool, probeAcpModelState } from "../core/acp-runtime.ts";
 import { defaultAcpRunnerRegistry } from "../core/acp-runner-registry.ts";
 import { AGENT_TEAM_TEMPLATES, AgentConfigStore, validateAgentConfigs } from "../core/agent-config-store.ts";
-import { AgentModelStateStore } from "../core/agent-model-state-store.ts";
+import { AgentModelStateStore, supervisorStorageKey } from "../core/agent-model-state-store.ts";
 import { probeAllRuntimes, runtimeKindToCliKey, type RuntimeProbeResult } from "../core/runtime-probe.ts";
 import type { AgentConfig } from "../core/agent-config-store.ts";
 import { WorkspaceConfigStore } from "../core/workspace-config-store.ts";
@@ -24,8 +24,8 @@ import { initialAgentConfigsForWorkspacePreset } from "../core/workspace-agent-p
 import { getWorkspacePresets } from "../core/workspace-presets.ts";
 import { migrateChannelLayer } from "../core/migrate-channel-layer.ts";
 import { cleanupHistory } from "../core/history-retention.ts";
-import type { AgentConfigWithModelState, AgentModelProbeResponse, AgentModelProbeState, ApprovalMode, Conversation, ConversationInfo, ElicitationResponse, InteractionMode, MessagePage, PermissionDecision, RunningSummary, WorkspaceInfo } from "../shared/types.ts";
-import { isInteractionMode } from "../shared/types.ts";
+import type { AgentConfigWithModelState, AgentModelProbeResponse, AgentModelProbeState, ApprovalMode, Conversation, ConversationInfo, ElicitationResponse, InteractionMode, MessagePage, PermissionDecision, RunningSummary, SupervisorConfig, WorkspaceInfo } from "../shared/types.ts";
+import { isAgentRuntimeKind, isInteractionMode } from "../shared/types.ts";
 import { ATTACHMENT_LIMITS } from "../shared/types.ts";
 import { AttachmentStore } from "../core/attachment-store.ts";
 import { ConversationContext } from "./conversation-context.ts";
@@ -47,14 +47,14 @@ function toActiveConversation(conversation: Conversation | {
   name: string;
   interactionMode?: InteractionMode;
   lastDirectAgentId?: ConversationInfo["lastDirectAgentId"];
-  supervisionRuntime?: ConversationInfo["supervisionRuntime"];
+  supervisorConfig?: ConversationInfo["supervisorConfig"];
 }): ConversationInfo {
   return {
     id: conversation.id,
     name: conversation.name,
     interactionMode: conversation.interactionMode ?? "direct",
     lastDirectAgentId: conversation.lastDirectAgentId,
-    supervisionRuntime: conversation.supervisionRuntime,
+    supervisorConfig: conversation.supervisorConfig,
   };
 }
 const execFileAsync = promisify(execFile);
@@ -103,6 +103,7 @@ async function probeConfiguredAgentModels(
   runtimeFilter?: AgentConfig["runtime"],
   targetAgentId?: string,
   targetWorkspaceId?: string,
+  targetConversationId?: string,
 ): Promise<void> {
   const workspaceId = targetWorkspaceId || activeWorkspaceId;
   if (!workspaceId) return;
@@ -157,7 +158,11 @@ async function probeConfiguredAgentModels(
         updatedAt: snapshot.updatedAt,
       });
       for (const target of targets) {
-        const previous = existing[target.id];
+        // 监工快照按会话隔离（issue #153）：存储键带会话后缀，
+        // 事件带 conversationId 以便 SSE 按页面过滤。
+        const isSupervisor = target.id === INTERNAL_SUPERVISOR_ID && targetConversationId !== undefined;
+        const storageKey = isSupervisor ? supervisorStorageKey(targetConversationId!) : target.id;
+        const previous = existing[storageKey];
         const hasSessionValue = previous?.runtimeKind === runtimeKind && previous.currentValueSource === "session";
         const targetSnapshot = {
           ...snapshot,
@@ -165,12 +170,13 @@ async function probeConfiguredAgentModels(
           currentValue: hasSessionValue ? previous.currentValue : undefined,
           currentValueSource: hasSessionValue ? "session" as const : "probe" as const,
         };
-        agentModelStateStore.update(workspaceId, targetSnapshot);
+        agentModelStateStore.update(workspaceId, targetSnapshot, storageKey);
         sseHub.publish({
           type: "agent.model_state",
           workspaceId,
           agentId: target.id,
           modelState: targetSnapshot,
+          ...(isSupervisor ? { conversationId: targetConversationId! } : {}),
         });
       }
     } catch (error) {
@@ -257,15 +263,19 @@ eventBus.subscribe((event) => {
   if (event.type === "runtime.activity") return;
   let scopedEvent = event;
   if (event.type !== "events.gap" && "conversationId" in event && event.workspaceId === undefined) {
-    const matches = [...contextMap.keys()].filter((key) => key.endsWith(`:${event.conversationId}`));
-    // An unscoped legacy event is safe to infer only when the conversation id
-    // is unique in this process. Otherwise dropping it is safer than leaking
-    // one workspace's activity into another page.
-    if (matches.length === 1) {
-      const key = matches[0]!;
-      scopedEvent = { ...event, workspaceId: key.slice(0, key.length - event.conversationId.length - 1) };
-    } else if (matches.length > 1) {
-      return;
+    // agent.model_state 的 conversationId 是可选的（issue #153），缺失时不做推断。
+    const eventConversationId = event.conversationId;
+    if (eventConversationId !== undefined) {
+      const matches = [...contextMap.keys()].filter((key) => key.endsWith(`:${eventConversationId}`));
+      // An unscoped legacy event is safe to infer only when the conversation id
+      // is unique in this process. Otherwise dropping it is safer than leaking
+      // one workspace's activity into another page.
+      if (matches.length === 1) {
+        const key = matches[0]!;
+        scopedEvent = { ...event, workspaceId: key.slice(0, key.length - eventConversationId.length - 1) };
+      } else if (matches.length > 1) {
+        return;
+      }
     }
   }
   sseHub.publish(scopedEvent);
@@ -441,15 +451,31 @@ function createContext(workspaceId: string, conversationId: string): Conversatio
     workspaceConfig,
     globalConfig: globalConfigStore.load(),
     interactionMode: conversation?.interactionMode,
-    supervisionRuntime: conversation?.supervisionRuntime,
+    supervisorConfig: conversation?.supervisorConfig,
     lastDirectAgentId: conversation?.lastDirectAgentId,
     // 模型快照桥（issue #142）：runtime 返回的模型列表/当前值写穿到 workspace
     // 级存储，同时广播给 UI；读取供池复用捷径补发偏好。
+    // 监工按会话隔离（issue #153）：所有会话共用 agentId "supervisor"，
+    // 存储键须带会话后缀，事件须带 conversationId 才能按页面过滤。
     modelState: {
-      load: (agentId) => agentModelStateStore.get(workspaceId, agentId),
+      load: (agentId) => agentModelStateStore.get(
+        workspaceId,
+        agentId === INTERNAL_SUPERVISOR_ID ? supervisorStorageKey(conversationId) : agentId,
+      ),
       update: (snapshot) => {
-        agentModelStateStore.update(workspaceId, snapshot);
-        sseHub.publish({ type: "agent.model_state", workspaceId, agentId: snapshot.agentId, modelState: snapshot });
+        const isSupervisor = snapshot.agentId === INTERNAL_SUPERVISOR_ID;
+        agentModelStateStore.update(
+          workspaceId,
+          snapshot,
+          isSupervisor ? supervisorStorageKey(conversationId) : snapshot.agentId,
+        );
+        sseHub.publish({
+          type: "agent.model_state",
+          workspaceId,
+          agentId: snapshot.agentId,
+          modelState: snapshot,
+          ...(isSupervisor ? { conversationId } : {}),
+        });
       },
     },
     onConversationPatch: (patch) => {
@@ -612,6 +638,46 @@ migrateChannelLayer();
 initActiveContext();
 runHistoryCleanup();
 runAttachmentDraftCleanup();
+
+/**
+ * 解析并校验监工配置（issue #153）。
+ *
+ * 模型取值不在当前列表里时不拒绝保存：运行时会在应用时提示并回退，
+ * 提前拒绝会让用户在模型列表刷新不出来时无法保存其他改动。
+ */
+function parseSupervisorConfig(input: { runtime?: unknown; model?: unknown }):
+  { config: SupervisorConfig } | { error: string } {
+  if (!isAgentRuntimeKind(input.runtime)) {
+    return { error: "监工运行时必须是 claude-code、codex 或 codebuddy。" };
+  }
+  const runtime = input.runtime;
+  if (input.model === undefined || input.model === null) return { config: { runtime } };
+  if (typeof input.model !== "object" || Array.isArray(input.model)) {
+    return { error: "监工模型配置格式不正确。" };
+  }
+  const model = input.model as { preferredModelId?: unknown; runtimeKind?: unknown };
+  if (model.runtimeKind !== undefined && !isAgentRuntimeKind(model.runtimeKind)) {
+    return { error: "监工模型配置格式不正确。" };
+  }
+  if (model.preferredModelId !== undefined
+    && model.preferredModelId !== null
+    && typeof model.preferredModelId !== "string") {
+    return { error: "监工模型配置格式不正确。" };
+  }
+  const preferredModelId = typeof model.preferredModelId === "string"
+    ? model.preferredModelId.trim()
+    : "";
+  if (preferredModelId.length > 512) {
+    return { error: "监工模型标识过长。" };
+  }
+  if (!preferredModelId) return { config: { runtime } };
+  return {
+    config: {
+      runtime,
+      model: { preferredModelId, runtimeKind: isAgentRuntimeKind(model.runtimeKind) ? model.runtimeKind : runtime },
+    },
+  };
+}
 
 // --- HTTP Server (created before probe to avoid blocking setup) ---
 const server = http.createServer(async (req, res) => {
@@ -911,17 +977,29 @@ const server = http.createServer(async (req, res) => {
         sendJson(res, 400, { ok: false, message: "刷新指定员工模型时需要有效的员工 ID 和运行时。" });
         return;
       }
+      const targetConversationId = url.searchParams.get("conversationId")?.trim() || undefined;
+      // 监工是内部保留 ID，所有会话共用；缺会话维度会读写到别的会话的快照。
+      if (targetAgentId === INTERNAL_SUPERVISOR_ID && !targetConversationId) {
+        sendJson(res, 400, { ok: false, message: "刷新监工模型列表时需要会话 ID。" });
+        return;
+      }
       await probeConfiguredAgentModels(
         url.searchParams.get("force") === "1",
         runtimeFilter ?? undefined,
         targetAgentId,
         url.searchParams.get("workspaceId") || undefined,
+        targetConversationId,
       );
       const workspaceId = url.searchParams.get("workspaceId") || activeWorkspaceId;
       const configs = workspaceId ? configsWithModelState(workspaceId) : allConfigs;
       const response: AgentModelProbeResponse = { configs };
       if (workspaceId && runtimeFilter && targetAgentId) {
-        const snapshot = agentModelStateStore.get(workspaceId, targetAgentId);
+        const snapshot = agentModelStateStore.get(
+          workspaceId,
+          targetAgentId === INTERNAL_SUPERVISOR_ID && targetConversationId
+            ? supervisorStorageKey(targetConversationId)
+            : targetAgentId,
+        );
         const matchingSnapshot = snapshot?.runtimeKind === runtimeFilter ? snapshot : undefined;
         response.target = {
           agentId: targetAgentId,
@@ -1278,15 +1356,54 @@ const server = http.createServer(async (req, res) => {
       try {
         const current = conversationStoreFor(target.workspaceId).get(target.workspaceId, convId);
         if (!current) throw new Error("Conversation not found.");
-        const runtime = typeof input.runtime === "string" ? input.runtime as import("../shared/types.ts").AgentRuntimeKind : current.supervisionRuntime;
+        // runtime 参数仅用于兼容旧调用方；内部统一以 supervisorConfig 为准。
+        const runtime = typeof input.runtime === "string"
+          ? input.runtime as import("../shared/types.ts").AgentRuntimeKind
+          : current.supervisorConfig?.runtime;
         if (mode === "supervised" && (!runtime || !runtimeAvailable(runtimeKindToCliKey(runtime)))) {
           sendJson(res, 409, { ok: false, message: "Choose an available runtime before enabling supervised collaboration." });
           return;
         }
-        // setInteractionMode 通过 onConversationPatch 持久化模式与监工运行时
+        // setInteractionMode 通过 onConversationPatch 持久化模式与监工配置
         ctx.setInteractionMode(mode, runtime);
         const updated = conversationStoreFor(target.workspaceId).get(target.workspaceId, convId) ?? current;
         sendJson(res, 200, { ok: true, conversation: updated });
+      } catch (error) {
+        sendJson(res, 409, { ok: false, message: error instanceof Error ? error.message : String(error) });
+      }
+      return;
+    }
+
+    // 监工配置（issue #153）：显式页面上下文，可在任意协作模式下修改，
+    // 不依赖全局 active 指针。
+    if (req.method === "PUT" && url.pathname.startsWith("/api/conversations/") && url.pathname.endsWith("/supervisor-config")) {
+      const parts = url.pathname.split("/");
+      const convId = parts[3];
+      if (!convId) { sendJson(res, 400, { ok: false, message: "Missing conversation id." }); return; }
+      const target = resolveTarget(url);
+      if (!target || target.conversationId !== convId) {
+        sendJson(res, 409, { ok: false, message: "workspaceId and conversationId are required." });
+        return;
+      }
+      const input = (await readJson(req)) as { runtime?: unknown; model?: unknown };
+      const parsed = parseSupervisorConfig(input);
+      if ("error" in parsed) {
+        sendJson(res, 400, { ok: false, message: parsed.error });
+        return;
+      }
+      if (!runtimeAvailable(runtimeKindToCliKey(parsed.config.runtime))) {
+        sendJson(res, 409, { ok: false, message: "所选运行时当前不可用，请先安装或换一个运行时。" });
+        return;
+      }
+      const ctx = contextForTarget(target);
+      if (!ctx) { sendJson(res, 409, { ok: false, message: "No active conversation context." }); return; }
+      try {
+        if (!conversationStoreFor(target.workspaceId).get(target.workspaceId, convId)) {
+          throw new Error("Conversation not found.");
+        }
+        ctx.setSupervisorConfig(parsed.config);
+        const updated = conversationStoreFor(target.workspaceId).get(target.workspaceId, convId);
+        sendJson(res, 200, { ok: true, conversation: updated ? toActiveConversation(updated) : undefined });
       } catch (error) {
         sendJson(res, 409, { ok: false, message: error instanceof Error ? error.message : String(error) });
       }

--- a/src/server/sse-hub.ts
+++ b/src/server/sse-hub.ts
@@ -3,9 +3,12 @@ import type { ServerResponse } from "node:http";
 import type { RuntimeEvent } from "../shared/types.ts";
 
 export class SseHub {
-  private readonly clients = new Set<ServerResponse>();
+  private readonly clients = new Map<ServerResponse, { workspaceId?: string; conversationId?: string }>();
+  private nextSequence = 0;
+  private readonly history: Array<{ sequence: number; event: RuntimeEvent }> = [];
+  private readonly maxHistory = 500;
 
-  add(res: ServerResponse): void {
+  add(res: ServerResponse, scope: { workspaceId?: string; conversationId?: string } = {}, lastEventId?: number): void {
     res.writeHead(200, {
       "Content-Type": "text/event-stream; charset=utf-8",
       "Cache-Control": "no-cache, no-transform",
@@ -14,22 +17,51 @@ export class SseHub {
     });
     res.write(": connected\n\n");
 
-    this.clients.add(res);
+    this.clients.set(res, scope);
+    if (lastEventId !== undefined) {
+      const oldest = this.history[0]?.sequence;
+      const historyGap = lastEventId > this.nextSequence
+        || (oldest === undefined ? lastEventId > 0 : lastEventId < oldest - 1);
+      if (historyGap) {
+        // Give the gap marker the current cursor so EventSource will resume
+        // from this point after the client refreshes its snapshot.
+        this.write(res, { type: "events.gap", ...scope }, this.nextSequence);
+      } else {
+        for (const entry of this.history) {
+          if (entry.sequence > lastEventId && this.matches(entry.event, scope)) {
+            this.write(res, entry.event, entry.sequence);
+          }
+        }
+      }
+    }
     res.on("close", () => {
       this.clients.delete(res);
     });
   }
 
   publish(event: RuntimeEvent): void {
-    const payload = `data: ${JSON.stringify(event)}\n\n`;
+    const sequence = ++this.nextSequence;
+    this.history.push({ sequence, event });
+    if (this.history.length > this.maxHistory) this.history.shift();
 
-    for (const client of this.clients) {
-      client.write(payload);
+    for (const [client, scope] of this.clients) {
+      if (this.matches(event, scope)) this.write(client, event, sequence);
     }
   }
 
+  private matches(event: RuntimeEvent, scope: { workspaceId?: string; conversationId?: string }): boolean {
+    if (event.type === "runtime.availability.updated" || event.type === "running.updated") return true;
+    if (scope.workspaceId && "workspaceId" in event && event.workspaceId !== undefined && event.workspaceId !== scope.workspaceId) return false;
+    if (scope.conversationId && "conversationId" in event && event.conversationId !== undefined && event.conversationId !== scope.conversationId) return false;
+    return true;
+  }
+
+  private write(res: ServerResponse, event: RuntimeEvent, sequence?: number): void {
+    res.write(`${sequence === undefined ? "" : `id: ${sequence}\n`}data: ${JSON.stringify(event)}\n\n`);
+  }
+
   closeAll(): void {
-    for (const client of this.clients) {
+    for (const client of this.clients.keys()) {
       client.end();
     }
     this.clients.clear();

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -82,6 +82,12 @@ export type PendingPermission = AgentPermissionRequest & {
 
 export type AgentRuntimeKind = "claude-code" | "codex" | "codebuddy";
 
+export const AGENT_RUNTIME_KINDS: readonly AgentRuntimeKind[] = ["claude-code", "codex", "codebuddy"];
+
+export function isAgentRuntimeKind(value: unknown): value is AgentRuntimeKind {
+  return value === "claude-code" || value === "codex" || value === "codebuddy";
+}
+
 export type ChannelWatchTriggers = {
   onUnassignedMessage?: boolean;
   onAgentBlocked?: boolean;
@@ -109,6 +115,15 @@ export function hasActiveChannelWatchTriggers(triggers?: ChannelWatchTriggers): 
 export type AgentModelPreference = {
   preferredModelId?: string;
   runtimeKind: AgentRuntimeKind;
+};
+
+/**
+ * 监工配置（issue #153）：会话级保存，用户可在协作模式菜单里修改。
+ * model 沿用普通员工的 runtime 归属门控——偏好所属 runtime 与 runtime 不一致时不应用、不显示。
+ */
+export type SupervisorConfig = {
+  runtime: AgentRuntimeKind;
+  model?: AgentModelPreference;
 };
 
 export type AgentConfig = {
@@ -439,7 +454,10 @@ export type RuntimeEvent =
   | { type: "elicitation.resolved"; workspaceId?: string; conversationId: string; requestId: string }
   | { type: "running.updated"; summaries: RunningSummary[] }
   | { type: "runtime.availability.updated"; availability: RuntimeAvailability[] }
-  | { type: "agent.model_state"; workspaceId: string; agentId: AgentId; modelState: AgentModelStateSnapshot }
+  // conversationId 用于按页面隔离监工的模型快照（issue #153）：
+  // 监工是内部保留 ID，多个会话共享 agentId "supervisor"，不带会话维度会把
+  // 一个会话的监工状态广播给同工作区的其他页面。
+  | { type: "agent.model_state"; workspaceId: string; agentId: AgentId; modelState: AgentModelStateSnapshot; conversationId?: string }
   | { type: "events.gap"; workspaceId?: string; conversationId?: string };
 
 export type TerminalState = Record<string, string>;
@@ -461,7 +479,13 @@ export type ConversationInfo = {
   interactionMode?: InteractionMode;
   /** 普通对话模式下最近一位直接对话员工；切换到其他模式不清除，切回后继续。 */
   lastDirectAgentId?: AgentId;
-  /** 内部字段：复杂协作（监工）使用的运行时，不对用户展示、不可由用户直接配置。 */
+  /**
+   * 复杂协作（监工）的运行时与模型偏好（issue #153）。
+   * 旧记录只有 supervisionRuntime，读取时由 ConversationStore 映射为
+   * `{ runtime: supervisionRuntime }`；新写入只用本字段。
+   */
+  supervisorConfig?: SupervisorConfig;
+  /** 已废弃（issue #153）：仅用于读取旧记录的监工运行时，新代码请用 supervisorConfig。 */
   supervisionRuntime?: AgentRuntimeKind;
 };
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -185,6 +185,20 @@ export type AgentConfigWithModelState = AgentConfig & {
   modelProbe?: AgentModelProbeState;
 };
 
+/**
+ * 设置页可以在保存员工配置前切换 runtime，因此模型探测结果不能只依附于
+ * 服务端已保存的 AgentConfig。target 单独描述本次实际探测的员工和 runtime。
+ */
+export type AgentModelProbeResponse = {
+  configs: AgentConfigWithModelState[];
+  target?: {
+    agentId: AgentId;
+    runtimeKind: AgentRuntimeKind;
+    modelState: AgentModelStateSnapshot | null;
+    modelProbe: AgentModelProbeState;
+  };
+};
+
 export type AgentStatus = "starting" | "idle" | "running" | "error" | "stopped";
 
 export type AgentState = {
@@ -279,6 +293,8 @@ export type AgentActivityEvent =
 
 export type ChatMessage = {
   id: string;
+  /** Client-generated id used to make message retries idempotent per conversation. */
+  clientMessageId?: string;
   kind: ChatMessageKind;
   agentId?: AgentId;
   content: string;
@@ -395,9 +411,10 @@ export type MessagePage = MessageHistoryState & {
 };
 
 export type RuntimeEvent =
-  | { type: "message.created"; conversationId: string; message: ChatMessage }
+  | { type: "message.created"; workspaceId?: string; conversationId: string; message: ChatMessage }
   | {
       type: "message.updated";
+      workspaceId?: string;
       conversationId: string;
       message: ChatMessage;
       settleTransientActivity?: boolean;
@@ -408,22 +425,22 @@ export type RuntimeEvent =
        */
       excludedAnswerGroup?: string;
     }
-  | { type: "agent.status"; conversationId: string; agentId: AgentId; status: AgentStatus }
-  | { type: "runtime.activity"; conversationId: string; agentId: AgentId; runId: string; activity: AgentActivityEvent }
-  | { type: "run.activity"; conversationId: string; agentId: AgentId; runId: string; activity: AgentActivityEvent }
-  | { type: "terminal.chunk"; conversationId: string; agentId: AgentId; runId?: string; text: string }
-  | { type: "run.completed"; conversationId: string; agentId: AgentId; runId: string; resultMessageId: string; suppressFollowupRouting?: boolean }
-  | { type: "run.failed"; conversationId: string; agentId: AgentId; runId: string; error: string; interactionMode?: InteractionMode }
-  | { type: "run.cancelled"; conversationId: string; agentId: AgentId; runId: string; resultMessageId: string }
-  | { type: "run.sessionId"; conversationId: string; agentId: AgentId; runId: string; sessionId: string }
-  | { type: "permission.requested"; conversationId: string; permission: PendingPermission }
-  | { type: "permission.resolved"; conversationId: string; requestId: string }
-  | { type: "elicitation.requested"; conversationId: string; elicitation: PendingElicitation }
-  | { type: "elicitation.resolved"; conversationId: string; requestId: string }
+  | { type: "agent.status"; workspaceId?: string; conversationId: string; agentId: AgentId; status: AgentStatus }
+  | { type: "runtime.activity"; workspaceId?: string; conversationId: string; agentId: AgentId; runId: string; activity: AgentActivityEvent }
+  | { type: "run.activity"; workspaceId?: string; conversationId: string; agentId: AgentId; runId: string; activity: AgentActivityEvent }
+  | { type: "terminal.chunk"; workspaceId?: string; conversationId: string; agentId: AgentId; runId?: string; text: string }
+  | { type: "run.completed"; workspaceId?: string; conversationId: string; agentId: AgentId; runId: string; resultMessageId: string; suppressFollowupRouting?: boolean }
+  | { type: "run.failed"; workspaceId?: string; conversationId: string; agentId: AgentId; runId: string; error: string; interactionMode?: InteractionMode }
+  | { type: "run.cancelled"; workspaceId?: string; conversationId: string; agentId: AgentId; runId: string; resultMessageId: string }
+  | { type: "run.sessionId"; workspaceId?: string; conversationId: string; agentId: AgentId; runId: string; sessionId: string }
+  | { type: "permission.requested"; workspaceId?: string; conversationId: string; permission: PendingPermission }
+  | { type: "permission.resolved"; workspaceId?: string; conversationId: string; requestId: string }
+  | { type: "elicitation.requested"; workspaceId?: string; conversationId: string; elicitation: PendingElicitation }
+  | { type: "elicitation.resolved"; workspaceId?: string; conversationId: string; requestId: string }
   | { type: "running.updated"; summaries: RunningSummary[] }
   | { type: "runtime.availability.updated"; availability: RuntimeAvailability[] }
   | { type: "agent.model_state"; workspaceId: string; agentId: AgentId; modelState: AgentModelStateSnapshot }
-  | { type: "context.switched"; workspace: WorkspaceInfo; conversation: ConversationInfo };
+  | { type: "events.gap"; workspaceId?: string; conversationId?: string };
 
 export type TerminalState = Record<string, string>;
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -3,7 +3,7 @@ import { renderMarkdown, LOCAL_PATH_LINK_CLASS } from "./markdown-renderer.ts";
 import { isSafeExternalUrl } from "./url-guard.ts";
 import { AGENT_RUNTIME_PRIORITY, runtimeKindToCliKey, runtimeMeta } from "../core/runtime-meta.ts";
 import { matchPreset } from "../core/workspace-presets.ts";
-import { type AgentActivityEvent, type AgentConfig, type AgentConfigWithModelState, type AgentId, type AgentModelStateSnapshot, type AgentPlanSnapshot, type AgentRuntimeKind, type AgentState, type AgentTeamTemplate, type AppState, type ApprovalMode, type ChatMessage, type Conversation, type ConversationInfo, type DraftAttachmentInfo, type ElicitationContent, type ElicitationFieldSchema, type ElicitationResponse, type InteractionMode, type MessagePage, type PendingElicitation, type PendingPermission, type PermissionDecision, type PersistedProcessTimelineEntry, type RunningSummary, type RuntimeEvent, type Workspace, type WorkspacePreset, ATTACHMENT_LIMITS } from "../shared/types.ts";
+import { type AgentActivityEvent, type AgentConfig, type AgentConfigWithModelState, type AgentId, type AgentModelProbeResponse, type AgentModelStateSnapshot, type AgentPlanSnapshot, type AgentRuntimeKind, type AgentState, type AgentTeamTemplate, type AppState, type ApprovalMode, type ChatMessage, type Conversation, type ConversationInfo, type DraftAttachmentInfo, type ElicitationContent, type ElicitationFieldSchema, type ElicitationResponse, type InteractionMode, type MessagePage, type PendingElicitation, type PendingPermission, type PermissionDecision, type PersistedProcessTimelineEntry, type RunningSummary, type RuntimeEvent, type Workspace, type WorkspacePreset, ATTACHMENT_LIMITS } from "../shared/types.ts";
 import { appendTransientProcessActivity, collapseToolExecutions, type ProcessToolActivity, type ProcessToolExecution } from "../shared/process-activity.ts";
 import { WorkAnalysisPanel } from "./WorkAnalysisPanel.tsx";
 import * as TDesign from "tdesign-react";
@@ -61,6 +61,30 @@ const initialState: AppState = {
 type ActiveView = "conversation" | "analysis";
 const ACTIVE_VIEW_STORAGE_KEY = "orbit.activeView";
 const APPROVAL_MODE_STORAGE_KEY = "orbit.approvalMode";
+
+export type PageContext = { workspaceId: string; conversationId: string };
+
+export function readPageContext(search: string): PageContext {
+  const params = new URLSearchParams(search);
+  return {
+    workspaceId: params.get("workspaceId") ?? "",
+    conversationId: params.get("conversationId") ?? "",
+  };
+}
+
+function pageContextQuery(context: PageContext): string {
+  const params = new URLSearchParams();
+  if (context.workspaceId) params.set("workspaceId", context.workspaceId);
+  if (context.conversationId) params.set("conversationId", context.conversationId);
+  const query = params.toString();
+  return query ? `?${query}` : "";
+}
+
+function withPageContext(path: string, context: PageContext): string {
+  const separator = path.includes("?") ? "&" : "?";
+  const query = pageContextQuery(context).slice(1);
+  return query ? `${path}${separator}${query}` : path;
+}
 
 export function resolveActiveView(storedView: string | null): ActiveView {
   return storedView === "analysis" ? "analysis" : "conversation";
@@ -151,6 +175,18 @@ export function App() {
   const [isSwitchingInteractionMode, setIsSwitchingInteractionMode] = useState(false);
   const [showInteractionModeMenu, setShowInteractionModeMenu] = useState(false);
   const isNearBottomRef = useRef(true);
+  const stateRequestVersionRef = useRef(0);
+  const sseLastEventIdRef = useRef(0);
+  // 同一份草稿在失败重试时必须复用同一个 clientMessageId，
+  // 否则服务端按 id 去重的幂等保护失效，重试会重复落库。
+  // 但 id 必须与草稿内容绑定：内容改过之后要换新 id，否则服务端按旧 id 去重直接返回成功，
+  // 新内容其实从未送达，用户却以为发送成功了。
+  const draftMessageIdRef = useRef<{ id: string; content: string } | null>(null);
+
+  const currentPageContext = (): PageContext => ({
+    workspaceId: state.workspace.id,
+    conversationId: state.conversation.id,
+  });
 
   useEffect(() => {
     try {
@@ -203,10 +239,17 @@ export function App() {
       setConversationsByWorkspace((prev) => ({ ...prev, ...byWs }));
     });
   };
-  const refreshState = () => {
-    fetch("/api/state")
+  const refreshState = (requestedContext: PageContext = currentPageContext()) => {
+    const requestVersion = ++stateRequestVersionRef.current;
+    fetch(withPageContext("/api/state", requestedContext))
       .then((r) => r.json())
-      .then((nextState: AppState) => setState(normalizeState(nextState)))
+      .then((nextState: AppState) => {
+        const pageContext = typeof window === "undefined" ? requestedContext : readPageContext(window.location.search);
+        if (requestVersion !== stateRequestVersionRef.current
+          || pageContext.workspaceId !== requestedContext.workspaceId
+          || pageContext.conversationId !== requestedContext.conversationId) return;
+        setState(normalizeState(nextState));
+      })
       .catch(() => setConnectionState("offline"));
   };
 
@@ -230,38 +273,48 @@ export function App() {
   useEffect(() => {
     let cancelled = false;
 
-    fetch("/api/state")
+    const initialContext = typeof window === "undefined" ? { workspaceId: "", conversationId: "" } : readPageContext(window.location.search);
+    const requestVersion = ++stateRequestVersionRef.current;
+    fetch(withPageContext("/api/state", initialContext))
       .then((response) => {
-        if (!response.ok) {
-          throw new Error(`State request failed: ${response.status}`);
-        }
+        if (!response.ok) throw new Error(`State request failed: ${response.status}`);
         return response.json();
       })
       .then((nextState: AppState) => {
-        if (!cancelled) {
+        const pageContext = typeof window === "undefined" ? initialContext : readPageContext(window.location.search);
+        if (!cancelled && requestVersion === stateRequestVersionRef.current
+          && pageContext.workspaceId === initialContext.workspaceId
+          && pageContext.conversationId === initialContext.conversationId) {
           setState(normalizeState(nextState));
         }
       })
       .catch(() => {
-        if (!cancelled) {
-          setConnectionState("offline");
-        }
+        if (!cancelled) setConnectionState("offline");
       });
 
-    const events = new EventSource("/events");
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Each browser tab subscribes only to its current page context. Switching
+  // pages changes the URL and this effect replaces the old subscription.
+  useEffect(() => {
+    if (!state.workspace.id) return;
+    sseLastEventIdRef.current = 0;
+    const events = new EventSource(withPageContext("/events", currentPageContext()));
     events.onopen = () => setConnectionState("live");
     events.onerror = () => setConnectionState("offline");
     events.onmessage = (message) => {
       try {
+        const sequence = Number(message.lastEventId);
+        if (Number.isFinite(sequence) && sequence > 0) {
+          if (sequence <= sseLastEventIdRef.current) return;
+          sseLastEventIdRef.current = sequence;
+        }
         const event = JSON.parse(message.data) as RuntimeEvent;
-        if (event.type === "context.switched") {
-          // Full state re-fetch on context switch
-          fetch("/api/state")
-            .then((r) => r.json())
-            .then((nextState: AppState) => {
-              if (!cancelled) setState(normalizeState(nextState));
-            })
-            .catch(() => {});
+        if (event.type === "events.gap") {
+          refreshState();
           return;
         }
         setState((current) => applyEvent(current, event));
@@ -269,11 +322,25 @@ export function App() {
         setConnectionState("offline");
       }
     };
+    return () => events.close();
+  }, [state.workspace.id, state.conversation.id]);
 
-    return () => {
-      cancelled = true;
-      events.close();
+  useEffect(() => {
+    if (!state.workspace.id) return;
+    const next = pageContextQuery(currentPageContext());
+    if (typeof window !== "undefined" && window.location.search !== next) {
+      window.history.replaceState(null, "", `${window.location.pathname}${next}${window.location.hash}`);
+    }
+  }, [state.workspace.id, state.conversation.id]);
+
+  // 浏览器前进/后退只改地址栏，state 不会自动跟随。必须按新的页面上下文重新拉状态，
+  // 否则 UI 与地址栏脱节，后续 refreshState 的上下文校验还会把新结果当成过期响应丢弃。
+  useEffect(() => {
+    const handlePopState = () => {
+      refreshState(readPageContext(window.location.search));
     };
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
   }, []);
 
   // Load workspace and conversation lists
@@ -501,10 +568,15 @@ export function App() {
     }
 
     setIsSending(true);
+    const requestedContext = currentPageContext();
+    if (!draftMessageIdRef.current || draftMessageIdRef.current.content !== trimmed) {
+      draftMessageIdRef.current = { id: crypto.randomUUID(), content: trimmed };
+    }
     try {
-      const body: { content: string; approvalMode: ApprovalMode; draftAttachments?: Array<{ id: string; mimeType: string; filename: string; size: number }> } = {
+      const body: { content: string; approvalMode: ApprovalMode; clientMessageId: string; draftAttachments?: Array<{ id: string; mimeType: string; filename: string; size: number }> } = {
         content: trimmed,
         approvalMode,
+        clientMessageId: draftMessageIdRef.current.id,
       };
       if (pendingAttachments.length > 0) {
         body.draftAttachments = pendingAttachments.map((a) => ({
@@ -514,7 +586,7 @@ export function App() {
           size: a.size,
         }));
       }
-      const response = await fetch("/api/messages", {
+      const response = await fetch(withPageContext("/api/messages", requestedContext), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
@@ -524,6 +596,26 @@ export function App() {
         throw new Error(`Message request failed: ${response.status}`);
       }
 
+      const sent = await response.json() as { conversationId?: string };
+      const sentConversationId = typeof sent.conversationId === "string" ? sent.conversationId : "";
+      const pageContext = readPageContext(window.location.search);
+      const stillOnSamePage = pageContext.workspaceId === requestedContext.workspaceId
+        && (!pageContext.conversationId || pageContext.conversationId === requestedContext.conversationId);
+      // 无会话页面发送时服务端会顺带建会话，客户端必须采用这个 id：
+      // 否则事件 conversationId 与 state.conversation.id 不匹配而被 applyEvent 丢弃，
+      // 首条消息及其回复都不可见，且之后每条消息都会再新建一个会话。
+      if (sentConversationId && sentConversationId !== requestedContext.conversationId && stillOnSamePage) {
+        const nextContext = { workspaceId: requestedContext.workspaceId, conversationId: sentConversationId };
+        // 先同步地址栏：refreshState 校验地址栏与请求上下文是否一致，
+        // 请求晚于 URL 更新会被当成过期响应丢弃。
+        window.history.replaceState(null, "", `${window.location.pathname}${pageContextQuery(nextContext)}${window.location.hash}`);
+        setState((current) => ({ ...current, conversation: { ...current.conversation, id: sentConversationId } }));
+        refreshConversations();
+        // 首条消息的 created 事件可能在会话 id 落地前送达并被丢弃，补一次全量拉取兜底。
+        refreshState(nextContext);
+      }
+
+      draftMessageIdRef.current = null;
       setContent("");
       setPendingAttachments([]);
       isNearBottomRef.current = true;
@@ -545,6 +637,7 @@ export function App() {
     if (isSwitchingInteractionMode || mode === interactionMode) return;
     setIsSwitchingInteractionMode(true);
     const label = interactionModeLabel(mode);
+    const targetWorkspaceId = state.workspace.id;
     try {
       // 复杂协作需要监工运行时：优先沿用会话已记录的运行时，否则按可用性选择
       const runtime = mode === "supervised"
@@ -554,25 +647,33 @@ export function App() {
       // 首次对话还没有会话：先创建一个会话，再切换模式，保证菜单在首条消息前即可使用
       let conversationId = state.conversation.id;
       if (!conversationId) {
-        if (!state.workspace.id) throw new Error("请先选择或创建工作区。");
-        const createResponse = await fetch(`/api/conversations?workspaceId=${encodeURIComponent(state.workspace.id)}`, {
+        if (!targetWorkspaceId) throw new Error("请先选择或创建工作区。");
+        const createResponse = await fetch(withPageContext("/api/conversations", { workspaceId: targetWorkspaceId, conversationId: "" }), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({}),
         });
         const created = await createResponse.json() as { id?: string; message?: string };
         if (!createResponse.ok || !created.id) throw new Error(created.message ?? "创建会话失败。");
+        if (readPageContext(window.location.search).workspaceId !== targetWorkspaceId) return;
         conversationId = created.id;
+        window.history.pushState(null, "", `${window.location.pathname}${pageContextQuery({ workspaceId: targetWorkspaceId, conversationId })}${window.location.hash}`);
         refreshConversations();
       }
 
-      const response = await fetch(`/api/conversations/${conversationId}/interaction-mode`, {
+      const targetContext = { workspaceId: targetWorkspaceId, conversationId };
+      const currentPage = readPageContext(window.location.search);
+      if (currentPage.workspaceId !== targetContext.workspaceId
+        || (currentPage.conversationId && currentPage.conversationId !== targetContext.conversationId)) return;
+      const response = await fetch(withPageContext(`/api/conversations/${conversationId}/interaction-mode`, targetContext), {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(runtime ? { mode, runtime } : { mode }),
       });
       const body = await response.json() as { conversation?: ConversationInfo; message?: string };
       if (!response.ok || !body.conversation) throw new Error(body.message ?? `${label}切换失败`);
+      const pageContext = readPageContext(window.location.search);
+      if (pageContext.workspaceId !== targetContext.workspaceId || pageContext.conversationId !== targetContext.conversationId) return;
       setState((current) => ({ ...current, conversation: body.conversation! }));
     } catch (error) {
       setState((current) => ({ ...current, messages: [...current.messages, createLocalSystemMessage(error instanceof Error ? error.message : `${label}切换失败`)] }));
@@ -585,10 +686,10 @@ export function App() {
     if (resolvingPermissionIds.includes(requestId)) return;
     setResolvingPermissionIds((current) => [...current, requestId]);
     try {
-      const response = await fetch("/api/permissions/resolve", {
+      const response = await fetch(withPageContext("/api/permissions/resolve", currentPageContext()), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ requestId, decision }),
+        body: JSON.stringify({ requestId, decision, ...currentPageContext() }),
       });
       if (!response.ok && response.status !== 404) {
         throw new Error(`Permission request failed: ${response.status}`);
@@ -613,10 +714,10 @@ export function App() {
     if (resolvingElicitationIds.includes(requestId)) return;
     setResolvingElicitationIds((current) => [...current, requestId]);
     try {
-      const httpResponse = await fetch("/api/elicitations/resolve", {
+      const httpResponse = await fetch(withPageContext("/api/elicitations/resolve", currentPageContext()), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ requestId, ...response }),
+        body: JSON.stringify({ requestId, ...response, ...currentPageContext() }),
       });
       if (!httpResponse.ok && httpResponse.status !== 404) {
         throw new Error(`Elicitation request failed: ${httpResponse.status}`);
@@ -661,6 +762,7 @@ export function App() {
       return;
     }
 
+    const uploadContext = currentPageContext();
     for (const file of imageFiles.slice(0, maxFiles - pendingAttachments.length)) {
       const reader = new FileReader();
       reader.onload = async () => {
@@ -668,7 +770,7 @@ export function App() {
         if (!base64) return;
 
         try {
-          const response = await fetch("/api/attachments/drafts", {
+          const response = await fetch(withPageContext("/api/attachments/drafts", uploadContext), {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
@@ -685,7 +787,17 @@ export function App() {
           }
           const result = await response.json();
           if (result.ok && result.attachment) {
-            setPendingAttachments((prev) => [...prev, result.attachment as DraftAttachmentInfo]);
+            const currentContext = readPageContext(window.location.search);
+            const isCurrentPage = currentContext.workspaceId === uploadContext.workspaceId
+              && currentContext.conversationId === uploadContext.conversationId;
+            if (isCurrentPage) {
+              setPendingAttachments((prev) => [...prev, result.attachment as DraftAttachmentInfo]);
+            } else {
+              // Do not let an upload that started on another page become a
+              // draft for the newly selected conversation.
+              const attachment = result.attachment as DraftAttachmentInfo;
+              void fetch(`/api/attachments/drafts/${uploadContext.workspaceId}/${uploadContext.conversationId}/${attachment.id}?workspaceId=${encodeURIComponent(uploadContext.workspaceId)}&conversationId=${encodeURIComponent(uploadContext.conversationId)}`, { method: "DELETE" });
+            }
           }
         } catch {
           setAttachmentToast("图片上传失败");
@@ -698,7 +810,7 @@ export function App() {
 
   async function removePendingAttachment(id: string) {
     try {
-      await fetch(`/api/attachments/drafts/${state.workspace.id}/${state.conversation.id}/${id}`, {
+      await fetch(`/api/attachments/drafts/${state.workspace.id}/${state.conversation.id}/${id}?workspaceId=${encodeURIComponent(state.workspace.id)}&conversationId=${encodeURIComponent(state.conversation.id)}`, {
         method: "DELETE",
       });
     } catch { /* best effort */ }
@@ -709,7 +821,7 @@ export function App() {
     if (isInterrupting) return;
     setIsInterrupting(true);
     try {
-      const response = await fetch("/api/conversation/interrupt", { method: "POST" });
+      const response = await fetch(withPageContext("/api/conversation/interrupt", currentPageContext()), { method: "POST" });
       if (!response.ok) {
         throw new Error(`Interrupt request failed: ${response.status}`);
       }
@@ -738,7 +850,7 @@ export function App() {
 
     setIsLoadingOlderMessages(true);
     try {
-      const response = await fetch(`/api/messages?before=${encodeURIComponent(cursor)}&limit=50`);
+      const response = await fetch(withPageContext(`/api/messages?before=${encodeURIComponent(cursor)}&limit=50`, requestContext));
       if (!response.ok) {
         throw new Error(`Messages request failed: ${response.status}`);
       }
@@ -770,11 +882,19 @@ export function App() {
 
   async function switchWorkspace(workspaceId: string) {
     if (workspaceId === state.workspace.id) return;
-    const response = await fetch(`/api/workspaces/${workspaceId}/switch`, { method: "POST" });
+    const nextContext = { workspaceId, conversationId: "" };
+    window.history.pushState(null, "", `${window.location.pathname}${pageContextQuery(nextContext)}${window.location.hash}`);
+    const requestVersion = ++stateRequestVersionRef.current;
+    const response = await fetch(withPageContext("/api/state", nextContext));
     if (!response.ok) return;
     refreshWorkspaces();
     refreshConversations();
-    refreshState();
+    const nextState = await response.json() as AppState;
+    const pageContext = readPageContext(window.location.search);
+    if (requestVersion !== stateRequestVersionRef.current
+      || pageContext.workspaceId !== nextContext.workspaceId
+      || pageContext.conversationId !== nextContext.conversationId) return;
+    setState(normalizeState(nextState));
   }
 
   function handleWorkspaceClick(workspaceId: string) {
@@ -873,35 +993,59 @@ export function App() {
   async function deleteWorkspace(workspace: Workspace) {
     if (!confirm(`Delete workspace "${workspace.name}"?`)) return;
     const response = await fetch(`/api/workspaces/${workspace.id}`, { method: "DELETE" });
-      if (response.ok) {
-        setOpenWorkspaceMenuId(null);
-        setExpandedWorkspaceIds((ids) => {
-          const next = new Set(ids);
-          next.delete(workspace.id);
-          return next;
-        });
-        refreshWorkspaces();
-        refreshConversations();
-        refreshState();
-      }
+    if (!response.ok) return;
+    setOpenWorkspaceMenuId(null);
+    setExpandedWorkspaceIds((ids) => {
+      const next = new Set(ids);
+      next.delete(workspace.id);
+      return next;
+    });
+    const isCurrentPage = readPageContext(window.location.search).workspaceId === workspace.id;
+    refreshWorkspaces();
+    if (!isCurrentPage) {
+      refreshConversations();
+      return;
     }
+
+    // The deleted page context is no longer valid. Let the server choose the
+    // next available workspace, then publish that choice in this tab's URL.
+    window.history.pushState(null, "", `${window.location.pathname}${window.location.hash}`);
+    const requestVersion = ++stateRequestVersionRef.current;
+    const nextStateResponse = await fetch("/api/state");
+    if (!nextStateResponse.ok || requestVersion !== stateRequestVersionRef.current) return;
+    const nextState = normalizeState(await nextStateResponse.json() as AppState);
+    if (nextState.workspace.id) {
+      window.history.replaceState(null, "", `${window.location.pathname}${pageContextQuery({ workspaceId: nextState.workspace.id, conversationId: nextState.conversation.id })}${window.location.hash}`);
+    }
+    setState(nextState);
+    refreshConversations();
+  }
 
   async function switchConversation(conversationId: string, targetWorkspaceId?: string) {
     // Always return to the conversation view when a conversation is clicked,
     // even if it is already the active one (e.g. returning from 协作洞察).
     // The guard below only skips the redundant /switch request.
     setActiveView("conversation");
-    if (conversationId === state.conversation.id) return;
-    const wsParam = targetWorkspaceId && targetWorkspaceId !== state.workspace.id ? `?workspaceId=${targetWorkspaceId}` : "";
-    const response = await fetch(`/api/conversations/${conversationId}/switch${wsParam}`, { method: "POST" });
+    const workspaceId = targetWorkspaceId || state.workspace.id;
+    if (conversationId === state.conversation.id) {
+      if (workspaceId === state.workspace.id) return;
+    }
+    const nextContext = { workspaceId, conversationId };
+    window.history.pushState(null, "", `${window.location.pathname}${pageContextQuery(nextContext)}${window.location.hash}`);
+    const requestVersion = ++stateRequestVersionRef.current;
+    const response = await fetch(withPageContext("/api/state", nextContext));
     if (!response.ok) return;
     refreshConversations();
-    refreshState();
+    const nextState = await response.json() as AppState;
+    const pageContext = readPageContext(window.location.search);
+    if (requestVersion !== stateRequestVersionRef.current
+      || pageContext.workspaceId !== nextContext.workspaceId
+      || pageContext.conversationId !== nextContext.conversationId) return;
+    setState(normalizeState(nextState));
   }
 
   async function createConversation(workspaceId: string) {
-    const wsParam = workspaceId !== state.workspace.id ? `?workspaceId=${workspaceId}` : "";
-    const response = await fetch(`/api/conversations${wsParam}`, {
+    const response = await fetch(withPageContext("/api/conversations", { workspaceId, conversationId: "" }), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({}),
@@ -914,8 +1058,16 @@ export function App() {
       next.add(workspaceId);
       return next;
     });
+    const conversation = await response.json() as Conversation;
+    const nextContext = { workspaceId, conversationId: conversation.id };
+    window.history.pushState(null, "", `${window.location.pathname}${pageContextQuery(nextContext)}${window.location.hash}`);
     refreshConversations();
-    refreshState();
+    const requestVersion = ++stateRequestVersionRef.current;
+    const stateResponse = await fetch(withPageContext("/api/state", nextContext));
+    if (!stateResponse.ok || requestVersion !== stateRequestVersionRef.current) return;
+    const pageContext = readPageContext(window.location.search);
+    if (pageContext.workspaceId !== nextContext.workspaceId || pageContext.conversationId !== nextContext.conversationId) return;
+    setState(normalizeState(await stateResponse.json() as AppState));
   }
 
   async function renameConversation(conversationId: string, name: string, workspaceId?: string) {
@@ -925,8 +1077,7 @@ export function App() {
       setEditingConversationName("");
       return;
     }
-    const wsParam = workspaceId && workspaceId !== state.workspace.id ? `?workspaceId=${workspaceId}` : "";
-    const response = await fetch(`/api/conversations/${conversationId}${wsParam}`, {
+    const response = await fetch(withPageContext(`/api/conversations/${conversationId}`, { workspaceId: workspaceId || state.workspace.id, conversationId }), {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: trimmed }),
@@ -935,7 +1086,7 @@ export function App() {
     setEditingConversationId(null);
     setEditingConversationName("");
     refreshConversations();
-    refreshState();
+    if ((workspaceId || state.workspace.id) === state.workspace.id && conversationId === state.conversation.id) refreshState();
   }
 
   async function deleteConversation(conversation: Conversation) {
@@ -944,7 +1095,24 @@ export function App() {
     if (response.ok) {
       setOpenConversationMenuId(null);
       refreshConversations();
-      refreshState();
+      if (conversation.workspaceId === state.workspace.id && conversation.id === state.conversation.id) {
+        const response = await fetch(`/api/workspaces/${conversation.workspaceId}/conversations`);
+        const conversations = response.ok ? await response.json() as Conversation[] : [];
+        const nextConversation = conversations[0];
+        const nextContext = {
+          workspaceId: conversation.workspaceId,
+          conversationId: nextConversation?.id ?? "",
+        };
+        window.history.pushState(null, "", `${window.location.pathname}${pageContextQuery(nextContext)}${window.location.hash}`);
+        const requestVersion = ++stateRequestVersionRef.current;
+        const stateResponse = await fetch(withPageContext("/api/state", nextContext));
+        if (stateResponse.ok && requestVersion === stateRequestVersionRef.current) {
+          const pageContext = readPageContext(window.location.search);
+          if (pageContext.workspaceId === nextContext.workspaceId && pageContext.conversationId === nextContext.conversationId) {
+            setState(normalizeState(await stateResponse.json() as AppState));
+          }
+        }
+      }
     }
   }
 
@@ -1561,6 +1729,7 @@ export function App() {
         <WorkspaceConfigPanel
           onClose={() => setShowWorkspaceConfig(false)}
           hasWorkspace={hasWorkspace}
+          workspaceId={state.workspace.id}
           presets={workspacePresets}
         />
       ) : null}
@@ -1588,6 +1757,7 @@ export function App() {
       ) : null}
       {showAgentManager ? (
         <AgentManagerPanel
+          workspaceId={state.workspace.id}
           focusedAgentId={focusedAgentId}
           onClose={() => { setShowAgentManager(false); setFocusedAgentId(null); }}
           onSaved={() => { setShowAgentManager(false); setFocusedAgentId(null); window.location.reload(); }}
@@ -2477,7 +2647,7 @@ function PresetCard({ preset, selected, onClick }: { preset: WorkspacePreset; se
 }
 
 // Workspace-level config - prompt and rules
-function WorkspaceConfigPanel({ onClose, hasWorkspace, presets }: { onClose: () => void; hasWorkspace: boolean; presets: WorkspacePreset[] }) {
+function WorkspaceConfigPanel({ onClose, hasWorkspace, workspaceId, presets }: { onClose: () => void; hasWorkspace: boolean; workspaceId: string; presets: WorkspacePreset[] }) {
   const [systemPrompt, setSystemPrompt] = useState("");
   const [rules, setRules] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
@@ -2489,7 +2659,7 @@ function WorkspaceConfigPanel({ onClose, hasWorkspace, presets }: { onClose: () 
       setLoading(false);
       return;
     }
-    fetch("/api/workspace-config")
+    fetch(`/api/workspace-config?workspaceId=${encodeURIComponent(workspaceId)}`)
       .then((r) => r.json())
       .then((cfg: { systemPrompt?: string; rules?: string[] }) => {
         setSystemPrompt(cfg.systemPrompt ?? "");
@@ -2497,7 +2667,7 @@ function WorkspaceConfigPanel({ onClose, hasWorkspace, presets }: { onClose: () 
         setLoading(false);
       })
       .catch(() => setLoading(false));
-  }, [hasWorkspace]);
+  }, [hasWorkspace, workspaceId]);
 
   function applyPreset(presetId: string) {
     const preset = presets.find((p) => p.id === presetId);
@@ -2530,7 +2700,7 @@ function WorkspaceConfigPanel({ onClose, hasWorkspace, presets }: { onClose: () 
     if (!hasWorkspace) return;
     setSaving(true);
     setSavedMsg("");
-    fetch("/api/workspace-config", {
+    fetch(`/api/workspace-config?workspaceId=${encodeURIComponent(workspaceId)}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -2646,6 +2816,7 @@ function WorkspaceConfigPanel({ onClose, hasWorkspace, presets }: { onClose: () 
 
 function AgentManagerPanel({
   onClose,
+  workspaceId,
   onSaved,
   runtimeAvailability,
   focusedAgentId,
@@ -2654,6 +2825,7 @@ function AgentManagerPanel({
   modelStates,
 }: {
   onClose: () => void;
+  workspaceId: string;
   onSaved: () => void;
   runtimeAvailability: AppState["runtimeAvailability"];
   focusedAgentId?: string | null;
@@ -2692,7 +2864,7 @@ function AgentManagerPanel({
   }, [availByRuntime]);
 
   useEffect(() => {
-    fetch("/api/agents")
+    fetch(`/api/agents?workspaceId=${encodeURIComponent(workspaceId)}`)
       .then((r) => r.json())
       .then((data) => { setConfigs(data as AgentConfigWithModelState[]); setLoading(false); })
       .catch(() => { setError("加载数字员工配置失败。"); setLoading(false); });
@@ -2702,21 +2874,24 @@ function AgentManagerPanel({
       .catch(() => setTeamTemplates([]));
   }, []);
 
-  async function probeModels(force = false, runtime?: AgentRuntimeKind) {
+  async function probeModels(force = false, runtime?: AgentRuntimeKind, agentId?: AgentId) {
     if (isProbingModels) return;
     setIsProbingModels(true);
     try {
       const params = new URLSearchParams();
       if (force) params.set("force", "1");
       if (runtime) params.set("runtime", runtime);
+      if (agentId) params.set("agentId", agentId);
       const query = params.toString();
-      const response = await fetch(`/api/agents/probe-models${query ? `?${query}` : ""}`, { method: "POST" });
+      const paramsWithWorkspace = new URLSearchParams(query);
+      paramsWithWorkspace.set("workspaceId", workspaceId);
+      const response = await fetch(`/api/agents/probe-models?${paramsWithWorkspace.toString()}`, { method: "POST" });
       if (!response.ok) {
         setError("获取模型列表失败，请稍后重试。");
         return;
       }
-      const probedConfigs = await response.json() as AgentConfigWithModelState[];
-      setConfigs((current) => mergeProbedConfigs(current, probedConfigs));
+      const probeResponse = await response.json() as AgentModelProbeResponse;
+      setConfigs((current) => mergeModelProbeResponse(current, probeResponse));
     } catch {
       setError("获取模型列表失败，请检查本地运行时是否可用。");
     } finally {
@@ -2804,7 +2979,7 @@ function AgentManagerPanel({
     setSaving(true);
     setError("");
     try {
-      const res = await fetch("/api/agents", {
+      const res = await fetch(`/api/agents?workspaceId=${encodeURIComponent(workspaceId)}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(configs),
@@ -2826,7 +3001,7 @@ function AgentManagerPanel({
     setSaving(true);
     setError("");
     try {
-      const res = await fetch("/api/agents/reset", { method: "POST" });
+      const res = await fetch(`/api/agents/reset?workspaceId=${encodeURIComponent(workspaceId)}`, { method: "POST" });
       if (!res.ok) {
         setError("重置失败。");
         return;
@@ -2845,7 +3020,7 @@ function AgentManagerPanel({
     setSaving(true);
     setError("");
     try {
-      const res = await fetch("/api/agents/apply-team", {
+      const res = await fetch(`/api/agents/apply-team?workspaceId=${encodeURIComponent(workspaceId)}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ teamId }),
@@ -2984,7 +3159,7 @@ function AgentManagerPanel({
                           snapshot={modelSnapshot}
                           probe={modelProbe}
                           onChange={(patch) => updateConfig(i, patch)}
-                          onRefreshModels={() => void probeModels(true, config.runtime)}
+                          onRefreshModels={() => void probeModels(true, config.runtime, config.id)}
                           isRefreshing={isProbingModels}
                         />
                         <div className="fieldWithHint fieldFullWidth">
@@ -3099,6 +3274,24 @@ export function mergeProbedConfigs(
   ];
 }
 
+export function mergeModelProbeResponse(
+  current: AgentConfigWithModelState[],
+  response: AgentModelProbeResponse,
+): AgentConfigWithModelState[] {
+  const merged = mergeProbedConfigs(current, response.configs);
+  const target = response.target;
+  if (!target) return merged;
+  return merged.map((config) => (
+    config.id === target.agentId && config.runtime === target.runtimeKind
+      ? {
+          ...config,
+          modelState: target.modelState ?? undefined,
+          modelProbe: target.modelProbe,
+        }
+      : config
+  ));
+}
+
 function MarkdownContent({ content }: { content: string }) {
   const html = renderMarkdown(content);
   return <div className="markdown" dangerouslySetInnerHTML={{ __html: html }} />;
@@ -3114,6 +3307,7 @@ function preferredSupervisionRuntime(availability: AppState["runtimeAvailability
 }
 
 export function applyEvent(state: AppState, event: RuntimeEvent): AppState {
+  if (event.type === "events.gap") return state;
   if (event.type === "running.updated") {
     return { ...state, runningSummaries: event.summaries };
   }
@@ -3142,6 +3336,10 @@ export function applyEvent(state: AppState, event: RuntimeEvent): AppState {
       ...state,
       agentModelStates: { ...state.agentModelStates, [event.agentId]: event.modelState },
     };
+  }
+
+  if ("workspaceId" in event && event.workspaceId !== undefined && event.workspaceId !== state.workspace.id) {
+    return state;
   }
 
   // For conversation-scoped events, only process if they match the active conversation

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -2,8 +2,9 @@ import { CSSProperties, FormEvent, KeyboardEvent, MouseEvent, useEffect, useLayo
 import { renderMarkdown, LOCAL_PATH_LINK_CLASS } from "./markdown-renderer.ts";
 import { isSafeExternalUrl } from "./url-guard.ts";
 import { AGENT_RUNTIME_PRIORITY, runtimeKindToCliKey, runtimeMeta } from "../core/runtime-meta.ts";
+import { INTERNAL_SUPERVISOR_ID } from "../core/agent-profiles.ts";
 import { matchPreset } from "../core/workspace-presets.ts";
-import { type AgentActivityEvent, type AgentConfig, type AgentConfigWithModelState, type AgentId, type AgentModelProbeResponse, type AgentModelStateSnapshot, type AgentPlanSnapshot, type AgentRuntimeKind, type AgentState, type AgentTeamTemplate, type AppState, type ApprovalMode, type ChatMessage, type Conversation, type ConversationInfo, type DraftAttachmentInfo, type ElicitationContent, type ElicitationFieldSchema, type ElicitationResponse, type InteractionMode, type MessagePage, type PendingElicitation, type PendingPermission, type PermissionDecision, type PersistedProcessTimelineEntry, type RunningSummary, type RuntimeEvent, type Workspace, type WorkspacePreset, ATTACHMENT_LIMITS } from "../shared/types.ts";
+import { type AgentActivityEvent, type AgentConfig, type AgentConfigWithModelState, type AgentId, type AgentModelPreference, type AgentModelProbeResponse, type AgentModelProbeState, type AgentModelStateSnapshot, type AgentPlanSnapshot, type AgentRuntimeKind, type AgentState, type AgentTeamTemplate, type AppState, type ApprovalMode, type ChatMessage, type Conversation, type ConversationInfo, type DraftAttachmentInfo, type ElicitationContent, type ElicitationFieldSchema, type ElicitationResponse, type InteractionMode, type MessagePage, type PendingElicitation, type PendingPermission, type PermissionDecision, type PersistedProcessTimelineEntry, type RunningSummary, type RuntimeEvent, type SupervisorConfig, type Workspace, type WorkspacePreset, ATTACHMENT_LIMITS } from "../shared/types.ts";
 import { appendTransientProcessActivity, collapseToolExecutions, type ProcessToolActivity, type ProcessToolExecution } from "../shared/process-activity.ts";
 import { WorkAnalysisPanel } from "./WorkAnalysisPanel.tsx";
 import * as TDesign from "tdesign-react";
@@ -174,6 +175,7 @@ export function App() {
   const [isRefreshingRuntimes, setIsRefreshingRuntimes] = useState(false);
   const [isSwitchingInteractionMode, setIsSwitchingInteractionMode] = useState(false);
   const [showInteractionModeMenu, setShowInteractionModeMenu] = useState(false);
+  const [showSupervisorSettings, setShowSupervisorSettings] = useState(false);
   const isNearBottomRef = useRef(true);
   const stateRequestVersionRef = useRef(0);
   const sseLastEventIdRef = useRef(0);
@@ -252,6 +254,45 @@ export function App() {
       })
       .catch(() => setConnectionState("offline"));
   };
+
+  /**
+   * 保存监工配置（issue #153）。无会话时先创建会话并采用返回的会话 ID，
+   * 再通过显式页面上下文保存，避免依赖全局 active 指针。
+   */
+  async function saveSupervisorConfig(config: SupervisorConfig): Promise<void> {
+    const targetWorkspaceId = state.workspace.id;
+    if (!targetWorkspaceId) throw new Error("请先选择或创建工作区。");
+    let conversationId = state.conversation.id;
+    if (!conversationId) {
+      const createResponse = await fetch(withPageContext("/api/conversations", { workspaceId: targetWorkspaceId, conversationId: "" }), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      const created = await createResponse.json() as { id?: string; message?: string };
+      if (!createResponse.ok || !created.id) throw new Error(created.message ?? "创建会话失败。");
+      if (readPageContext(window.location.search).workspaceId !== targetWorkspaceId) return;
+      conversationId = created.id;
+      // 先同步地址栏，后续请求与状态刷新都以页面上下文为准。
+      window.history.replaceState(null, "", `${window.location.pathname}${pageContextQuery({ workspaceId: targetWorkspaceId, conversationId })}${window.location.hash}`);
+      setState((current) => ({ ...current, conversation: { ...current.conversation, id: conversationId } }));
+      refreshConversations();
+    }
+    const targetContext = { workspaceId: targetWorkspaceId, conversationId };
+    const response = await fetch(withPageContext(`/api/conversations/${conversationId}/supervisor-config`, targetContext), {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(config),
+    });
+    const body = await response.json() as { message?: string; conversation?: ConversationInfo };
+    if (!response.ok) throw new Error(body.message ?? "保存监工设置失败。");
+    const pageContext = readPageContext(window.location.search);
+    if (pageContext.workspaceId !== targetContext.workspaceId
+      || pageContext.conversationId !== targetContext.conversationId) return;
+    if (body.conversation) {
+      setState((current) => ({ ...current, conversation: { ...current.conversation, ...body.conversation! } }));
+    }
+  }
 
   async function refreshRuntimeAvailability() {
     if (isRefreshingRuntimes) return;
@@ -371,16 +412,23 @@ export function App() {
     refreshConversations();
   }, [workspaces, state.workspace.id]);
 
+  // 监工的运行时与模型偏好来自会话级配置（issue #153）。
+  const supervisorConfig: SupervisorConfig = state.conversation.supervisorConfig
+    ?? { runtime: preferredSupervisionRuntime(state.runtimeAvailability) ?? "codebuddy" };
   const agentsById = useMemo(() => {
     const agents = new Map(state.agents.map((agent) => [agent.id, agent]));
-    agents.set("supervisor", {
-      id: "supervisor",
-      label: "监工",
-      runtime: state.conversation.supervisionRuntime ?? "codebuddy",
-      status: "idle",
-    });
+    // 监工是内部员工，通常不在服务端员工列表里；若服务端返回了就保留其真实状态，
+    // 不要强制覆盖成 idle。
+    if (!agents.has(INTERNAL_SUPERVISOR_ID)) {
+      agents.set(INTERNAL_SUPERVISOR_ID, {
+        id: INTERNAL_SUPERVISOR_ID,
+        label: "监工",
+        runtime: supervisorConfig.runtime,
+        status: "idle",
+      });
+    }
     return agents;
-  }, [state.agents, state.conversation.supervisionRuntime]);
+  }, [state.agents, supervisorConfig.runtime]);
   const messagesById = useMemo(() => new Map(state.messages.map((message) => [message.id, message])), [state.messages]);
   const visibleMessages = useMemo(() => state.messages.filter((message) => !message.discarded), [state.messages]);
   const agentIds = useMemo(() => state.agents.map((agent) => agent.id), [state.agents]);
@@ -639,9 +687,9 @@ export function App() {
     const label = interactionModeLabel(mode);
     const targetWorkspaceId = state.workspace.id;
     try {
-      // 复杂协作需要监工运行时：优先沿用会话已记录的运行时，否则按可用性选择
+      // 复杂协作需要监工运行时：优先沿用会话已配置的运行时，否则按可用性选择
       const runtime = mode === "supervised"
-        ? state.conversation.supervisionRuntime ?? preferredSupervisionRuntime(state.runtimeAvailability)
+        ? state.conversation.supervisorConfig?.runtime ?? preferredSupervisionRuntime(state.runtimeAvailability)
         : undefined;
 
       // 首次对话还没有会话：先创建一个会话，再切换模式，保证菜单在首条消息前即可使用
@@ -1642,18 +1690,33 @@ export function App() {
                 {showInteractionModeMenu ? (
                   <div className="interactionModeMenu" role="menu" aria-label="会话协作模式">
                     {INTERACTION_MODE_META.map((meta) => (
-                      <button
-                        key={meta.mode}
-                        type="button"
-                        role="menuitemradio"
-                        aria-checked={interactionMode === meta.mode}
-                        title={meta.tooltip}
-                        onClick={() => { void selectInteractionMode(meta.mode); }}
-                      >
-                        <InteractionModeIcon mode={meta.mode} />
-                        <span><strong>{meta.label}</strong><small>{meta.tooltip}</small></span>
-                        {interactionMode === meta.mode ? <span className="approvalModeCheck" aria-hidden="true">✓</span> : null}
-                      </button>
+                      <div className="interactionModeRow" key={meta.mode}>
+                        <button
+                          type="button"
+                          role="menuitemradio"
+                          aria-checked={interactionMode === meta.mode}
+                          title={meta.tooltip}
+                          onClick={() => { void selectInteractionMode(meta.mode); }}
+                        >
+                          <InteractionModeIcon mode={meta.mode} />
+                          <span><strong>{meta.label}</strong><small>{meta.tooltip}</small></span>
+                          {interactionMode === meta.mode ? <span className="approvalModeCheck" aria-hidden="true">✓</span> : null}
+                        </button>
+                        {/* 监工设置是独立入口而非嵌套按钮：复杂协作开启前后都能改。 */}
+                        {meta.mode === "supervised" ? (
+                          <button
+                            type="button"
+                            className="supervisorSettingsTrigger"
+                            title="设置监工使用的运行时与模型"
+                            onClick={() => {
+                              setShowInteractionModeMenu(false);
+                              setShowSupervisorSettings(true);
+                            }}
+                          >
+                            监工设置
+                          </button>
+                        ) : null}
+                      </div>
                     ))}
                   </div>
                 ) : null}
@@ -1765,6 +1828,16 @@ export function App() {
           isRefreshingRuntimes={isRefreshingRuntimes}
           onRefreshRuntimes={refreshRuntimeAvailability}
           modelStates={state.agentModelStates}
+        />
+      ) : null}
+      {showSupervisorSettings ? (
+        <SupervisorSettingsPanel
+          workspaceId={state.workspace.id}
+          conversationId={state.conversation.id}
+          config={supervisorConfig}
+          availability={state.runtimeAvailability}
+          onClose={() => setShowSupervisorSettings(false)}
+          onSave={saveSupervisorConfig}
         />
       ) : null}
       {previewAttachment ? (
@@ -3301,6 +3374,193 @@ function PlainText({ content }: { content: string }) {
   return <div className="plainText">{content}</div>;
 }
 
+/**
+ * 监工设置（issue #153）：运行时与模型偏好按会话保存。
+ *
+ * - 运行时与模型都可在开启复杂协作前后修改，入口在协作模式菜单里独立存在。
+ * - 模型列表由所选运行时提供，按会话隔离探测（监工是所有会话共用的内部 ID）。
+ * - 偏好按 runtime 归属门控：换运行时后旧偏好既不生效也不展示。
+ */
+function SupervisorSettingsPanel({
+  workspaceId,
+  conversationId,
+  config,
+  availability,
+  onClose,
+  onSave,
+}: {
+  workspaceId: string;
+  conversationId: string;
+  config: SupervisorConfig;
+  availability: AppState["runtimeAvailability"];
+  onClose: () => void;
+  onSave: (config: SupervisorConfig) => Promise<void>;
+}) {
+  const [runtime, setRuntime] = useState<AgentRuntimeKind>(config.runtime);
+  const [model, setModel] = useState<AgentModelPreference | undefined>(config.model);
+  const [snapshot, setSnapshot] = useState<AgentModelStateSnapshot | undefined>(undefined);
+  const [probe, setProbe] = useState<AgentModelProbeState | undefined>(undefined);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const probedRuntimeRef = useRef<AgentRuntimeKind | undefined>(undefined);
+
+  async function refreshModels(targetRuntime: AgentRuntimeKind, force = false): Promise<void> {
+    if (!workspaceId) return;
+    setIsRefreshing(true);
+    setError("");
+    try {
+      const params = new URLSearchParams({ workspaceId, runtime: targetRuntime, agentId: INTERNAL_SUPERVISOR_ID });
+      // 监工是所有会话共用的内部 ID，模型快照按会话隔离，必须带会话维度。
+      if (conversationId) params.set("conversationId", conversationId);
+      if (force) params.set("force", "1");
+      const response = await fetch(`/api/agents/probe-models?${params.toString()}`, { method: "POST" });
+      const body = await response.json() as AgentModelProbeResponse;
+      const target = body.target;
+      if (target && target.runtimeKind === targetRuntime) {
+        setSnapshot(target.modelState ?? undefined);
+        setProbe(target.modelProbe);
+      }
+    } catch {
+      setError("模型列表获取失败，请重试。");
+    } finally {
+      setIsRefreshing(false);
+    }
+  }
+
+  // 首次打开按需探测当前监工的运行时；切换运行时后再探测一次新的。
+  useEffect(() => {
+    if (probedRuntimeRef.current === runtime) return;
+    probedRuntimeRef.current = runtime;
+    void refreshModels(runtime);
+  }, [runtime, workspaceId, conversationId]);
+
+  function chooseRuntime(next: AgentRuntimeKind): void {
+    if (next === runtime) return;
+    setRuntime(next);
+    // 切换运行时后旧偏好不再生效，也不展示。
+    setModel(undefined);
+    setSnapshot(undefined);
+    setProbe(undefined);
+  }
+
+  async function save(): Promise<void> {
+    setSaving(true);
+    setError("");
+    try {
+      await onSave(model ? { runtime, model } : { runtime });
+      onClose();
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : "保存监工设置失败。");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const probeStatus = probe?.status ?? (snapshot ? (snapshot.choices.length > 0 ? "ready" : "unsupported") : "idle");
+  const choices = probeStatus === "ready" ? snapshot?.choices ?? [] : [];
+  const nameOf = (value: string) => choices.find((choice) => choice.value === value)?.name ?? value;
+  // 偏好按 runtime 归属：与当前 runtime 不一致即不应用、不展示。
+  const preferred = model?.runtimeKind === runtime ? model.preferredModelId?.trim() || undefined : undefined;
+  const unavailable = new Set(
+    availability.filter((item) => !item.available).map((item) => runtimeKindToCliKey(item.runtime)),
+  );
+
+  return (
+    <div className="modalOverlay" onClick={onClose}>
+      <div className="modalPanel" onClick={(e) => e.stopPropagation()}>
+        <div className="modalHeader">
+          <h2>监工设置</h2>
+          <button type="button" onClick={onClose}>&times;</button>
+        </div>
+        <div className="settingsBody">
+          <p className="modelHint">
+            选择监工使用的运行时与模型。修改从监工的下一次运行开始生效；更换运行时会重建监工会话，普通员工和历史消息不受影响。
+          </p>
+          <div className="modelField fieldFullWidth">
+            <span className="pillLabel">运行时</span>
+            <div className="modelChoiceList">
+              {AGENT_RUNTIME_PRIORITY.map((kind) => (
+                <label key={kind} className={`modelChoice ${runtime === kind ? "modelChoiceActive" : ""}`}>
+                  <input
+                    type="radio"
+                    name="supervisor-runtime"
+                    checked={runtime === kind}
+                    onChange={() => chooseRuntime(kind)}
+                  />
+                  <span>
+                    {runtimeMeta(kind).label}
+                    {unavailable.has(runtimeKindToCliKey(kind)) ? "（当前不可用）" : ""}
+                  </span>
+                </label>
+              ))}
+            </div>
+          </div>
+          <div className="modelField fieldFullWidth">
+            <div className="modelFieldHeader">
+              <span className="pillLabel">模型 <span className="fieldHint" title="监工使用的模型。可选列表由所选运行时提供，每次运行开始时应用。">?</span></span>
+              <button
+                type="button"
+                className="modelRefreshBtn"
+                onClick={() => { void refreshModels(runtime, true); }}
+                disabled={isRefreshing}
+              >
+                {isRefreshing ? "获取中..." : "刷新模型列表"}
+              </button>
+            </div>
+            <div className="modelChoiceList">
+              <label className={`modelChoice ${preferred === undefined ? "modelChoiceActive" : ""}`}>
+                <input
+                  type="radio"
+                  name="supervisor-model"
+                  checked={preferred === undefined}
+                  onChange={() => setModel(undefined)}
+                />
+                <span>
+                  跟随运行时默认
+                  {probeStatus === "ready" && snapshot?.currentValueSource === "session" && snapshot.currentValue
+                    ? `（当前：${nameOf(snapshot.currentValue)}）`
+                    : ""}
+                </span>
+              </label>
+              {choices.map((choice) => (
+                <label key={choice.value} className={`modelChoice ${preferred === choice.value ? "modelChoiceActive" : ""}`}>
+                  <input
+                    type="radio"
+                    name="supervisor-model"
+                    checked={preferred === choice.value}
+                    onChange={() => setModel({ preferredModelId: choice.value, runtimeKind: runtime })}
+                  />
+                  <span>
+                    {choice.name}
+                    {probeStatus === "ready" && snapshot?.currentValueSource === "session"
+                      && snapshot.currentValue === choice.value && preferred !== choice.value ? "（当前）" : ""}
+                  </span>
+                </label>
+              ))}
+            </div>
+            {probeStatus === "error" ? (
+              <div className="modelHint modelHintWarn">{probe?.message ?? "模型列表获取失败，请重试。"}</div>
+            ) : probeStatus === "unsupported" ? (
+              <div className="modelHint">该运行时未提供可选模型列表。</div>
+            ) : probeStatus === "loading" ? (
+              <div className="modelHint">正在获取模型列表...</div>
+            ) : null}
+            <div className="modelHint">模型选择在监工下次运行时生效。</div>
+          </div>
+          {error ? <div className="modelHint modelHintWarn">{error}</div> : null}
+          <div className="modalFooter">
+            <button type="button" onClick={onClose} disabled={saving}>关闭</button>
+            <button type="button" className="primaryBtn" onClick={() => { void save(); }} disabled={saving}>
+              {saving ? "保存中..." : "保存"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function preferredSupervisionRuntime(availability: AppState["runtimeAvailability"]): AgentRuntimeKind | undefined {
   const available = new Set(availability.filter((item) => item.available).map((item) => item.runtime));
   return AGENT_RUNTIME_PRIORITY.find((runtime) => available.has(runtimeKindToCliKey(runtime)));
@@ -3328,10 +3588,13 @@ export function applyEvent(state: AppState, event: RuntimeEvent): AppState {
     };
   }
 
-  // agent.model_state 是 workspace 级事件（无 conversationId），在会话过滤前处理，
+  // agent.model_state 通常是 workspace 级事件（无 conversationId），在会话过滤前处理，
   // 但不能让后台工作区的同名员工覆盖当前工作区的模型状态。
   if (event.type === "agent.model_state") {
     if (event.workspaceId !== state.workspace.id) return state;
+    // 监工是所有会话共用的内部 ID，其快照带会话维度（issue #153）：
+    // 其他会话的监工状态不能覆盖本页。
+    if (event.conversationId !== undefined && event.conversationId !== state.conversation.id) return state;
     return {
       ...state,
       agentModelStates: { ...state.agentModelStates, [event.agentId]: event.modelState },

--- a/src/ui/WorkAnalysisPanel.tsx
+++ b/src/ui/WorkAnalysisPanel.tsx
@@ -25,7 +25,7 @@ export function WorkAnalysisPanel(props: {
     const controller = new AbortController();
     setLoading(true);
     setError(null);
-    fetch(`/api/work-analysis?days=${days}`, { signal: controller.signal })
+    fetch(`/api/work-analysis?workspaceId=${encodeURIComponent(props.workspaceId)}&days=${days}`, { signal: controller.signal })
       .then(async (response) => {
         if (!response.ok) throw new Error("协作洞察暂时无法加载");
         return response.json() as Promise<WorkAnalysis>;

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1832,6 +1832,36 @@ button:active:not(:disabled) {
   box-shadow: var(--shadow-lg);
 }
 
+/* 监工设置入口与模式项同一行，避免在模式按钮内嵌套按钮（issue #153） */
+.interactionModeRow {
+  display: flex;
+  align-items: stretch;
+  gap: 4px;
+}
+
+.interactionModeRow > button:first-child {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.interactionModeMenu .supervisorSettingsTrigger {
+  display: block;
+  flex: 0 0 auto;
+  align-self: center;
+  width: auto;
+  padding: 6px 10px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+.interactionModeMenu .supervisorSettingsTrigger:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: transparent;
+}
+
 .approvalModeMenu button,
 .interactionModeMenu button {
   display: grid;

--- a/tests/agent-context-builder.test.ts
+++ b/tests/agent-context-builder.test.ts
@@ -38,7 +38,7 @@ test("employee instructions replace the old role section", () => {
 });
 
 test("supervisor constraints are limited to the internal supervisor", () => {
-  const profiles = [...createDefaultAgentProfiles("D:/project"), createSupervisorProfile("D:/project", "codebuddy")];
+  const profiles = [...createDefaultAgentProfiles("D:/project"), createSupervisorProfile("D:/project", { runtime: "codebuddy" })];
   const output = buildAgentContext({
     agentId: "supervisor",
     profiles,
@@ -121,7 +121,7 @@ test("direct mode omits the available employees section for regular employees", 
 });
 
 test("supervised supervisor prompt keeps coordinator duties while employees must not impersonate it", () => {
-  const profiles = [...createDefaultAgentProfiles("D:/project"), createSupervisorProfile("D:/project", "codebuddy")];
+  const profiles = [...createDefaultAgentProfiles("D:/project"), createSupervisorProfile("D:/project", { runtime: "codebuddy" })];
   const supervisor = buildAgentContext({
     agentId: "supervisor",
     profiles,
@@ -178,7 +178,7 @@ test("custom teams receive all built-in mode rules without workspace instruction
 
   const supervised = buildAgentContext({
     agentId: "supervisor",
-    profiles: [...customProfiles, createSupervisorProfile("D:/project", "codebuddy")],
+    profiles: [...customProfiles, createSupervisorProfile("D:/project", { runtime: "codebuddy" })],
     agentMessage: "Coordinate.",
     interactionMode: "supervised",
     workspaceConfig: emptyWorkspace,

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -96,3 +96,78 @@ test("states include each agent runtime", () => {
 
   assert.equal(developer?.runtime, "codebuddy");
 });
+
+test("updatePreferredModel changes the preference in place without recreating the session", () => {
+  const profiles = createDefaultAgentProfiles(process.cwd());
+  const noopRuntime: AgentRuntime = {
+    kind: "claude-code",
+    run() { throw new Error("this test does not start runs"); },
+  };
+  const codexRuntime: AgentRuntime = { ...noopRuntime, kind: "codex" };
+  const codeBuddyRuntime: AgentRuntime = { ...noopRuntime, kind: "codebuddy" };
+  const registry = new AgentRegistry(
+    profiles,
+    new EventBus(),
+    createTempSessionStore(),
+    "conv-model-only",
+    new Map([
+      ["claude-code", noopRuntime],
+      ["codex", codexRuntime],
+      ["codebuddy", codeBuddyRuntime],
+    ]),
+  );
+
+  const session = registry.get("implementation");
+  assert.equal(session.preferredModel(), undefined);
+
+  assert.equal(registry.updatePreferredModel("implementation", "claude-opus-4"), true);
+  // 会话实例未变：仅模型变化时不应重建会话、不打断排队/运行中的任务。
+  assert.strictEqual(registry.get("implementation"), session);
+  assert.equal(session.preferredModel(), "claude-opus-4");
+  assert.equal(registry.profile("implementation")?.preferredModelId, "claude-opus-4");
+
+  // 清空偏好：整字段移除，而不是留空字符串。
+  assert.equal(registry.updatePreferredModel("implementation", "   "), true);
+  assert.equal(session.preferredModel(), undefined);
+  assert.equal("preferredModelId" in (registry.profile("implementation") ?? {}), false);
+
+  assert.equal(registry.updatePreferredModel("unknown-employee", "claude-opus-4"), false);
+});
+
+test("an updated preference reaches the runtime on the next run only", async () => {
+  const profiles = createDefaultAgentProfiles(process.cwd());
+  const seen: Array<string | undefined> = [];
+  const codexRuntime: AgentRuntime = {
+    kind: "codex",
+    run(options) {
+      seen.push(options.preferredModelId);
+      return {
+        process: { kill: () => {}, pid: 12345, interrupt: () => {} },
+        result: Promise.resolve("codex final"),
+        sessionId: Promise.resolve("codex-session"),
+      };
+    },
+  };
+  const noopRuntime: AgentRuntime = {
+    kind: "claude-code",
+    run() { throw new Error("only the codex employee runs in this test"); },
+  };
+  const registry = new AgentRegistry(
+    profiles,
+    new EventBus(),
+    createTempSessionStore(),
+    "conv-next-run",
+    new Map([
+      ["claude-code", noopRuntime],
+      ["codex", codexRuntime],
+      ["codebuddy", { ...noopRuntime, kind: "codebuddy" }],
+    ]),
+  );
+  registry.startAll();
+
+  await registry.get("requirements").send("run-1", "first");
+  registry.updatePreferredModel("requirements", "gpt-5-codex");
+  await registry.get("requirements").send("run-2", "second");
+
+  assert.deepEqual(seen, [undefined, "gpt-5-codex"]);
+});

--- a/tests/app-process-events.test.ts
+++ b/tests/app-process-events.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { applyEvent, buildProcessTimeline, mergeProbedConfigs, upsertMessage } from "../src/ui/App.tsx";
+import { applyEvent, buildProcessTimeline, mergeModelProbeResponse, mergeProbedConfigs, upsertMessage } from "../src/ui/App.tsx";
 import type { AgentActivityEvent, AgentModelStateSnapshot, AgentPlanSnapshot, AppState, ChatMessage } from "../src/shared/types.ts";
 
 const CONVERSATION = "conv1";
@@ -401,4 +401,75 @@ test("model probe responses preserve unsaved local employee configuration", () =
   assert.equal(merged[0]?.model?.preferredModelId, "model-b");
   assert.deepEqual(merged[0]?.modelState, probed.modelState);
   assert.deepEqual(merged[0]?.modelProbe, probed.modelProbe);
+});
+
+test("targeted model probe applies to an unsaved runtime switch", () => {
+  const local = {
+    id: "developer",
+    name: "本地改名",
+    description: "未保存描述",
+    runtime: "codebuddy" as const,
+    systemPrompt: "未保存提示词",
+    enabled: true,
+  };
+  const serverConfig = {
+    ...local,
+    name: "服务端旧名称",
+    runtime: "claude-code" as const,
+  };
+  const modelState: AgentModelStateSnapshot = {
+    agentId: "developer",
+    runtimeKind: "codebuddy",
+    configId: "model",
+    choices: [{ value: "glm-5.3", name: "GLM-5.3" }],
+    currentValue: undefined,
+    currentValueSource: "probe",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+
+  const merged = mergeModelProbeResponse([local], {
+    configs: [serverConfig],
+    target: {
+      agentId: "developer",
+      runtimeKind: "codebuddy",
+      modelState,
+      modelProbe: { runtimeKind: "codebuddy", status: "ready", updatedAt: modelState.updatedAt },
+    },
+  });
+
+  assert.equal(merged[0]?.name, "本地改名");
+  assert.equal(merged[0]?.runtime, "codebuddy");
+  assert.equal(merged[0]?.systemPrompt, "未保存提示词");
+  assert.deepEqual(merged[0]?.modelState, modelState);
+  assert.equal(merged[0]?.modelProbe?.status, "ready");
+});
+
+test("targeted model probe does not overwrite a later runtime switch", () => {
+  const local = {
+    id: "developer",
+    name: "开发",
+    runtime: "codex" as const,
+    systemPrompt: "实现任务",
+    enabled: true,
+  };
+  const merged = mergeModelProbeResponse([local], {
+    configs: [local],
+    target: {
+      agentId: "developer",
+      runtimeKind: "codebuddy",
+      modelState: {
+        agentId: "developer",
+        runtimeKind: "codebuddy",
+        configId: "model",
+        choices: [{ value: "glm-5.3", name: "GLM-5.3" }],
+        currentValue: undefined,
+        currentValueSource: "probe",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+      modelProbe: { runtimeKind: "codebuddy", status: "ready" },
+    },
+  });
+
+  assert.equal(merged[0]?.runtime, "codex");
+  assert.equal(merged[0]?.modelState, undefined);
 });

--- a/tests/conversation-store.test.ts
+++ b/tests/conversation-store.test.ts
@@ -28,13 +28,46 @@ test("interaction mode persists across repeated switches", () => {
   const store = new ConversationStore(dir);
   const conv = store.create("ws1", "Mode switching");
 
-  store.update("ws1", conv.id, { interactionMode: "supervised", supervisionRuntime: "codebuddy" });
+  store.update("ws1", conv.id, { interactionMode: "supervised", supervisorConfig: { runtime: "codebuddy" } });
   store.update("ws1", conv.id, { interactionMode: "direct" });
   store.update("ws1", conv.id, { interactionMode: "supervised" });
 
   const reloaded = new ConversationStore(dir).get("ws1", conv.id)!;
   assert.equal(reloaded.interactionMode, "supervised");
-  assert.equal(reloaded.supervisionRuntime, "codebuddy");
+  assert.equal(reloaded.supervisorConfig?.runtime, "codebuddy");
+});
+
+test("legacy supervisionRuntime records are read as supervisorConfig", () => {
+  const dir = tmpDir();
+  const store = new ConversationStore(dir);
+  const conv = store.create("ws1", "Legacy supervision runtime");
+
+  // 直接改底层文件，模拟 issue #153 之前只保存 supervisionRuntime 的记录。
+  const file = path.join(dir, "conversations", "ws1", "conversations.json");
+  const raw = JSON.parse(fs.readFileSync(file, "utf8")) as {
+    conversations: Array<Record<string, unknown>>;
+  };
+  fs.writeFileSync(file, JSON.stringify({
+    conversations: raw.conversations.map((entry) => ({ ...entry, supervisionRuntime: "codex" })),
+  }, null, 2));
+
+  const reloaded = new ConversationStore(dir).get("ws1", conv.id)!;
+  assert.equal(reloaded.supervisorConfig?.runtime, "codex");
+});
+
+test("supervisor model preference persists across reload", () => {
+  const dir = tmpDir();
+  const store = new ConversationStore(dir);
+  const conv = store.create("ws1", "Supervisor model");
+
+  store.update("ws1", conv.id, {
+    supervisorConfig: { runtime: "codebuddy", model: { preferredModelId: "gpt-5", runtimeKind: "codebuddy" } },
+  });
+
+  const reloaded = new ConversationStore(dir).get("ws1", conv.id)!;
+  assert.equal(reloaded.supervisorConfig?.runtime, "codebuddy");
+  assert.equal(reloaded.supervisorConfig?.model?.preferredModelId, "gpt-5");
+  assert.equal(reloaded.supervisorConfig?.model?.runtimeKind, "codebuddy");
 });
 
 test("last direct employee persists alongside mode switches away and back", () => {

--- a/tests/first-message-conversation-adoption.test.ts
+++ b/tests/first-message-conversation-adoption.test.ts
@@ -1,0 +1,162 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Issue #116: sending the first message from a page with no active conversation.
+ *
+ * The server creates a conversation on demand when the POST carries an empty
+ * conversationId, and returns that id in the response body. The client used to
+ * ignore the body entirely, so:
+ *
+ *   1. `state.conversation.id` stayed "" and every later message created yet
+ *      another conversation.
+ *   2. `applyEvent` drops events whose `conversationId` does not match
+ *      `state.conversation.id`, so the message and its replies never rendered.
+ *
+ * There is no React rendering harness in this repo, so this mirrors the
+ * source-scanning style used by the other UI tests (e.g.
+ * switch-conversation-view.test.ts).
+ */
+
+const appSource = fs.readFileSync(
+  path.resolve(import.meta.dirname, "../src/ui/App.tsx"),
+  "utf-8",
+);
+
+/** Extract the body of a function/method by name (matches `name(...) {`). */
+function extractFunctionBody(source: string, name: string): string | null {
+  const regex = new RegExp(`${name}\\([^)]*\\)[^{]*\\{`, "g");
+  let match;
+  while ((match = regex.exec(source)) !== null) {
+    const start = match.index + match[0].length;
+    let depth = 1;
+    let i = start;
+    while (i < source.length && depth > 0) {
+      if (source[i] === "{") depth++;
+      else if (source[i] === "}") depth--;
+      i++;
+    }
+    return source.slice(start, i - 1);
+  }
+  return null;
+}
+
+const sendMessageBody = extractFunctionBody(appSource, "sendMessage");
+
+describe("Issue #116: first message adopts the conversation created by the server", () => {
+  test("sendMessage reads conversationId from the POST response", () => {
+    assert.ok(sendMessageBody, "Could not find sendMessage() in App.tsx");
+
+    assert.match(
+      sendMessageBody,
+      /await response\.json\(\)/,
+      "sendMessage must read the response body, otherwise the server-created conversation id is lost. " +
+        "Got body:\n" + sendMessageBody,
+    );
+    assert.match(
+      sendMessageBody,
+      /sentConversationId/,
+      "sendMessage must derive the returned conversation id into a local before adopting it. " +
+        "Got body:\n" + sendMessageBody,
+    );
+  });
+
+  test("adopted conversation id reaches state and the address bar", () => {
+    assert.ok(sendMessageBody, "Could not find sendMessage() in App.tsx");
+
+    assert.match(
+      sendMessageBody,
+      /conversation:\s*\{\s*\.\.\.current\.conversation,\s*id:\s*sentConversationId\s*\}/,
+      "state.conversation.id must be updated with the returned id, otherwise SSE events are " +
+        "filtered out by applyEvent and later messages create duplicate conversations. " +
+        "Got body:\n" + sendMessageBody,
+    );
+    assert.match(
+      sendMessageBody,
+      /window\.history\.replaceState\([^)]*pageContextQuery\(nextContext\)/,
+      "The address bar must be updated with the new conversation id so the page context stays " +
+        "the source of truth across reloads and per-tab isolation. Got body:\n" + sendMessageBody,
+    );
+  });
+
+  test("address bar is updated before the state request", () => {
+    assert.ok(sendMessageBody, "Could not find sendMessage() in App.tsx");
+
+    const urlIdx = sendMessageBody.indexOf("window.history.replaceState");
+    const refreshIdx = sendMessageBody.indexOf("refreshState(nextContext)");
+
+    assert.notStrictEqual(urlIdx, -1, "URL must be synced with the new conversation id");
+    assert.notStrictEqual(
+      refreshIdx,
+      -1,
+      "A full state refresh must follow as a safety net: the message.created event can arrive " +
+        "before the conversation id lands and would then be dropped with no replay.",
+    );
+    assert.ok(
+      urlIdx < refreshIdx,
+      "window.history.replaceState must run BEFORE refreshState(nextContext). refreshState " +
+        "validates the address bar against the requested context and discards responses that " +
+        "arrive before the URL is updated. Got body:\n" + sendMessageBody,
+    );
+  });
+
+  test("clientMessageId is reused across retries and reset after success", () => {
+    assert.ok(sendMessageBody, "Could not find sendMessage() in App.tsx");
+
+    assert.match(
+      sendMessageBody,
+      /clientMessageId:\s*draftMessageIdRef\.current/,
+      "The idempotency key must come from a ref so a failed send can be retried under the same " +
+        "clientMessageId. Regenerating it per attempt defeats the server-side dedupe and " +
+        "duplicates the message. Got body:\n" + sendMessageBody,
+    );
+    assert.doesNotMatch(
+      sendMessageBody,
+      /clientMessageId:\s*crypto\.randomUUID\(\)/,
+      "clientMessageId must not be generated inline per attempt. Got body:\n" + sendMessageBody,
+    );
+    assert.match(
+      sendMessageBody,
+      /draftMessageIdRef\.current = null;/,
+      "The draft id must be cleared after a successful send so the next message gets a new key. " +
+        "Got body:\n" + sendMessageBody,
+    );
+  });
+
+  test("changed draft content gets a fresh idempotency key", () => {
+    assert.ok(sendMessageBody, "Could not find sendMessage() in App.tsx");
+
+    assert.match(
+      sendMessageBody,
+      /draftMessageIdRef\.current\.content !== trimmed/,
+      "The draft id must be regenerated when the draft content changes. Otherwise, if a request " +
+        "reached the server but its response was lost, retrying edited text would reuse the old " +
+        "clientMessageId — the server dedupes it and reports success while the new content never " +
+        "arrives. Got body:\n" + sendMessageBody,
+    );
+    assert.match(
+      sendMessageBody,
+      /draftMessageIdRef\.current = \{\s*id:\s*crypto\.randomUUID\(\),\s*content:\s*trimmed\s*\}/,
+      "The draft id must be stored alongside the content it was generated for, so a retry can tell " +
+        "'same content, retry the same message' apart from 'edited content, a new message'. " +
+        "Got body:\n" + sendMessageBody,
+    );
+  });
+
+  test("browser back/forward re-syncs state from the address bar", () => {
+    assert.match(
+      appSource,
+      /window\.addEventListener\("popstate"/,
+      "Page-context navigation uses pushState/replaceState, so without a popstate listener " +
+        "browser back/forward leaves the UI out of sync with the URL and later state responses " +
+        "are discarded by the context guard.",
+    );
+    assert.match(
+      appSource,
+      /refreshState\(readPageContext\(window\.location\.search\)\)/,
+      "The popstate handler must pull state for the URL's page context.",
+    );
+  });
+});

--- a/tests/message-store.test.ts
+++ b/tests/message-store.test.ts
@@ -48,6 +48,20 @@ test("get returns message by id or null", () => {
   assert.equal(store.get("nonexistent"), null);
 });
 
+test("findByClientMessageId searches older persisted shards", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orbit-client-message-test-"));
+  const filePath = path.join(dir, "messages.json");
+  let now = new Date("2025-01-01T12:00:00.000Z");
+  const store = new MessageStore(filePath, { recentShardCount: 1, now: () => now });
+  const original = store.append({ kind: "user", clientMessageId: "client-1", content: "old" });
+  now = new Date("2025-01-03T12:00:00.000Z");
+  store.append({ kind: "system", content: "new" });
+
+  assert.equal(new MessageStore(filePath, { recentShardCount: 1 }).findByClientMessageId("client-1")?.id, original.id);
+  assert.equal(store.findByClientMessageId("missing"), null);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
 test("markRouteState updates route state and returns the message", () => {
   const store = new MessageStore();
   const msg = store.append({ kind: "user", content: "@agent1 hello" });

--- a/tests/sse-hub.test.ts
+++ b/tests/sse-hub.test.ts
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import type { ServerResponse } from "node:http";
+
+import { SseHub } from "../src/server/sse-hub.ts";
+
+class FakeResponse extends EventEmitter {
+  readonly chunks: string[] = [];
+
+  writeHead(): void {}
+
+  write(chunk: string): boolean {
+    this.chunks.push(chunk);
+    return true;
+  }
+
+  end(): void {}
+}
+
+function response(): FakeResponse & ServerResponse {
+  return new FakeResponse() as FakeResponse & ServerResponse;
+}
+
+function events(res: FakeResponse): Array<{ id?: number; data: Record<string, unknown> }> {
+  return res.chunks
+    .join("")
+    .split("\n\n")
+    .filter((chunk) => chunk.includes("data: "))
+    .map((chunk) => {
+      const id = chunk.match(/^id: (\d+)$/m)?.[1];
+      const data = chunk.match(/^data: (.+)$/m)?.[1];
+      return { ...(id ? { id: Number(id) } : {}), data: JSON.parse(data!) as Record<string, unknown> };
+    });
+}
+
+test("SSE only sends conversation events to the matching workspace and conversation", () => {
+  const hub = new SseHub();
+  const page = response();
+  hub.add(page, { workspaceId: "ws-a", conversationId: "conv-1" });
+
+  hub.publish({ type: "message.created", workspaceId: "ws-a", conversationId: "conv-1", message: { id: "a", kind: "system", content: "a", createdAt: "now" } });
+  hub.publish({ type: "message.created", workspaceId: "ws-b", conversationId: "conv-1", message: { id: "b", kind: "system", content: "b", createdAt: "now" } });
+  hub.publish({ type: "message.created", workspaceId: "ws-a", conversationId: "conv-2", message: { id: "c", kind: "system", content: "c", createdAt: "now" } });
+
+  assert.deepEqual(events(page).map((entry) => entry.data), [
+    { type: "message.created", workspaceId: "ws-a", conversationId: "conv-1", message: { id: "a", kind: "system", content: "a", createdAt: "now" } },
+  ]);
+});
+
+test("SSE replays events after the page's last event id", () => {
+  const hub = new SseHub();
+  const initial = response();
+  hub.add(initial, { workspaceId: "ws-a", conversationId: "conv-1" });
+  hub.publish({ type: "message.created", workspaceId: "ws-a", conversationId: "conv-1", message: { id: "a", kind: "system", content: "a", createdAt: "now" } });
+  hub.publish({ type: "message.created", workspaceId: "ws-a", conversationId: "conv-1", message: { id: "b", kind: "system", content: "b", createdAt: "now" } });
+
+  const resumed = response();
+  hub.add(resumed, { workspaceId: "ws-a", conversationId: "conv-1" }, 1);
+  assert.deepEqual(events(resumed).map((entry) => entry.data), [
+    { type: "message.created", workspaceId: "ws-a", conversationId: "conv-1", message: { id: "b", kind: "system", content: "b", createdAt: "now" } },
+  ]);
+});
+
+test("SSE emits a gap marker when the requested cursor is no longer retained", () => {
+  const hub = new SseHub();
+  const publisher = response();
+  hub.add(publisher);
+  for (let i = 0; i < 502; i += 1) {
+    hub.publish({ type: "message.created", workspaceId: "ws-a", conversationId: "conv-1", message: { id: String(i), kind: "system", content: String(i), createdAt: "now" } });
+  }
+
+  const resumed = response();
+  hub.add(resumed, { workspaceId: "ws-a", conversationId: "conv-1" }, 1);
+  const replay = events(resumed);
+  assert.equal(replay.length, 1);
+  assert.equal(replay[0]?.data.type, "events.gap");
+  assert.ok(replay[0]?.id);
+});

--- a/tests/supervisor-config.test.ts
+++ b/tests/supervisor-config.test.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, test } from "node:test";
+
+import { AgentModelStateStore, storageKeyAgentId, supervisorStorageKey } from "../src/core/agent-model-state-store.ts";
+import { createSupervisorProfile, INTERNAL_SUPERVISOR_ID } from "../src/core/agent-profiles.ts";
+import type { AgentModelStateSnapshot, AgentRuntimeKind } from "../src/shared/types.ts";
+
+/**
+ * Issue #153：监工的运行时与模型偏好可按会话配置。
+ *
+ * 覆盖点：
+ * - 模型偏好的 runtime 归属门控（跨运行时不应用）。
+ * - 监工模型快照按会话隔离，不同会话互不覆盖。
+ * - UI 的监工设置入口与保存路径（无 React 渲染环境，沿用源码扫描风格）。
+ */
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "orbit-supervisor-"));
+}
+
+function snapshot(runtimeKind: AgentRuntimeKind): AgentModelStateSnapshot {
+  return {
+    agentId: INTERNAL_SUPERVISOR_ID,
+    runtimeKind,
+    configId: "model",
+    choices: [{ value: "m1", name: "M1" }],
+    currentValue: undefined,
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+describe("supervisor model preference gating", () => {
+  test("a runtime-matching preference is applied to the supervisor profile", () => {
+    const profile = createSupervisorProfile("/tmp/project", {
+      runtime: "codex",
+      model: { preferredModelId: "gpt-5-codex", runtimeKind: "codex" },
+    });
+
+    assert.equal(profile.runtime, "codex");
+    assert.equal(profile.preferredModelId, "gpt-5-codex");
+  });
+
+  test("a cross-runtime preference is ignored", () => {
+    // value ID 不跨 runtime 通用：偏好属于 codex，当前运行时是 codebuddy。
+    const profile = createSupervisorProfile("/tmp/project", {
+      runtime: "codebuddy",
+      model: { preferredModelId: "gpt-5-codex", runtimeKind: "codex" },
+    });
+
+    assert.equal(profile.preferredModelId, undefined);
+  });
+
+  test("a blank preference is not applied", () => {
+    const profile = createSupervisorProfile("/tmp/project", {
+      runtime: "codex",
+      model: { preferredModelId: "   ", runtimeKind: "codex" },
+    });
+
+    assert.equal(profile.preferredModelId, undefined);
+  });
+
+  test("the supervisor keeps its internal identity and Chinese display name", () => {
+    const profile = createSupervisorProfile("/tmp/project", { runtime: "codebuddy" });
+
+    assert.equal(profile.id, INTERNAL_SUPERVISOR_ID);
+    assert.equal(profile.name, "监工");
+    assert.equal(profile.internal, true);
+  });
+});
+
+describe("supervisor model snapshots are isolated per conversation", () => {
+  test("two conversations keep their own supervisor snapshot", () => {
+    const store = new AgentModelStateStore(tmpDir());
+
+    store.update("ws1", snapshot("codex"), supervisorStorageKey("conv-a"));
+    store.update("ws1", snapshot("codebuddy"), supervisorStorageKey("conv-b"));
+
+    assert.equal(store.get("ws1", supervisorStorageKey("conv-a"))?.runtimeKind, "codex");
+    assert.equal(store.get("ws1", supervisorStorageKey("conv-b"))?.runtimeKind, "codebuddy");
+  });
+
+  test("overwriting one conversation does not disturb another or regular employees", () => {
+    const store = new AgentModelStateStore(tmpDir());
+    const employeeSnapshot: AgentModelStateSnapshot = {
+      ...snapshot("codex"),
+      agentId: "implementation",
+    };
+
+    store.update("ws1", snapshot("codex"), supervisorStorageKey("conv-a"));
+    store.update("ws1", employeeSnapshot);
+    store.update("ws1", snapshot("codebuddy"), supervisorStorageKey("conv-b"));
+
+    assert.equal(store.get("ws1", supervisorStorageKey("conv-a"))?.runtimeKind, "codex");
+    assert.equal(store.get("ws1", supervisorStorageKey("conv-b"))?.runtimeKind, "codebuddy");
+    assert.equal(store.get("ws1", "implementation")?.agentId, "implementation");
+  });
+
+  test("the composite storage key still exposes the supervisor agent id", () => {
+    assert.equal(storageKeyAgentId(supervisorStorageKey("conv-a")), INTERNAL_SUPERVISOR_ID);
+    assert.equal(storageKeyAgentId("implementation"), "implementation");
+  });
+
+  test("supervisor snapshots survive a reload", () => {
+    const dir = tmpDir();
+    new AgentModelStateStore(dir).update("ws1", snapshot("codebuddy"), supervisorStorageKey("conv-a"));
+
+    const reloaded = new AgentModelStateStore(dir).get("ws1", supervisorStorageKey("conv-a"));
+
+    assert.equal(reloaded?.runtimeKind, "codebuddy");
+    assert.equal(reloaded?.agentId, INTERNAL_SUPERVISOR_ID);
+  });
+});
+
+const appSource = fs.readFileSync(
+  path.resolve(import.meta.dirname, "../src/ui/App.tsx"),
+  "utf-8",
+);
+
+describe("supervisor settings entry in the UI", () => {
+  test("the collaboration menu exposes a dedicated supervisor settings entry", () => {
+    // 入口与模式项并列，避免嵌套按钮；复杂协作开启前后都可点。
+    assert.match(appSource, /supervisorSettingsTrigger/, "应有独立的监工设置入口样式类");
+    assert.match(appSource, /监工设置/, "入口文案应使用产品术语“监工设置”");
+    assert.match(appSource, /function SupervisorSettingsPanel/, "应存在监工设置面板组件");
+    assert.match(appSource, /showSupervisorSettings/, "入口应能打开监工设置面板");
+  });
+
+  test("saving uses the explicit page context endpoint", () => {
+    assert.match(
+      appSource,
+      /withPageContext\(`\/api\/conversations\/\$\{conversationId\}\/supervisor-config`, targetContext\)/,
+      "保存监工配置必须走显式页面上下文接口，不能依赖全局 active 指针。",
+    );
+  });
+
+  test("saving without a conversation creates one and adopts its id first", () => {
+    const body = appSource.slice(appSource.indexOf("async function saveSupervisorConfig"));
+    const createIdx = body.indexOf('/api/conversations"');
+    const saveIdx = body.indexOf("/supervisor-config");
+
+    assert.notStrictEqual(createIdx, -1, "无会话时应先创建会话");
+    assert.notStrictEqual(saveIdx, -1, "随后再保存监工配置");
+    assert.ok(createIdx < saveIdx, "必须先创建并采用会话 ID，再保存配置");
+  });
+
+  test("probing the supervisor model list carries the conversation id", () => {
+    assert.match(
+      appSource,
+      /params\.set\("conversationId", conversationId\)/,
+      "监工是所有会话共用的内部 ID，探测模型必须带会话维度。",
+    );
+  });
+
+  test("the panel addresses the supervisor with the product term only", () => {
+    const start = appSource.indexOf("function SupervisorSettingsPanel");
+    const panel = appSource.slice(start, appSource.indexOf("function preferredSupervisionRuntime"));
+    assert.ok(start >= 0 && panel.length > 0, "Could not locate SupervisorSettingsPanel in App.tsx");
+
+    assert.match(panel, /<h2>监工设置<\/h2>/, "面板标题应使用产品术语“监工”");
+    assert.match(panel, /跟随运行时默认/, "应提供“跟随运行时默认”选项");
+    assert.match(panel, /刷新模型列表/, "应提供刷新模型列表入口");
+    // 可见文案用“监工”，内部名只作为标识符（radio name 等属性）出现。
+    assert.ok(
+      (panel.match(/监工/g) ?? []).length >= 3,
+      "面板可见文案应统一使用“监工”，而不是内部名",
+    );
+  });
+});


### PR DESCRIPTION
Closes #116
Closes #153

本 PR 包含两个独立提交，分别对应两个 issue（`bd98c73` → #116，`a7d0484` → #153），外加一次 `origin/main` 合并（`706f156`）。

## 改了什么

### #116：多页面工作区/会话上下文隔离

每个浏览器标签页的请求、运行与事件都限定在页面上下文（`workspaceId` + `conversationId`），两个标签页不再共享同一个会话。

- 事件携带 `workspaceId`，`SseHub` 按页面范围过滤，并支持 `Last-Event-ID` 重放
- `/api/runs/cancel` 定向到发起请求的会话，不再遍历全部上下文
- 附件草稿绑定到页面上下文，跨页时回滚删除
- 客户端读取 `POST /api/messages` 返回的 `conversationId` 并采用它：此前无会话页面发出的首条消息会被 `applyEvent` 的会话过滤丢弃，且之后每条消息都会再新建一个会话。先同步地址栏再发状态请求（`refreshState` 会校验两者一致），并补一次全量拉取兜底——`message.created` 在响应之前就已发布，可能早于会话 id 落地送达，而新的 `EventSource` 首次连接不重放
- 幂等键 `clientMessageId` 与草稿内容绑定：重试复用同一键，改动内容则换新键，避免「改了内容却显示发送成功」的静默丢弃
- 新增 `popstate` 监听，浏览器前进/后退不再让 UI 与地址栏脱节
- 删除死代码 `switchConversation()`、被注释的上下文遍历取消逻辑，以及描述已移除 `context.switched` 广播的过期注释

### #153：监工的运行时与模型可配置

复杂协作使用的内置监工此前由 UI 一次性挑选运行时且无法再改，也不支持模型偏好。现在按会话配置 `SupervisorConfig = { runtime, model? }`。

- **运行时变化**：取消监工排队/运行中的检查并重建其 session（沿用原有语义），普通员工与历史消息不受影响
- **仅模型变化**：不取消任务、不重建会话。`AgentSession` 改为持有可变偏好，运行开始时惰性应用，新值从下一次运行生效
- 偏好按 runtime 归属：记录在别的 runtime 下的偏好会被忽略，与普通员工行为一致
- 监工是跨会话共用的内部 ID，模型快照改用 `supervisor:<conversationId>` 组合键，`agent.model_state` 事件带上 `conversationId`，否则一个会话的探测结果会覆盖另一个会话的，页面级 SSE 也无法过滤
- 新增 `PUT /api/conversations/:id/supervisor-config`（显式页面上下文），校验 runtime 合法性与可用性、模型结构；旧的 interaction-mode 接口继续兼容 runtime 参数
- UI 在协作模式菜单「复杂协作」旁新增独立「监工设置」入口，开启前后都可修改；无会话时先创建并采用会话 ID 再保存。文案统一用「监工」
- 旧记录只有 `supervisionRuntime`，`ConversationStore` 读取时映射为 `{ runtime }`，不做批量迁移

### 合并 origin/main（706f156）

合并后的树与 `a7d0484` **完全相同**，没有改动任何一行代码。原因是本分支已包含 #152 的等价超集实现（以 #116 的「显式工作区上下文」形态存在）：`AgentModelProbeResponse` 类型、`targetAgentId` 与 `response.target` 响应、`mergeModelProbeResponse` 与 targeted probe 调用、ARCHITECTURE 对应段落、两条 targeted probe 测试。#144 经 `git merge-base --is-ancestor` 确认是 HEAD 的祖先。无冲突标记残留。

## 如何验证

- `npm test`：**631 项，630 通过，1 跳过，0 失败**（新增 17 项 #153 测试，#116 既有用例全部保持通过）
- `npx tsc --noEmit`：通过
- `npx vite build`：通过
- `git diff origin/main...HEAD --check`：通过

独立评审用真实服务端到端方式（覆盖 `os.homedir` + `ORBIT_PORT` 拉起真服务，含真实 ACP 探测）补充验证：

- 首条消息采纳：无会话页面连发两条会建两个会话；采用返回的会话 ID 后，第三条复用同一会话
- SSE 跨页隔离：页面 A 只收到自己会话的事件，页面 B 收到 0 条
- 监工快照隔离：磁盘键为 `supervisor:conv_…` 两个不同后缀，两页面各收到自己会话的监工状态，无互串
- 接口校验矩阵：合法 200；非法 runtime 400；缺页面上下文 409；模型结构错 400；超长标识 400；会话与上下文不匹配 409
- 旧字段兼容：手工改回 `supervisionRuntime` 后读出 `{ runtime }`，不批量迁移
- 幂等重试：同内容重试返回 `deduplicated: true`；改内容后以新 id 落库且新内容真实送达
- 两种变更语义：仅改模型时会话实例保持同一引用；连续两次运行收到 `[undefined, "gpt-5-codex"]`

## 已知限制 / 后续跟进

1. **[P3]** 无会话时打开「监工设置」，`refreshModels` 不带 `conversationId` → 服务端 400 → 面板显示「模型列表获取失败」，需点保存（此时才建会话）后才有列表。
2. **[P3]** `probe-models` 的 `conversationId` 未校验存在性，任意值会写入 `supervisor:<任意值>` 垃圾键。
3. **[P3]** `PUT interaction-mode` 的 `runtime` 未过 `isAgentRuntimeKind`，目前靠可用性检查兜底。
4. **服务端集成测试基建欠账**：API 校验与 `setSupervisorConfig` 语义没有常驻端到端覆盖。评审两轮验证证明「覆盖 `os.homedir` + `ORBIT_PORT`」可行，建议后续沉淀为 `tests/server-integration.test.ts`，顺带覆盖上面 1–3。
5. **完整 `npm run build` 未跑**：独立可执行步骤需 Bun，本机未安装；已单独跑通 tsc 与 vite 两级。
6. **新增测试沿用源码扫描风格**：能挡住退回旧写法，但断言绑定标识符，重命名即失效。
7. **分支名只体现 #116**：按用户决定，一个 PR 同时承载两个 issue、不拆分（#153 依赖 #116 的显式页面上下文约定）。
