### PR TITLE
Confirm mention candidates with Enter when the menu is open

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -143,6 +143,9 @@ export function App() {
   const [inputFocused, setInputFocused] = useState(false);
   const [cursorIndex, setCursorIndex] = useState(0);
   const [selectedMentionIndex, setSelectedMentionIndex] = useState(0);
+  // Esc 关闭候选菜单用独立标志，不复用 inputFocused：按 Esc 时输入框并未
+  // 真正失焦，onFocus 不会再次触发，复用会导致菜单再也无法重新唤起。
+  const [mentionDismissed, setMentionDismissed] = useState(false);
   const messagesRef = useRef<HTMLDivElement | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
@@ -478,14 +481,14 @@ export function App() {
   );
   const mentionDraft = useMemo(() => findMentionDraft(content, cursorIndex), [content, cursorIndex]);
   const mentionCandidates = useMemo(() => {
-    if (!inputFocused || !mentionDraft) {
+    if (!inputFocused || mentionDismissed || !mentionDraft) {
       return [];
     }
 
     const query = mentionDraft.query.toLowerCase();
     const matched = state.agents.filter((agent) => agent.label.toLocaleLowerCase().startsWith(query)).map((agent) => agent.id);
     return matched;
-  }, [agentIds, inputFocused, mentionDraft, state.agents]);
+  }, [agentIds, inputFocused, mentionDismissed, mentionDraft, state.agents]);
 
   useEffect(() => {
     if (!agentsById.has(selectedAgent) && agentIds[0]) {
@@ -520,6 +523,14 @@ export function App() {
   useEffect(() => {
     setSelectedMentionIndex(0);
   }, [mentionDraft?.query]);
+
+  // Esc 关闭的候选菜单在 @ 草稿消失（删掉 @ 或发出消息清空输入框）后允许
+  // 重新唤起；只改动查询词时保持关闭，避免继续打字被菜单打扰。
+  useEffect(() => {
+    if (!mentionDraft) {
+      setMentionDismissed(false);
+    }
+  }, [mentionDraft]);
 
   useEffect(() => {
     if (!openWorkspaceMenuId && !openConversationMenuId) return;
@@ -1372,7 +1383,7 @@ export function App() {
 
     if (event.key === "Escape") {
       event.preventDefault();
-      setInputFocused(false);
+      setMentionDismissed(true);
     }
   }
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1364,7 +1364,7 @@ export function App() {
       return;
     }
 
-    if (event.key === "Enter" || event.key === "Tab") {
+    if ((event.key === "Enter" && !event.shiftKey) || event.key === "Tab") {
       event.preventDefault();
       chooseMention(mentionCandidates[selectedMentionIndex] ?? mentionCandidates[0]);
       return;
@@ -1830,12 +1830,16 @@ export function App() {
                 if (isImeComposition(event)) {
                   return;
                 }
+                // @ 候选菜单打开时，Enter/Tab/方向键/Esc 优先交给候选菜单处理，
+                // 只有菜单关闭时 Enter 才是发送消息。
+                if (mentionCandidates.length > 0) {
+                  handleComposerKeyDown(event as unknown as KeyboardEvent<HTMLInputElement>);
+                  return;
+                }
                 if (event.key === "Enter" && !event.shiftKey) {
                   event.preventDefault();
                   sendMessage(event as unknown as FormEvent<HTMLFormElement>);
-                  return;
                 }
-                handleComposerKeyDown(event as unknown as KeyboardEvent<HTMLInputElement>);
               }}
               onKeyUp={updateCursorFromInput}
               placeholder={!hasWorkspace

--- a/tests/mention-enter-confirm.test.ts
+++ b/tests/mention-enter-confirm.test.ts
@@ -7,6 +7,8 @@ import path from "node:path";
  * 回归：#157 —— @ 候选菜单打开时按 Enter 曾被"发送消息"分支拦截，
  * 未完成的 @xxx 文本直接发出，Enter 选人分支不可达，只能鼠标点选；
  * Shift+Enter 反而漏进选人分支，占用换行语义。
+ * 另覆盖其姊妹 bug：Esc 曾用 setInputFocused(false) 关闭菜单，但输入框
+ * 并未真正失焦、onFocus 不会再次触发，导致之后再按 @ 无法唤起候选。
  * 无 React 渲染环境，按仓库惯例对 App.tsx 的按键接线做源码结构断言。
  */
 
@@ -54,5 +56,26 @@ describe("mention menu Enter confirm", () => {
       handler.indexOf("chooseMention") > handler.indexOf('event.key === "Enter" && !event.shiftKey'),
       "the shift-guarded Enter branch must drive chooseMention",
     );
+  });
+
+  test("Esc dismisses the menu through a dedicated flag, not the focus state", () => {
+    const match = appSource.match(/function handleComposerKeyDown\([\s\S]*?\n  \}/);
+    assert.ok(match, "handleComposerKeyDown must exist in App.tsx");
+    assert.ok(match[0].includes("setMentionDismissed(true)"), "Esc must set the dismissal flag");
+    assert.ok(
+      !match[0].includes("setInputFocused(false)"),
+      "Esc must not clear inputFocused: the textarea keeps DOM focus, so onFocus never refires and the menu could never reopen",
+    );
+  });
+
+  test("dismissal blocks candidates and clears once the mention draft is gone", () => {
+    const memo = appSource.match(/const mentionCandidates = useMemo\(\(\) => \{[\s\S]*?\n  \}, \[/);
+    assert.ok(memo, "mentionCandidates memo must exist in App.tsx");
+    assert.ok(memo[0].includes("mentionDismissed"), "candidates must respect the dismissal flag");
+
+    const resetEffect = appSource.match(
+      /useEffect\(\(\) => \{\s*if \(!mentionDraft\) \{\s*setMentionDismissed\(false\);\s*\}\s*\}, \[mentionDraft\]\);/,
+    );
+    assert.ok(resetEffect, "dismissal must reset when the mention draft disappears");
   });
 });

--- a/tests/mention-enter-confirm.test.ts
+++ b/tests/mention-enter-confirm.test.ts
@@ -1,0 +1,58 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * 回归：#157 —— @ 候选菜单打开时按 Enter 曾被"发送消息"分支拦截，
+ * 未完成的 @xxx 文本直接发出，Enter 选人分支不可达，只能鼠标点选；
+ * Shift+Enter 反而漏进选人分支，占用换行语义。
+ * 无 React 渲染环境，按仓库惯例对 App.tsx 的按键接线做源码结构断言。
+ */
+
+const appSource = fs.readFileSync(
+  path.resolve(import.meta.dirname, "../src/ui/App.tsx"),
+  "utf-8",
+);
+
+describe("mention menu Enter confirm", () => {
+  test("composer dispatches to the mention menu before the Enter-send branch", () => {
+    const guardIndex = appSource.indexOf("if (isImeComposition(event)) {");
+    const mentionOpenIndex = appSource.indexOf("if (mentionCandidates.length > 0) {");
+    const dispatchIndex = appSource.indexOf(
+      "handleComposerKeyDown(event as unknown as KeyboardEvent<HTMLInputElement>);",
+    );
+    const sendIndex = appSource.indexOf("sendMessage(event as unknown as FormEvent<HTMLFormElement>)");
+
+    assert.ok(guardIndex > 0, "composer onKeyDown must keep the composition guard");
+    assert.ok(mentionOpenIndex > guardIndex, "mention dispatch must come after the composition guard");
+    assert.ok(dispatchIndex > mentionOpenIndex, "mention dispatch must be guarded by open candidates");
+    assert.ok(sendIndex > dispatchIndex, "Enter-send must run only when the mention menu is closed");
+
+    const dispatchBlock = appSource.slice(dispatchIndex, sendIndex);
+    assert.ok(dispatchBlock.includes("return;"), "handled mention keys must not fall through to send");
+  });
+
+  test("menu-closed Enter still sends; the send condition stays shift-guarded", () => {
+    const sendIndex = appSource.indexOf("sendMessage(event as unknown as FormEvent<HTMLFormElement>)");
+    const sendCondition = appSource.slice(sendIndex - 300, sendIndex);
+    assert.ok(
+      sendCondition.includes('event.key === "Enter" && !event.shiftKey'),
+      "plain Enter sends only when no mention candidate is open",
+    );
+  });
+
+  test("Enter confirm in the mention menu keeps Shift+Enter as a newline", () => {
+    const match = appSource.match(/function handleComposerKeyDown\([\s\S]*?\n  \}/);
+    assert.ok(match, "handleComposerKeyDown must exist in App.tsx");
+    const handler = match[0];
+    assert.ok(
+      handler.includes('event.key === "Enter" && !event.shiftKey'),
+      "Shift+Enter must not be treated as mention confirmation",
+    );
+    assert.ok(
+      handler.indexOf("chooseMention") > handler.indexOf('event.key === "Enter" && !event.shiftKey'),
+      "the shift-guarded Enter branch must drive chooseMention",
+    );
+  });
+});


### PR DESCRIPTION
## 变更内容

修复 #157：@ 候选菜单打开时按 Enter 被发送分支拦截，未完成的 `@xxx` 文本直接发出，Enter 选人不可达，只能鼠标点选；Shift+Enter 反而漏进选人分支，占用换行语义。

- `src/ui/App.tsx` 输入框 `onKeyDown`：IME 组合守卫之后、发送分支之前，先判断 `mentionCandidates.length > 0` 并把 Enter/Tab/方向键/Esc 交给 `handleComposerKeyDown`，处理完即返回，不再落回发送。
- `handleComposerKeyDown`：Enter 确认分支增加 `!event.shiftKey` 条件，Shift+Enter 恢复为换行。
- 菜单关闭时 Enter 发送、Shift+Enter 换行、↑/↓/Tab 及 IME 组合期保护（#148）行为均不变。

姊妹 bug（用户在 #157 验证时发现）：Esc 关闭候选菜单后，再按 `@` 无法唤起列表。原因是 Esc 通过 `setInputFocused(false)` 关闭菜单，但输入框按 Esc 后并未真正失焦，`onFocus` 不会再次触发，`mentionCandidates` 恒为空，只能失焦再聚焦才能恢复。修复：

- 新增独立的 `mentionDismissed` 状态，Esc 置位、不再复用 `inputFocused`。
- `mentionDraft` 消失（删掉 `@` 文本或发出消息清空输入框）时复位；仅改动查询词时保持关闭，继续打字不被菜单打扰。

## 验证

- 新增 `tests/mention-enter-confirm.test.ts`：按仓库惯例（无 React 渲染环境）以源码结构断言覆盖——候选分发先于发送分支且处理即返回、发送条件保持 shift 守卫、Enter 确认分支不吞 Shift+Enter、Esc 用独立关闭标志且不复用 `inputFocused`、关闭状态在草稿消失后复位。5/5 通过。
- `tests/ime-composition-guard.test.ts`（IME 守卫既有用例）4/4 通过。
- `npm run test`：720 通过 / 4 失败，4 个为 `tests/local-path-reveal.test.ts` 在 macOS 上的既有失败（`os.tmpdir()` 与 `realpathSync` 符号链接差异，与本次改动无关）。
- `npx tsc --noEmit` 通过；`npx vite build` 通过（chunk 体积警告为既有提示）。

## 已知限制

- 本机未安装 Bun，未运行 `npm run build` 的 standalone 打包阶段，由 CI 补齐。

Fixes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)
