### PR TITLE
Update license copyright holder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Qianzhen Sun
+Copyright (c) 2026 Kevin Forge
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

- Update the MIT license copyright holder from Qianzhen Sun to Kevin Forge.

## Verification

- git diff --check passed.
- Tests and build not run; this is a license-only text change.