### PR TITLE
Print the version for orbit --version and -v

### DIFF
--- a/src/cli-flags.ts
+++ b/src/cli-flags.ts
@@ -1,0 +1,25 @@
+/**
+ * CLI flag helpers for the standalone entry point.
+ *
+ * Kept free of side effects so tests can import this module without
+ * booting the server.
+ */
+
+import orbitPackageJson from "../package.json";
+
+/**
+ * Detect a `--version` / `-v` request in the raw argv list.
+ */
+export function isVersionRequest(argv: string[]): boolean {
+  return argv.includes("--version") || argv.includes("-v");
+}
+
+/**
+ * Return the Orbit version declared in `package.json`.
+ *
+ * The standalone build bundles this module, so Bun inlines the imported
+ * value into the binary at build time; no version constant is hardcoded.
+ */
+export function getOrbitVersion(): string {
+  return orbitPackageJson.version;
+}

--- a/src/standalone-entry.ts
+++ b/src/standalone-entry.ts
@@ -12,6 +12,7 @@
  */
 
 import { validateLicenseAsync, generateMachineId, getHardwareInfo, ensureOrbitHomeDir } from "./license/index.ts";
+import { isVersionRequest, getOrbitVersion } from "./cli-flags.ts";
 import path from "node:path";
 
 async function main() {
@@ -21,12 +22,19 @@ async function main() {
     console.log("Usage:");
     console.log("  orbit              Start Orbit");
     console.log("  orbit --help       Show this help");
+    console.log("  orbit --version    Print the Orbit version");
     console.log("  orbit --machine-id Print a machine id for private licensed builds");
     console.log("  orbit --hardware-info Print hardware info for diagnostics");
     console.log("");
     console.log("Environment:");
     console.log("  ORBIT_PORT=4317");
     console.log("  ORBIT_UI_DIR=/path/to/dist/ui");
+    process.exit(0);
+  }
+
+  // Handle --version / -v flag
+  if (isVersionRequest(process.argv)) {
+    console.log(getOrbitVersion());
     process.exit(0);
   }
 

--- a/tests/cli-flags.test.ts
+++ b/tests/cli-flags.test.ts
@@ -1,0 +1,39 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { getOrbitVersion, isVersionRequest } from '../src/cli-flags.ts';
+import orbitPackageJson from '../package.json';
+
+describe('standalone CLI flags', () => {
+  describe('isVersionRequest', () => {
+    it('detects --version', () => {
+      assert.equal(isVersionRequest(['orbit', '--version']), true);
+    });
+
+    it('detects -v', () => {
+      assert.equal(isVersionRequest(['orbit', '-v']), true);
+    });
+
+    it('detects the flag among other arguments', () => {
+      assert.equal(isVersionRequest(['orbit', '--unknown', '--version', 'extra']), true);
+    });
+
+    it('ignores argument lists without a version request', () => {
+      assert.equal(isVersionRequest(['orbit']), false);
+      assert.equal(isVersionRequest(['orbit', '--help', '-h']), false);
+      assert.equal(isVersionRequest(['orbit', '--machine-id']), false);
+      assert.equal(isVersionRequest(['orbit', '--hardware-info']), false);
+    });
+
+    it('matches flags exactly instead of by prefix', () => {
+      assert.equal(isVersionRequest(['orbit', '--version-lock']), false);
+      assert.equal(isVersionRequest(['orbit', '-verbose']), false);
+    });
+  });
+
+  describe('getOrbitVersion', () => {
+    it('returns the version declared in package.json', () => {
+      assert.equal(getOrbitVersion(), orbitPackageJson.version);
+      assert.ok(getOrbitVersion().length > 0);
+    });
+  });
+});


### PR DESCRIPTION
## What changed

- `src/cli-flags.ts` (new): `isVersionRequest()` detects `--version` / `-v`; `getOrbitVersion()` returns the version from `package.json` via a JSON import.
- `src/standalone-entry.ts`: new `--version` / `-v` branch that prints the version and exits 0 without starting the server or binding the port; `--help` output documents the flag.
- `tests/cli-flags.test.ts` (new): focused tests for exact-flag matching (rejects `--version-lock` / `-verbose`), non-flag argument lists, and version source.

### Why a JSON import instead of a build-script `--define`

The task originally suggested injecting `process.env.ORBIT_VERSION` from `scripts/build-standalone.mjs`. During verification I found Bun 1.4.0 **silently ignores `--define` in `--compile` builds** (reproduced with a minimal probe: string, boolean, and identifier defines are all absent at runtime, regardless of argument order; JSON imports are inlined correctly). The JSON import achieves the same goal — the version comes from `package.json` at build time with no hardcoded constant — through the mechanism that actually works. `build-standalone.mjs` is therefore unchanged.

## How it was verified

- `node --test --import tsx tests/cli-flags.test.ts` — 6/6 pass.
- `npm run test` — 794 tests: 793 pass, 1 skipped (pre-existing), 0 fail.
- `npm run build` — type-check, Vite UI build, and standalone binary build all pass.
- Standalone binary: `dist/bin/orbit.exe --version` and `-v` both print `1.3.0` with exit code 0, no server start.
- npm entry: `node bin/orbit.js --version` prints `1.3.0` with exit code 0 (exit code propagates through the wrapper).
- `git diff --check` passes; diff is limited to the entry point and the two new files.

## Known limitations / follow-up

- Unknown arguments are still silently ignored and start the server (out of scope per #166 discussion; CLI-convention error handling can be decided separately).
- While probing I noticed the existing `--define:process.env.ORBIT_STANDALONE=true` in `scripts/build-standalone.mjs` is also a silent no-op in Bun `--compile` builds, and nothing under `src/` reads that variable anyway — dead config worth cleaning up in a follow-up.

Closes #166